### PR TITLE
feat: add bulletin listing and detail pages

### DIFF
--- a/app/Http/Controllers/BulletinController.php
+++ b/app/Http/Controllers/BulletinController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use App\Models\PostCategory;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class BulletinController extends Controller
+{
+    /**
+     * 公告列表
+     */
+    public function index(Request $request)
+    {
+        // 取得公告列表，支援分類與搜尋
+        $posts = Post::with('category')
+            ->where('status', 'published')
+            ->where('publish_at', '<=', now())
+            ->where(function ($q) {
+                $q->whereNull('expire_at')->orWhere('expire_at', '>', now());
+            })
+            ->when($request->query('cat'), function ($query, $cat) {
+                $query->whereHas('category', function ($q) use ($cat) {
+                    $q->where('slug', $cat);
+                });
+            })
+            ->when($request->query('q'), function ($query, $search) {
+                $query->where(function ($qq) use ($search) {
+                    $qq->where('title', 'like', "%{$search}%")
+                       ->orWhere('summary', 'like', "%{$search}%");
+                });
+            })
+            ->orderByDesc('pinned')
+            ->orderByDesc('publish_at')
+            ->paginate(10)
+            ->withQueryString();
+
+        // 取得可見的公告分類
+        $categories = PostCategory::where('visible', true)->orderBy('sort_order')->get();
+
+        return Inertia::render('bulletins/index', [
+            'posts' => $posts,
+            'categories' => $categories,
+            'filters' => $request->only(['cat', 'q']),
+        ]);
+    }
+
+    /**
+     * 公告詳細
+     */
+    public function show(string $slug)
+    {
+        // 依據 slug 取得公告內容
+        $post = Post::with(['category', 'attachments'])
+            ->where('slug', $slug)
+            ->where('status', 'published')
+            ->firstOrFail();
+
+        return Inertia::render('bulletins/show', [
+            'post' => $post,
+        ]);
+    }
+}
+

--- a/resources/js/pages/bulletins/index.tsx
+++ b/resources/js/pages/bulletins/index.tsx
@@ -1,0 +1,76 @@
+import PublicLayout from '@/layouts/public-layout';
+import { Head, Link, router, usePage } from '@inertiajs/react';
+import { useState } from 'react';
+import type { SharedData } from '@/types';
+
+interface Props {
+    posts: any;
+    categories: any[];
+    filters: { cat?: string; q?: string };
+}
+
+export default function BulletinIndex({ posts, categories, filters }: Props) {
+    const page = usePage<SharedData & { i18n: any }>();
+    const { i18n } = page.props;
+    const t = (key: string, fallback?: string) =>
+        key.split('.').reduce((acc: any, k: string) => (acc && acc[k] !== undefined ? acc[k] : undefined), i18n?.common) ?? fallback ?? key;
+
+    // 搜尋字串狀態
+    const [search, setSearch] = useState(filters.q || '');
+
+    // 提交搜尋
+    const submitSearch = (e: React.FormEvent) => {
+        e.preventDefault();
+        router.get('/bulletins', { ...filters, q: search }, { preserveState: true, replace: true });
+    };
+
+    return (
+        <PublicLayout>
+            <Head title={t('bulletin.title', 'Bulletins')} />
+            <section className="mx-auto max-w-4xl space-y-4 p-4">
+                {/* 公告分類選單 */}
+                <div className="flex flex-wrap gap-2">
+                    <Link href="/bulletins" className={!filters.cat ? 'font-bold' : ''}>
+                        {t('bulletin.all', 'All')}
+                    </Link>
+                    {categories.map((cat) => (
+                        <Link
+                            key={cat.id}
+                            href={`/bulletins?cat=${cat.slug}${filters.q ? `&q=${filters.q}` : ''}`}
+                            className={filters.cat === cat.slug ? 'font-bold' : ''}
+                        >
+                            {cat.name}
+                        </Link>
+                    ))}
+                </div>
+
+                {/* 搜尋表單 */}
+                <form onSubmit={submitSearch} className="flex gap-2">
+                    <input
+                        type="text"
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        placeholder={t('search', 'Search')}
+                        className="flex-grow rounded border px-2 py-1"
+                    />
+                    <button type="submit" className="rounded border px-3 py-1">
+                        {t('search', 'Search')}
+                    </button>
+                </form>
+
+                {/* 公告列表 */}
+                <ul className="space-y-4">
+                    {posts.data.map((post: any) => (
+                        <li key={post.id}>
+                            <Link href={`/bulletins/${post.slug}`} className="text-blue-600 hover:underline">
+                                {post.title}
+                            </Link>
+                            {post.summary && <div className="text-sm text-gray-500">{post.summary}</div>}
+                        </li>
+                    ))}
+                </ul>
+            </section>
+        </PublicLayout>
+    );
+}
+

--- a/resources/js/pages/bulletins/show.tsx
+++ b/resources/js/pages/bulletins/show.tsx
@@ -1,0 +1,31 @@
+import PublicLayout from '@/layouts/public-layout';
+import { Head, Link, usePage } from '@inertiajs/react';
+import type { SharedData } from '@/types';
+
+interface Props {
+    post: any;
+}
+
+export default function BulletinShow({ post }: Props) {
+    const page = usePage<SharedData & { i18n: any }>();
+    const { i18n } = page.props;
+    const t = (key: string, fallback?: string) =>
+        key.split('.').reduce((acc: any, k: string) => (acc && acc[k] !== undefined ? acc[k] : undefined), i18n?.common) ?? fallback ?? key;
+
+    return (
+        <PublicLayout>
+            <Head title={post.title} />
+            <section className="mx-auto max-w-4xl space-y-4 p-4">
+                <h1 className="text-2xl font-bold">{post.title}</h1>
+                {/* 顯示公告內容 */}
+                {post.content && (
+                    <div className="prose" dangerouslySetInnerHTML={{ __html: post.content }} />
+                )}
+                <Link href="/bulletins" className="text-blue-600 hover:underline">
+                    {t('bulletin.back', 'Back')}
+                </Link>
+            </section>
+        </PublicLayout>
+    );
+}
+

--- a/resources/lang/en/common.php
+++ b/resources/lang/en/common.php
@@ -22,6 +22,11 @@ return [
         'dashboard' => 'Dashboard',
     ],
     'search' => 'Search',
+    'bulletin' => [
+        'title' => 'Bulletins',
+        'all' => 'All',
+        'back' => 'Back to bulletins',
+    ],
     'language' => [
         'en' => 'EN',
         'zh_tw' => '繁中',

--- a/resources/lang/zh-TW/common.php
+++ b/resources/lang/zh-TW/common.php
@@ -22,6 +22,11 @@ return [
         'dashboard' => '主控台',
     ],
     'search' => '搜尋',
+    'bulletin' => [
+        'title' => '公告',
+        'all' => '全部',
+        'back' => '返回公告列表',
+    ],
     'language' => [
         'en' => 'EN',
         'zh_tw' => '繁中',

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use App\Http\Controllers\AttachmentDownloadController;
+use App\Http\Controllers\BulletinController;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
@@ -11,6 +12,9 @@ use App\Http\Controllers\TestController;
 Route::get('/', function () {
     return Inertia::render('welcome');
 })->name('home');
+
+Route::get('/bulletins', [BulletinController::class, 'index'])->name('bulletins.index');
+Route::get('/bulletins/{slug}', [BulletinController::class, 'show'])->name('bulletins.show');
 
 // Locale switcher: sets session locale and redirects back
 Route::get('/locale/{locale}', function (string $locale) {


### PR DESCRIPTION
## Summary
- add BulletinController with index and show actions
- add bulletins routes
- create frontend pages for bulletin list and detail using PublicLayout
- extend common translations for bulletin text

## Testing
- `./vendor/bin/phpunit` *(fails: Tests: 34, Assertions: 1, Errors: 33)*

------
https://chatgpt.com/codex/tasks/task_e_68c7639d802c8323b72a45f795d30df3