### PR TITLE
新增人員列表與詳情頁面

### DIFF
--- a/app/Http/Controllers/StaffController.php
+++ b/app/Http/Controllers/StaffController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class StaffController extends Controller
+{
+    // 顯示成員列表
+    public function index(Request $request)
+    {
+        $people = [
+            [
+                'slug' => 'john-doe',
+                'name' => ['en' => 'John Doe', 'zh-TW' => '約翰·杜'],
+                'role' => 'faculty',
+            ],
+            [
+                'slug' => 'jane-smith',
+                'name' => ['en' => 'Jane Smith', 'zh-TW' => '珍·史密斯'],
+                'role' => 'staff',
+            ],
+        ];
+
+        $role = $request->query('role');
+
+        return Inertia::render('people/index', [
+            'people' => $people,
+            'role' => $role,
+        ]);
+    }
+
+    // 顯示單一成員
+    public function show(string $slug)
+    {
+        $person = [
+            'slug' => $slug,
+            'name' => ['en' => 'John Doe', 'zh-TW' => '約翰·杜'],
+            'role' => 'faculty',
+            'bio' => ['en' => 'Sample bio', 'zh-TW' => '範例簡介'],
+        ];
+
+        return Inertia::render('people/show', [
+            'person' => $person,
+        ]);
+    }
+}

--- a/resources/js/pages/people/index.tsx
+++ b/resources/js/pages/people/index.tsx
@@ -1,0 +1,61 @@
+import PublicLayout from '@/layouts/public-layout';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { useState } from 'react';
+import type { SharedData } from '@/types';
+
+interface Person {
+    slug: string;
+    name: Record<string, string>;
+    role: string;
+}
+
+export default function PeopleIndex() {
+    const { people = [], role = 'all', locale, i18n } = usePage<SharedData & { people: Person[]; role?: string; i18n: any }>().props;
+    const t = (key: string, fallback?: string) =>
+        key.split('.').reduce((acc: any, k: string) => (acc && acc[k] !== undefined ? acc[k] : undefined), i18n?.common) ?? fallback ?? key;
+
+    // 角色篩選狀態
+    const [selectedRole, setSelectedRole] = useState<string>(role || 'all');
+    const isZh = locale?.toLowerCase() === 'zh-tw';
+    const filtered = selectedRole === 'all' ? people : people.filter((p) => p.role === selectedRole);
+
+    return (
+        <PublicLayout>
+            <Head title={t('nav.people', 'People')} />
+            <div className="mx-auto max-w-7xl p-6">
+                {/* 篩選按鈕 */}
+                <div className="mb-4 flex gap-2">
+                    <button
+                        className={`border px-3 py-1 ${selectedRole === 'all' ? 'bg-neutral-200' : ''}`}
+                        onClick={() => setSelectedRole('all')}
+                    >
+                        全部
+                    </button>
+                    <button
+                        className={`border px-3 py-1 ${selectedRole === 'faculty' ? 'bg-neutral-200' : ''}`}
+                        onClick={() => setSelectedRole('faculty')}
+                    >
+                        {t('people.faculty', 'Faculty')}
+                    </button>
+                    <button
+                        className={`border px-3 py-1 ${selectedRole === 'staff' ? 'bg-neutral-200' : ''}`}
+                        onClick={() => setSelectedRole('staff')}
+                    >
+                        {t('people.staff', 'Staff')}
+                    </button>
+                </div>
+
+                {/* 列表 */}
+                <ul className="space-y-2">
+                    {filtered.map((person) => (
+                        <li key={person.slug}>
+                            <Link href={`/people/${person.slug}`} className="text-blue-600 hover:underline">
+                                {person.name[isZh ? 'zh-TW' : 'en']}
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </PublicLayout>
+    );
+}

--- a/resources/js/pages/people/show.tsx
+++ b/resources/js/pages/people/show.tsx
@@ -1,0 +1,31 @@
+import PublicLayout from '@/layouts/public-layout';
+import { Head, usePage } from '@inertiajs/react';
+import type { SharedData } from '@/types';
+
+interface Person {
+    slug: string;
+    name: Record<string, string>;
+    role: string;
+    bio?: Record<string, string>;
+}
+
+export default function PeopleShow() {
+    const { person, locale, i18n } = usePage<SharedData & { person: Person; i18n: any }>().props;
+    const t = (key: string, fallback?: string) =>
+        key.split('.').reduce((acc: any, k: string) => (acc && acc[k] !== undefined ? acc[k] : undefined), i18n?.common) ?? fallback ?? key;
+    const isZh = locale?.toLowerCase() === 'zh-tw';
+
+    return (
+        <PublicLayout>
+            <Head title={person.name[isZh ? 'zh-TW' : 'en']} />
+            <div className="mx-auto max-w-3xl p-6 space-y-4">
+                {/* 姓名 */}
+                <h1 className="text-2xl font-bold">{person.name[isZh ? 'zh-TW' : 'en']}</h1>
+                {/* 角色顯示 */}
+                <p className="text-sm text-neutral-600">{t(`people.${person.role}`, person.role)}</p>
+                {/* 簡介 */}
+                {person.bio && <p>{person.bio[isZh ? 'zh-TW' : 'en']}</p>}
+            </div>
+        </PublicLayout>
+    );
+}

--- a/resources/lang/en/common.php
+++ b/resources/lang/en/common.php
@@ -21,6 +21,10 @@ return [
         'login' => 'Login',
         'dashboard' => 'Dashboard',
     ],
+    'people' => [
+        'faculty' => 'Faculty',
+        'staff' => 'Staff',
+    ],
     'search' => 'Search',
     'language' => [
         'en' => 'EN',

--- a/resources/lang/zh-TW/common.php
+++ b/resources/lang/zh-TW/common.php
@@ -21,6 +21,10 @@ return [
         'login' => '登入',
         'dashboard' => '主控台',
     ],
+    'people' => [
+        'faculty' => '師資',
+        'staff' => '行政',
+    ],
     'search' => '搜尋',
     'language' => [
         'en' => 'EN',

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,10 +7,14 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
 use App\Http\Controllers\TestController;
+use App\Http\Controllers\StaffController;
 
 Route::get('/', function () {
     return Inertia::render('welcome');
 })->name('home');
+
+Route::get('/people', [StaffController::class, 'index'])->name('people.index');
+Route::get('/people/{slug}', [StaffController::class, 'show'])->name('people.show');
 
 // Locale switcher: sets session locale and redirects back
 Route::get('/locale/{locale}', function (string $locale) {


### PR DESCRIPTION
## Summary
- 建立 `StaffController` 提供人員列表與詳情
- 新增 `/people` 與 `/people/{slug}` 路由
- 增加前台 People 頁面，支援角色篩選與多語顯示
- 翻譯檔加入「師資」、「行政」字串

## Testing
- `npm run types` *(失敗：缺少模組宣告)*
- `php artisan test` *(失敗：MissingAppKeyException)*


------
https://chatgpt.com/codex/tasks/task_e_68c7639fbce08323bd9e72b52622ebdc