### PR TITLE
feat: 新增實驗室頁面與控制器

### DIFF
--- a/app/Http/Controllers/LabController.php
+++ b/app/Http/Controllers/LabController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Lab;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class LabController extends Controller
+{
+    // 顯示所有實驗室列表
+    public function index(): Response
+    {
+        // 取得所有可見的實驗室並載入教師
+        $labs = Lab::where('visible', true)
+            ->with('teachers')
+            ->orderBy('sort_order')
+            ->get();
+
+        return Inertia::render('labs/index', [
+            'labs' => $labs,
+        ]);
+    }
+
+    // 顯示單一實驗室詳細資料
+    public function show(Lab $lab): Response
+    {
+        // 預先載入教師資料
+        $lab->load('teachers');
+
+        return Inertia::render('labs/show', [
+            'lab' => $lab,
+        ]);
+    }
+}

--- a/resources/js/pages/labs/index.tsx
+++ b/resources/js/pages/labs/index.tsx
@@ -1,0 +1,45 @@
+import PublicLayout from '@/layouts/public-layout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Head, Link } from '@inertiajs/react';
+
+// 實驗室列表頁面
+interface Teacher {
+    id: number;
+    name: string;
+}
+
+interface Lab {
+    id: number;
+    code: string;
+    name: string;
+    teachers: Teacher[];
+}
+
+export default function LabsIndex({ labs }: { labs: Lab[] }) {
+    return (
+        <PublicLayout>
+            {/* 頁面標題 */}
+            <Head title="實驗室" />
+            <div className="container mx-auto space-y-6 py-8">
+                {labs.map((lab) => (
+                    <Card key={lab.id}>
+                        <CardHeader>
+                            {/* 實驗室名稱 */}
+                            <CardTitle>
+                                <Link href={`/labs/${lab.code}`}>{lab.name}</Link>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {/* 負責教師名單 */}
+                            {lab.teachers.length > 0 && (
+                                <p className="text-sm">
+                                    負責教師：{lab.teachers.map((t) => t.name).join('、')}
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                ))}
+            </div>
+        </PublicLayout>
+    );
+}

--- a/resources/js/pages/labs/show.tsx
+++ b/resources/js/pages/labs/show.tsx
@@ -1,0 +1,43 @@
+import PublicLayout from '@/layouts/public-layout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Head } from '@inertiajs/react';
+
+// 實驗室詳細頁面
+interface Teacher {
+    id: number;
+    name: string;
+}
+
+interface Lab {
+    id: number;
+    name: string;
+    description?: string;
+    teachers: Teacher[];
+}
+
+export default function LabShow({ lab }: { lab: Lab }) {
+    return (
+        <PublicLayout>
+            {/* 使用實驗室名稱作為標題 */}
+            <Head title={lab.name} />
+            <div className="container mx-auto py-8">
+                <Card>
+                    <CardHeader>
+                        {/* 實驗室名稱 */}
+                        <CardTitle>{lab.name}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        {/* 實驗室介紹 */}
+                        {lab.description && <p>{lab.description}</p>}
+                        {/* 負責教師名單 */}
+                        {lab.teachers.length > 0 && (
+                            <p className="text-sm">
+                                負責教師：{lab.teachers.map((t) => t.name).join('、')}
+                            </p>
+                        )}
+                    </CardContent>
+                </Card>
+            </div>
+        </PublicLayout>
+    );
+}

--- a/resources/lang/en/common.php
+++ b/resources/lang/en/common.php
@@ -16,6 +16,7 @@ return [
         'contact' => 'Contact',
         'others' => 'Others',
         'education' => 'Education',
+        'labs' => 'Labs',
     ],
     'auth' => [
         'login' => 'Login',

--- a/resources/lang/en/labs.php
+++ b/resources/lang/en/labs.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'title' => 'Labs',
+    'responsible_teachers' => 'Faculty',
+];

--- a/resources/lang/zh-TW/common.php
+++ b/resources/lang/zh-TW/common.php
@@ -16,6 +16,7 @@ return [
         'contact' => '聯絡我們',
         'others' => '其他',
         'education' => '教育',
+        'labs' => '實驗室',
     ],
     'auth' => [
         'login' => '登入',

--- a/resources/lang/zh-TW/labs.php
+++ b/resources/lang/zh-TW/labs.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'title' => '實驗室',
+    'responsible_teachers' => '負責教師',
+];

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use App\Http\Controllers\AttachmentDownloadController;
+use App\Http\Controllers\LabController;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
@@ -11,6 +12,10 @@ use App\Http\Controllers\TestController;
 Route::get('/', function () {
     return Inertia::render('welcome');
 })->name('home');
+
+// Labs
+Route::get('/labs', [LabController::class, 'index'])->name('labs.index');
+Route::get('/labs/{lab:code}', [LabController::class, 'show'])->name('labs.show');
 
 // Locale switcher: sets session locale and redirects back
 Route::get('/locale/{locale}', function (string $locale) {


### PR DESCRIPTION
## Summary
- 建立 `LabController` 並實作 `index`、`show`
- 新增實驗室列表與詳細頁面
- 補齊實驗室相關翻譯與路由

## Testing
- `composer test` *(fails: No application encryption key has been specified)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c763a2ac788323ae073b6608ca6dd8