### PR TITLE
feat: add staff and lab admin modules

### DIFF
--- a/app/Http/Controllers/Admin/LabController.php
+++ b/app/Http/Controllers/Admin/LabController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Lab;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class LabController extends Controller
+{
+    public function __construct()
+    {
+        // 使用政策進行授權
+        $this->authorizeResource(Lab::class, 'lab');
+    }
+
+    // 列出所有實驗室
+    public function index()
+    {
+        $labs = Lab::orderBy('sort_order')->get();
+        return Inertia::render('admin/labs/index', [
+            'labs' => $labs,
+        ]);
+    }
+
+    // 顯示新增實驗室表單
+    public function create()
+    {
+        return Inertia::render('admin/labs/create');
+    }
+
+    // 儲存新的實驗室
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'code' => ['nullable', 'string'],
+            'website_url' => ['nullable', 'string'],
+            'email' => ['nullable', 'string'],
+            'phone' => ['nullable', 'string'],
+            'cover_image' => ['nullable', 'file'],
+            'name' => ['required', 'string'],
+            'name_en' => ['nullable', 'string'],
+            'description' => ['nullable', 'string'],
+            'description_en' => ['nullable', 'string'],
+            'sort_order' => ['nullable', 'integer'],
+            'visible' => ['boolean'],
+        ]);
+
+        if ($request->hasFile('cover_image')) {
+            // 儲存上傳封面圖路徑
+            $data['cover_image_url'] = $request->file('cover_image')->store('labs', 'public');
+        }
+
+        Lab::create($data);
+
+        return redirect()->route('admin.labs.index');
+    }
+
+    // 顯示編輯表單
+    public function edit(Lab $lab)
+    {
+        return Inertia::render('admin/labs/edit', [
+            'lab' => $lab,
+        ]);
+    }
+
+    // 更新實驗室資料
+    public function update(Request $request, Lab $lab)
+    {
+        $data = $request->validate([
+            'code' => ['nullable', 'string'],
+            'website_url' => ['nullable', 'string'],
+            'email' => ['nullable', 'string'],
+            'phone' => ['nullable', 'string'],
+            'cover_image' => ['nullable', 'file'],
+            'name' => ['required', 'string'],
+            'name_en' => ['nullable', 'string'],
+            'description' => ['nullable', 'string'],
+            'description_en' => ['nullable', 'string'],
+            'sort_order' => ['nullable', 'integer'],
+            'visible' => ['boolean'],
+        ]);
+
+        if ($request->hasFile('cover_image')) {
+            $data['cover_image_url'] = $request->file('cover_image')->store('labs', 'public');
+        }
+
+        $lab->update($data);
+
+        return redirect()->route('admin.labs.index');
+    }
+
+    // 刪除實驗室
+    public function destroy(Lab $lab)
+    {
+        $lab->delete();
+        return redirect()->route('admin.labs.index');
+    }
+}

--- a/app/Http/Controllers/Admin/StaffController.php
+++ b/app/Http/Controllers/Admin/StaffController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Staff;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class StaffController extends Controller
+{
+    public function __construct()
+    {
+        // 使用政策進行授權
+        $this->authorizeResource(Staff::class, 'staff');
+    }
+
+    // 列出所有職員
+    public function index()
+    {
+        $staff = Staff::orderBy('sort_order')->get();
+        return Inertia::render('admin/staff/index', [
+            'staff' => $staff,
+        ]);
+    }
+
+    // 顯示新增職員表單
+    public function create()
+    {
+        return Inertia::render('admin/staff/create');
+    }
+
+    // 儲存新的職員
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'email' => ['nullable', 'string'],
+            'phone' => ['nullable', 'string'],
+            'photo' => ['nullable', 'file'],
+            'name' => ['required', 'string'],
+            'name_en' => ['nullable', 'string'],
+            'position' => ['nullable', 'string'],
+            'position_en' => ['nullable', 'string'],
+            'bio' => ['nullable', 'string'],
+            'bio_en' => ['nullable', 'string'],
+            'sort_order' => ['nullable', 'integer'],
+            'visible' => ['boolean'],
+        ]);
+
+        if ($request->hasFile('photo')) {
+            // 儲存上傳圖片路徑
+            $data['photo_url'] = $request->file('photo')->store('staff', 'public');
+        }
+
+        Staff::create($data);
+
+        return redirect()->route('admin.staff.index');
+    }
+
+    // 顯示編輯表單
+    public function edit(Staff $staff)
+    {
+        return Inertia::render('admin/staff/edit', [
+            'staff' => $staff,
+        ]);
+    }
+
+    // 更新職員資料
+    public function update(Request $request, Staff $staff)
+    {
+        $data = $request->validate([
+            'email' => ['nullable', 'string'],
+            'phone' => ['nullable', 'string'],
+            'photo' => ['nullable', 'file'],
+            'name' => ['required', 'string'],
+            'name_en' => ['nullable', 'string'],
+            'position' => ['nullable', 'string'],
+            'position_en' => ['nullable', 'string'],
+            'bio' => ['nullable', 'string'],
+            'bio_en' => ['nullable', 'string'],
+            'sort_order' => ['nullable', 'integer'],
+            'visible' => ['boolean'],
+        ]);
+
+        if ($request->hasFile('photo')) {
+            $data['photo_url'] = $request->file('photo')->store('staff', 'public');
+        }
+
+        $staff->update($data);
+
+        return redirect()->route('admin.staff.index');
+    }
+
+    // 刪除職員
+    public function destroy(Staff $staff)
+    {
+        $staff->delete();
+        return redirect()->route('admin.staff.index');
+    }
+}

--- a/app/Policies/LabPolicy.php
+++ b/app/Policies/LabPolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\Lab;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class LabPolicy
+{
+    use HandlesAuthorization;
+
+    // 判斷使用者是否可檢視列表
+    public function viewAny(User $user): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    // 判斷使用者是否可檢視單筆資料
+    public function view(User $user, Lab $lab): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    // 判斷使用者是否可新增
+    public function create(User $user): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    // 判斷使用者是否可更新
+    public function update(User $user, Lab $lab): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    // 判斷使用者是否可刪除
+    public function delete(User $user, Lab $lab): bool
+    {
+        return $user->role === 'admin';
+    }
+}

--- a/app/Policies/StaffPolicy.php
+++ b/app/Policies/StaffPolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\Staff;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class StaffPolicy
+{
+    use HandlesAuthorization;
+
+    // 判斷使用者是否可檢視列表
+    public function viewAny(User $user): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    // 判斷使用者是否可檢視單筆資料
+    public function view(User $user, Staff $staff): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    // 判斷使用者是否可新增
+    public function create(User $user): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    // 判斷使用者是否可更新
+    public function update(User $user, Staff $staff): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    // 判斷使用者是否可刪除
+    public function delete(User $user, Staff $staff): bool
+    {
+        return $user->role === 'admin';
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Staff;
+use App\Models\Lab;
+use App\Policies\StaffPolicy;
+use App\Policies\LabPolicy;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /** @var array<class-string, class-string> */
+    protected $policies = [
+        // 職員授權政策
+        Staff::class => StaffPolicy::class,
+        // 實驗室授權政策
+        Lab::class => LabPolicy::class,
+    ];
+
+    public function boot(): void
+    {
+        // 可在此處加入額外授權邏輯
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
 ];

--- a/resources/js/pages/admin/labs/create.tsx
+++ b/resources/js/pages/admin/labs/create.tsx
@@ -1,0 +1,43 @@
+// 新增實驗室頁面
+import LabController from '@/actions/App/Http/Controllers/Admin/LabController';
+import AppLayout from '@/layouts/app-layout';
+import { Form, Head, Link } from '@inertiajs/react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/input-error';
+
+export default function LabCreate() {
+    return (
+        <AppLayout>
+            <Head title="新增實驗室" />
+            <Form {...LabController.store.form()} encType="multipart/form-data" className="space-y-4">
+                {({ errors, processing }) => (
+                    <>
+                        {/* 多語欄位 */}
+                        <div className="grid gap-2">
+                            <Label htmlFor="name">名稱</Label>
+                            <Input id="name" name="name" />
+                            <InputError message={errors.name} />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="name_en">名稱（英文）</Label>
+                            <Input id="name_en" name="name_en" />
+                            <InputError message={errors.name_en} />
+                        </div>
+                        {/* 附件管理 */}
+                        <div className="grid gap-2">
+                            <Label htmlFor="cover_image">封面圖</Label>
+                            <Input id="cover_image" type="file" name="cover_image" />
+                            <InputError message={errors.cover_image} />
+                        </div>
+                        <Button disabled={processing}>儲存</Button>
+                        <Link href={LabController.index().url} className="ml-2">
+                            取消
+                        </Link>
+                    </>
+                )}
+            </Form>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/admin/labs/edit.tsx
+++ b/resources/js/pages/admin/labs/edit.tsx
@@ -1,0 +1,49 @@
+// 編輯實驗室頁面
+import LabController from '@/actions/App/Http/Controllers/Admin/LabController';
+import AppLayout from '@/layouts/app-layout';
+import { Form, Head, Link } from '@inertiajs/react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/input-error';
+
+interface Lab {
+    id: number;
+    name: string;
+    name_en?: string;
+}
+
+export default function LabEdit({ lab }: { lab: Lab }) {
+    return (
+        <AppLayout>
+            <Head title="編輯實驗室" />
+            <Form {...LabController.update.form({ lab: lab.id })} encType="multipart/form-data" className="space-y-4">
+                {({ errors, processing }) => (
+                    <>
+                        {/* 多語欄位 */}
+                        <div className="grid gap-2">
+                            <Label htmlFor="name">名稱</Label>
+                            <Input id="name" name="name" defaultValue={lab.name} />
+                            <InputError message={errors.name} />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="name_en">名稱（英文）</Label>
+                            <Input id="name_en" name="name_en" defaultValue={lab.name_en} />
+                            <InputError message={errors.name_en} />
+                        </div>
+                        {/* 附件管理 */}
+                        <div className="grid gap-2">
+                            <Label htmlFor="cover_image">封面圖</Label>
+                            <Input id="cover_image" type="file" name="cover_image" />
+                            <InputError message={errors.cover_image} />
+                        </div>
+                        <Button disabled={processing}>更新</Button>
+                        <Link href={LabController.index().url} className="ml-2">
+                            取消
+                        </Link>
+                    </>
+                )}
+            </Form>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/admin/labs/index.tsx
+++ b/resources/js/pages/admin/labs/index.tsx
@@ -1,0 +1,33 @@
+// 實驗室列表頁面
+import LabController from '@/actions/App/Http/Controllers/Admin/LabController';
+import AppLayout from '@/layouts/app-layout';
+import { Button } from '@/components/ui/button';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { type SharedData } from '@/types';
+
+interface Lab {
+    id: number;
+    name: string;
+}
+
+export default function LabIndex({ labs }: { labs: Lab[] }) {
+    const { auth } = usePage<SharedData>().props;
+
+    return (
+        <AppLayout>
+            <Head title="實驗室列表" />
+            <div className="space-y-4">
+                {auth.user.role === 'admin' && (
+                    <Link href={LabController.create().url}>
+                        <Button>新增實驗室</Button>
+                    </Link>
+                )}
+                <ul className="list-disc pl-4">
+                    {labs.map((l) => (
+                        <li key={l.id}>{l.name}</li>
+                    ))}
+                </ul>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/admin/staff/create.tsx
+++ b/resources/js/pages/admin/staff/create.tsx
@@ -1,0 +1,54 @@
+// 新增職員頁面
+import StaffController from '@/actions/App/Http/Controllers/Admin/StaffController';
+import AppLayout from '@/layouts/app-layout';
+import { Form, Head, Link } from '@inertiajs/react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/input-error';
+
+export default function StaffCreate() {
+    return (
+        <AppLayout>
+            <Head title="新增職員" />
+            <Form {...StaffController.store.form()} encType="multipart/form-data" className="space-y-4">
+                {({ errors, processing }) => (
+                    <>
+                        {/* 多語欄位 */}
+                        <div className="grid gap-2">
+                            <Label htmlFor="name">姓名</Label>
+                            <Input id="name" name="name" />
+                            <InputError message={errors.name} />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="name_en">姓名（英文）</Label>
+                            <Input id="name_en" name="name_en" />
+                            <InputError message={errors.name_en} />
+                        </div>
+                        {/* 職稱多語欄位 */}
+                        <div className="grid gap-2">
+                            <Label htmlFor="position">職稱</Label>
+                            <Input id="position" name="position" />
+                            <InputError message={errors.position} />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="position_en">職稱（英文）</Label>
+                            <Input id="position_en" name="position_en" />
+                            <InputError message={errors.position_en} />
+                        </div>
+                        {/* 附件管理 */}
+                        <div className="grid gap-2">
+                            <Label htmlFor="photo">照片</Label>
+                            <Input id="photo" type="file" name="photo" />
+                            <InputError message={errors.photo} />
+                        </div>
+                        <Button disabled={processing}>儲存</Button>
+                        <Link href={StaffController.index().url} className="ml-2">
+                            取消
+                        </Link>
+                    </>
+                )}
+            </Form>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/admin/staff/edit.tsx
+++ b/resources/js/pages/admin/staff/edit.tsx
@@ -1,0 +1,62 @@
+// 編輯職員頁面
+import StaffController from '@/actions/App/Http/Controllers/Admin/StaffController';
+import AppLayout from '@/layouts/app-layout';
+import { Form, Head, Link } from '@inertiajs/react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import InputError from '@/components/input-error';
+
+interface Staff {
+    id: number;
+    name: string;
+    name_en?: string;
+    position?: string;
+    position_en?: string;
+}
+
+export default function StaffEdit({ staff }: { staff: Staff }) {
+    return (
+        <AppLayout>
+            <Head title="編輯職員" />
+            <Form {...StaffController.update.form({ staff: staff.id })} encType="multipart/form-data" className="space-y-4">
+                {({ errors, processing }) => (
+                    <>
+                        {/* 多語欄位 */}
+                        <div className="grid gap-2">
+                            <Label htmlFor="name">姓名</Label>
+                            <Input id="name" name="name" defaultValue={staff.name} />
+                            <InputError message={errors.name} />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="name_en">姓名（英文）</Label>
+                            <Input id="name_en" name="name_en" defaultValue={staff.name_en} />
+                            <InputError message={errors.name_en} />
+                        </div>
+                        {/* 職稱多語欄位 */}
+                        <div className="grid gap-2">
+                            <Label htmlFor="position">職稱</Label>
+                            <Input id="position" name="position" defaultValue={staff.position} />
+                            <InputError message={errors.position} />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="position_en">職稱（英文）</Label>
+                            <Input id="position_en" name="position_en" defaultValue={staff.position_en} />
+                            <InputError message={errors.position_en} />
+                        </div>
+                        {/* 附件管理 */}
+                        <div className="grid gap-2">
+                            <Label htmlFor="photo">照片</Label>
+                            <Input id="photo" type="file" name="photo" />
+                            <InputError message={errors.photo} />
+                        </div>
+                        <Button disabled={processing}>更新</Button>
+                        <Link href={StaffController.index().url} className="ml-2">
+                            取消
+                        </Link>
+                    </>
+                )}
+            </Form>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/admin/staff/index.tsx
+++ b/resources/js/pages/admin/staff/index.tsx
@@ -1,0 +1,33 @@
+// 職員列表頁面
+import StaffController from '@/actions/App/Http/Controllers/Admin/StaffController';
+import AppLayout from '@/layouts/app-layout';
+import { Button } from '@/components/ui/button';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { type SharedData } from '@/types';
+
+interface Staff {
+    id: number;
+    name: string;
+}
+
+export default function StaffIndex({ staff }: { staff: Staff[] }) {
+    const { auth } = usePage<SharedData>().props;
+
+    return (
+        <AppLayout>
+            <Head title="職員列表" />
+            <div className="space-y-4">
+                {auth.user.role === 'admin' && (
+                    <Link href={StaffController.create().url}>
+                        <Button>新增職員</Button>
+                    </Link>
+                )}
+                <ul className="list-disc pl-4">
+                    {staff.map((s) => (
+                        <li key={s.id}>{s.name}</li>
+                    ))}
+                </ul>
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
 use App\Http\Controllers\TestController;
+use App\Http\Controllers\Admin\StaffController;
+use App\Http\Controllers\Admin\LabController;
 
 Route::get('/', function () {
     return Inertia::render('welcome');
@@ -39,6 +41,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/{test}/edit', [TestController::class, 'edit'])->name('edit');
         Route::put('/{test}', [TestController::class, 'update'])->name('update');
         Route::delete('/{test}', [TestController::class, 'destroy'])->name('destroy');
+    });
+
+    Route::prefix('admin')->name('admin.')->group(function () {
+        Route::resource('staff', StaffController::class);
+        Route::resource('labs', LabController::class);
     });
 
 });


### PR DESCRIPTION
## Summary
- add Staff and Lab controllers with CRUD and multilingual fields
- add admin routes and authorization policies
- add admin React pages for staff and labs

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c763afdd5c8323a760f7df83f33567