### PR TITLE
調整側邊欄為黑底白字

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -90,8 +90,8 @@
     --chart-4: oklch(0.828 0.189 84.429);
     --chart-5: oklch(0.769 0.188 70.08);
     --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar: oklch(0 0 0);
+    --sidebar-foreground: oklch(1 0 0);
     --sidebar-primary: oklch(0.205 0 0);
     --sidebar-primary-foreground: oklch(0.985 0 0);
     --sidebar-accent: oklch(0.97 0 0);
@@ -125,8 +125,8 @@
     --chart-3: oklch(0.769 0.188 70.08);
     --chart-4: oklch(0.627 0.265 303.9);
     --chart-5: oklch(0.645 0.246 16.439);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar: oklch(0 0 0);
+    --sidebar-foreground: oklch(1 0 0);
     --sidebar-primary: oklch(0.985 0 0);
     --sidebar-primary-foreground: oklch(0.985 0 0);
     --sidebar-accent: oklch(0.269 0 0);


### PR DESCRIPTION
## 摘要
- 將 `--sidebar` 變數改為黑色，`--sidebar-foreground` 改為白色
- 同步更新 dark mode 的側邊欄背景與前景色

## 測試
- `php artisan test`（失敗：No application encryption key has been specified）

------
https://chatgpt.com/codex/tasks/task_e_68c7b9d93e908323a6087f18aab72b17