### PR TITLE
使用按鈕包裹取消連結

### DIFF
--- a/resources/js/pages/admin/labs/create.tsx
+++ b/resources/js/pages/admin/labs/create.tsx
@@ -1,11 +1,11 @@
 // 新增實驗室頁面
 import LabController from '@/actions/App/Http/Controllers/Admin/LabController';
-import AppLayout from '@/layouts/app-layout';
-import { Form, Head, Link } from '@inertiajs/react';
+import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import InputError from '@/components/input-error';
+import AppLayout from '@/layouts/app-layout';
+import { Form, Head, Link } from '@inertiajs/react';
 
 export default function LabCreate() {
     return (
@@ -32,8 +32,11 @@ export default function LabCreate() {
                             <InputError message={errors.cover_image} />
                         </div>
                         <Button disabled={processing}>儲存</Button>
-                        <Link href={LabController.index().url} className="ml-2">
-                            取消
+                        <Link href={LabController.index().url}>
+                            {/* 取消按鈕 */}
+                            <Button variant="outline" className="ml-2">
+                                取消
+                            </Button>
                         </Link>
                     </>
                 )}

--- a/resources/js/pages/admin/labs/edit.tsx
+++ b/resources/js/pages/admin/labs/edit.tsx
@@ -1,11 +1,11 @@
 // 編輯實驗室頁面
 import LabController from '@/actions/App/Http/Controllers/Admin/LabController';
-import AppLayout from '@/layouts/app-layout';
-import { Form, Head, Link } from '@inertiajs/react';
+import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import InputError from '@/components/input-error';
+import AppLayout from '@/layouts/app-layout';
+import { Form, Head, Link } from '@inertiajs/react';
 
 interface Lab {
     id: number;
@@ -38,8 +38,11 @@ export default function LabEdit({ lab }: { lab: Lab }) {
                             <InputError message={errors.cover_image} />
                         </div>
                         <Button disabled={processing}>更新</Button>
-                        <Link href={LabController.index().url} className="ml-2">
-                            取消
+                        <Link href={LabController.index().url}>
+                            {/* 取消按鈕 */}
+                            <Button variant="outline" className="ml-2">
+                                取消
+                            </Button>
                         </Link>
                     </>
                 )}

--- a/resources/js/pages/admin/staff/create.tsx
+++ b/resources/js/pages/admin/staff/create.tsx
@@ -1,11 +1,11 @@
 // 新增職員頁面
 import StaffController from '@/actions/App/Http/Controllers/Admin/StaffController';
-import AppLayout from '@/layouts/app-layout';
-import { Form, Head, Link } from '@inertiajs/react';
+import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import InputError from '@/components/input-error';
+import AppLayout from '@/layouts/app-layout';
+import { Form, Head, Link } from '@inertiajs/react';
 
 export default function StaffCreate() {
     return (
@@ -43,8 +43,11 @@ export default function StaffCreate() {
                             <InputError message={errors.photo} />
                         </div>
                         <Button disabled={processing}>儲存</Button>
-                        <Link href={StaffController.index().url} className="ml-2">
-                            取消
+                        <Link href={StaffController.index().url}>
+                            {/* 取消按鈕 */}
+                            <Button variant="outline" className="ml-2">
+                                取消
+                            </Button>
                         </Link>
                     </>
                 )}

--- a/resources/js/pages/admin/staff/edit.tsx
+++ b/resources/js/pages/admin/staff/edit.tsx
@@ -1,11 +1,11 @@
 // 編輯職員頁面
 import StaffController from '@/actions/App/Http/Controllers/Admin/StaffController';
-import AppLayout from '@/layouts/app-layout';
-import { Form, Head, Link } from '@inertiajs/react';
+import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import InputError from '@/components/input-error';
+import AppLayout from '@/layouts/app-layout';
+import { Form, Head, Link } from '@inertiajs/react';
 
 interface Staff {
     id: number;
@@ -51,8 +51,11 @@ export default function StaffEdit({ staff }: { staff: Staff }) {
                             <InputError message={errors.photo} />
                         </div>
                         <Button disabled={processing}>更新</Button>
-                        <Link href={StaffController.index().url} className="ml-2">
-                            取消
+                        <Link href={StaffController.index().url}>
+                            {/* 取消按鈕 */}
+                            <Button variant="outline" className="ml-2">
+                                取消
+                            </Button>
                         </Link>
                     </>
                 )}


### PR DESCRIPTION
## Summary
- 使用`variant="outline"`的按鈕包裹「取消」連結以統一表單操作

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run types`
- `npm run format:check` *(fails: Code style issues found in 38 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cbf34bc8832390ed3fe5ccb5acb1