### PR TITLE
feat: wrap admin forms with container card

### DIFF
--- a/resources/js/pages/admin/labs/create.tsx
+++ b/resources/js/pages/admin/labs/create.tsx
@@ -2,6 +2,7 @@
 import LabController from '@/actions/App/Http/Controllers/Admin/LabController';
 import LabForm from '@/components/admin/lab-form';
 import AppLayout from '@/layouts/app-layout';
+import { Card, CardContent } from '@/components/ui/card';
 import { Head } from '@inertiajs/react';
 
 export default function LabCreate() {
@@ -12,7 +13,13 @@ export default function LabCreate() {
     return (
         <AppLayout>
             <Head title="新增實驗室" />
-            <LabForm initialValues={{}} onSubmit={submit} />
+            <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <Card>
+                    <CardContent>
+                        <LabForm initialValues={{}} onSubmit={submit} />
+                    </CardContent>
+                </Card>
+            </div>
         </AppLayout>
     );
 }

--- a/resources/js/pages/admin/labs/edit.tsx
+++ b/resources/js/pages/admin/labs/edit.tsx
@@ -2,6 +2,7 @@
 import LabController from '@/actions/App/Http/Controllers/Admin/LabController';
 import LabForm from '@/components/admin/lab-form';
 import AppLayout from '@/layouts/app-layout';
+import { Card, CardContent } from '@/components/ui/card';
 import { Head } from '@inertiajs/react';
 
 interface Lab {
@@ -18,7 +19,13 @@ export default function LabEdit({ lab }: { lab: Lab }) {
     return (
         <AppLayout>
             <Head title="編輯實驗室" />
-            <LabForm initialValues={lab} onSubmit={submit} />
+            <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <Card>
+                    <CardContent>
+                        <LabForm initialValues={lab} onSubmit={submit} />
+                    </CardContent>
+                </Card>
+            </div>
         </AppLayout>
     );
 }

--- a/resources/js/pages/admin/staff/create.tsx
+++ b/resources/js/pages/admin/staff/create.tsx
@@ -2,6 +2,7 @@
 import StaffController from '@/actions/App/Http/Controllers/Admin/StaffController';
 import StaffForm from '@/components/admin/staff-form';
 import AppLayout from '@/layouts/app-layout';
+import { Card, CardContent } from '@/components/ui/card';
 import { Head } from '@inertiajs/react';
 
 export default function StaffCreate() {
@@ -12,7 +13,13 @@ export default function StaffCreate() {
     return (
         <AppLayout>
             <Head title="新增職員" />
-            <StaffForm initialValues={{}} onSubmit={submit} />
+            <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <Card>
+                    <CardContent>
+                        <StaffForm initialValues={{}} onSubmit={submit} />
+                    </CardContent>
+                </Card>
+            </div>
         </AppLayout>
     );
 }

--- a/resources/js/pages/admin/staff/edit.tsx
+++ b/resources/js/pages/admin/staff/edit.tsx
@@ -2,6 +2,7 @@
 import StaffController from '@/actions/App/Http/Controllers/Admin/StaffController';
 import StaffForm from '@/components/admin/staff-form';
 import AppLayout from '@/layouts/app-layout';
+import { Card, CardContent } from '@/components/ui/card';
 import { Head } from '@inertiajs/react';
 
 interface Staff {
@@ -20,7 +21,13 @@ export default function StaffEdit({ staff }: { staff: Staff }) {
     return (
         <AppLayout>
             <Head title="編輯職員" />
-            <StaffForm initialValues={staff} onSubmit={submit} />
+            <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <Card>
+                    <CardContent>
+                        <StaffForm initialValues={staff} onSubmit={submit} />
+                    </CardContent>
+                </Card>
+            </div>
         </AppLayout>
     );
 }


### PR DESCRIPTION
## Summary
- style admin lab forms with responsive container and card
- style admin staff forms with responsive container and card

## Testing
- `npm run types` *(fails: Cannot find module '@/actions/...')*
- `./vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ce9c14e48323947efa34668dc4f2