### PR TITLE
feat: 支援公告連結來源內容擷取

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -5,12 +5,20 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Post;
 use App\Models\PostCategory;
+use App\Services\PostContentFetcher;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
+use RuntimeException;
 
 class PostController extends Controller
 {
+    public function __construct(private PostContentFetcher $contentFetcher)
+    {
+    }
+
     /**
      * Display a listing of the resource.
      */
@@ -45,13 +53,29 @@ class PostController extends Controller
         $validated = $request->validate([
             'title.zh-TW' => 'required|string|max:255',
             'title.en' => 'nullable|string|max:255',
-            'content.zh-TW' => 'required|string',
+            'content.zh-TW' => [Rule::requiredIf(fn () => $request->input('source_type', 'manual') === 'manual'), 'nullable', 'string'],
             'content.en' => 'nullable|string',
             'category_id' => 'required|exists:post_categories,id',
-            'status' => 'required|in:draft,published',
+            'status' => 'required|in:draft,published,archived',
             'pinned' => 'boolean',
             'publish_at' => 'nullable|date',
+            'source_type' => ['required', Rule::in(['manual', 'link'])],
+            'source_url' => [Rule::requiredIf(fn () => $request->input('source_type') === 'link'), 'nullable', 'url'],
         ]);
+
+        $sourceType = $validated['source_type'];
+        $fetchedHtml = null;
+
+        if ($sourceType === 'link') {
+            try {
+                $fetched = $this->contentFetcher->fetch($validated['source_url']);
+                $fetchedHtml = $fetched['html'];
+            } catch (RuntimeException $exception) {
+                throw ValidationException::withMessages([
+                    'source_url' => '抓取內容失敗：' . $exception->getMessage(),
+                ]);
+            }
+        }
 
         $postData = [
             'category_id' => $validated['category_id'],
@@ -60,17 +84,44 @@ class PostController extends Controller
             'publish_at' => $validated['publish_at'] ?? null,
             'title' => $validated['title']['zh-TW'] ?? '',
             'title_en' => $validated['title']['en'] ?? '',
-            'content' => $validated['content']['zh-TW'] ?? '',
-            'content_en' => $validated['content']['en'] ?? '',
+            'content' => $sourceType === 'manual' ? ($validated['content']['zh-TW'] ?? '') : '',
+            'content_en' => $sourceType === 'manual' ? ($validated['content']['en'] ?? '') : '',
+            'source_type' => $sourceType,
+            'source_url' => $sourceType === 'link' ? $validated['source_url'] : null,
+            'fetched_html' => $sourceType === 'link' ? $fetchedHtml : null,
             'created_by' => auth()->id(),
             'updated_by' => auth()->id(),
-            'slug' => Str::slug($validated['title']['zh-TW'] . '-' . time()),
+            'slug' => Str::slug(($validated['title']['zh-TW'] ?? '') . '-' . time()),
         ];
 
         Post::create($postData);
 
         return redirect()->route('admin.posts.index')
             ->with('success', '公告建立成功');
+    }
+
+    /**
+     * 即時抓取外部內容供後台預覽使用。
+     */
+    public function fetchPreview(Request $request)
+    {
+        $validated = $request->validate([
+            'source_url' => ['required', 'url'],
+        ]);
+
+        try {
+            $result = $this->contentFetcher->fetch($validated['source_url']);
+        } catch (RuntimeException $exception) {
+            return response()->json([
+                'message' => $exception->getMessage(),
+            ], 422);
+        }
+
+        return response()->json([
+            'title' => $result['title'],
+            'description' => $result['description'],
+            'html' => $result['html'],
+        ]);
     }
 
     /**
@@ -102,23 +153,42 @@ class PostController extends Controller
         $validated = $request->validate([
             'title.zh-TW' => 'required|string|max:255',
             'title.en' => 'nullable|string|max:255',
-            'content.zh-TW' => 'required|string',
+            'content.zh-TW' => [Rule::requiredIf(fn () => $request->input('source_type', 'manual') === 'manual'), 'nullable', 'string'],
             'content.en' => 'nullable|string',
             'category_id' => 'required|exists:post_categories,id',
-            'status' => 'required|in:draft,published',
+            'status' => 'required|in:draft,published,archived',
             'pinned' => 'boolean',
             'publish_at' => 'nullable|date',
+            'source_type' => ['required', Rule::in(['manual', 'link'])],
+            'source_url' => [Rule::requiredIf(fn () => $request->input('source_type') === 'link'), 'nullable', 'url'],
         ]);
+
+        $sourceType = $validated['source_type'];
+        $fetchedHtml = null;
+
+        if ($sourceType === 'link') {
+            try {
+                $fetched = $this->contentFetcher->fetch($validated['source_url']);
+                $fetchedHtml = $fetched['html'];
+            } catch (RuntimeException $exception) {
+                throw ValidationException::withMessages([
+                    'source_url' => '抓取內容失敗：' . $exception->getMessage(),
+                ]);
+            }
+        }
 
         $postData = [
             'category_id' => $validated['category_id'],
             'status' => $validated['status'],
-            'pinned' => $validated['pinned'] ?? false,
-            'publish_at' => $validated['publish_at'],
-            'title' => $validated['title']['zh-TW'],
-            'title_en' => $validated['title']['en'],
-            'content' => $validated['content']['zh-TW'],
-            'content_en' => $validated['content']['en'],
+            'pinned' => $request->boolean('pinned'),
+            'publish_at' => $validated['publish_at'] ?? null,
+            'title' => $validated['title']['zh-TW'] ?? $post->title,
+            'title_en' => $validated['title']['en'] ?? $post->title_en,
+            'content' => $sourceType === 'manual' ? ($validated['content']['zh-TW'] ?? '') : '',
+            'content_en' => $sourceType === 'manual' ? ($validated['content']['en'] ?? '') : '',
+            'source_type' => $sourceType,
+            'source_url' => $sourceType === 'link' ? $validated['source_url'] : null,
+            'fetched_html' => $sourceType === 'link' ? $fetchedHtml : null,
             'updated_by' => auth()->id(),
         ];
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -24,6 +24,9 @@ class Post extends Model
         'summary_en',
         'content',
         'content_en',
+        'source_type',
+        'source_url',
+        'fetched_html',
         'created_by',
         'updated_by',
     ];
@@ -34,6 +37,9 @@ class Post extends Model
             'publish_at' => 'datetime',
             'expire_at' => 'datetime',
             'pinned' => 'boolean',
+            'source_type' => 'string',
+            'source_url' => 'string',
+            'fetched_html' => 'string',
         ];
     }
 

--- a/app/Services/PostContentFetcher.php
+++ b/app/Services/PostContentFetcher.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace App\Services;
+
+use DOMDocument;
+use DOMNode;
+use DOMXPath;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use RuntimeException;
+
+class PostContentFetcher
+{
+    private Client $client;
+
+    /**
+     * 禁止直接輸出的 HTML 標籤，避免注入惡意內容。
+     */
+    private const DISALLOWED_TAGS = [
+        'script',
+        'iframe',
+        'object',
+        'embed',
+        'form',
+        'input',
+        'button',
+        'link',
+        'meta',
+        'style',
+    ];
+
+    public function __construct(?Client $client = null)
+    {
+        $this->client = $client ?? new Client([
+            'timeout' => 10,
+            'http_errors' => false,
+            'allow_redirects' => true,
+            'headers' => [
+                'User-Agent' => 'CSIEWebContentFetcher/1.0 (+https://csie.example)',
+                'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            ],
+        ]);
+    }
+
+    /**
+     * 擷取遠端網頁並回傳整理後的資訊。
+     */
+    public function fetch(string $url): array
+    {
+        try {
+            $response = $this->client->request('GET', $url);
+        } catch (GuzzleException $exception) {
+            throw new RuntimeException('無法連線至遠端來源，請稍後再試。', 0, $exception);
+        }
+
+        if ($response->getStatusCode() >= 400) {
+            throw new RuntimeException('遠端來源回應異常（HTTP ' . $response->getStatusCode() . '）。');
+        }
+
+        $rawHtml = (string) $response->getBody();
+
+        if (trim($rawHtml) === '') {
+            throw new RuntimeException('遠端來源未提供可解析的內容。');
+        }
+
+        $document = $this->createDocument($rawHtml);
+        $mainContent = $this->locateMainContent($document);
+
+        if (trim($mainContent) === '') {
+            $mainContent = $this->nodeToHtml($document->getElementsByTagName('body')->item(0));
+        }
+
+        $sanitized = $this->sanitizeHtml($mainContent);
+
+        if (trim($sanitized) === '') {
+            throw new RuntimeException('未能擷取到合適的主要內容，請改用手動輸入。');
+        }
+
+        return [
+            'title' => $this->extractTitle($document),
+            'description' => $this->extractDescription($document),
+            'html' => $sanitized,
+        ];
+    }
+
+    private function createDocument(string $html): DOMDocument
+    {
+        $document = new DOMDocument('1.0', 'UTF-8');
+        $previous = libxml_use_internal_errors(true);
+        $document->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_NOWARNING | LIBXML_NOERROR);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        return $document;
+    }
+
+    private function locateMainContent(DOMDocument $document): string
+    {
+        $xpath = new DOMXPath($document);
+        $queries = [
+            '//article',
+            '//main',
+            '//*[@id="content"]',
+            '//*[@id="main"]',
+            '//*[contains(@class, "article")]',
+            '//*[contains(@class, "content")]',
+            '//*[contains(@class, "post")]',
+        ];
+
+        foreach ($queries as $query) {
+            $nodes = $xpath->query($query);
+
+            if (! $nodes instanceof \DOMNodeList || $nodes->length === 0) {
+                continue;
+            }
+
+            foreach ($nodes as $node) {
+                if ($this->textLength($node) >= 200) {
+                    return $this->nodeToHtml($node);
+                }
+            }
+
+            return $this->nodeToHtml($nodes->item(0));
+        }
+
+        return $this->nodeToHtml($document->getElementsByTagName('body')->item(0));
+    }
+
+    private function textLength(?DOMNode $node): int
+    {
+        return $node ? mb_strlen(trim($node->textContent ?? '')) : 0;
+    }
+
+    private function extractTitle(DOMDocument $document): ?string
+    {
+        $title = $document->getElementsByTagName('title')->item(0)?->textContent;
+
+        return $title ? trim($title) : null;
+    }
+
+    private function extractDescription(DOMDocument $document): ?string
+    {
+        $xpath = new DOMXPath($document);
+        $targets = [
+            '//meta[@name="description"]/@content',
+            '//meta[@property="og:description"]/@content',
+            '//meta[@name="twitter:description"]/@content',
+        ];
+
+        foreach ($targets as $query) {
+            $nodes = $xpath->query($query);
+
+            if ($nodes instanceof \DOMNodeList && $nodes->length > 0) {
+                $value = trim($nodes->item(0)?->nodeValue ?? '');
+
+                if ($value !== '') {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function sanitizeHtml(string $html): string
+    {
+        $document = new DOMDocument('1.0', 'UTF-8');
+        $previous = libxml_use_internal_errors(true);
+        $document->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_NOWARNING | LIBXML_NOERROR);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        foreach (self::DISALLOWED_TAGS as $tag) {
+            $nodes = $document->getElementsByTagName($tag);
+
+            while ($nodes->length > 0) {
+                $node = $nodes->item(0);
+                $node?->parentNode?->removeChild($node);
+            }
+        }
+
+        $xpath = new DOMXPath($document);
+
+        foreach ($xpath->query('//@*') as $attribute) {
+            $name = strtolower($attribute->nodeName);
+            $value = trim($attribute->nodeValue ?? '');
+
+            if (str_starts_with($name, 'on')) {
+                $attribute->ownerElement?->removeAttribute($attribute->nodeName);
+                continue;
+            }
+
+            if (in_array($name, ['src', 'href'], true) && preg_match('/^\s*javascript:/i', $value)) {
+                $attribute->ownerElement?->removeAttribute($attribute->nodeName);
+            }
+        }
+
+        $body = $document->getElementsByTagName('body')->item(0);
+
+        return trim($this->nodeToHtml($body));
+    }
+
+    private function nodeToHtml(?DOMNode $node): string
+    {
+        if (! $node) {
+            return '';
+        }
+
+        $document = new DOMDocument('1.0', 'UTF-8');
+        $document->appendChild($document->importNode($node, true));
+
+        return $document->saveHTML() ?: '';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "guzzlehttp/guzzle": "^7.10",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de34702a58937cb6544a6c94104a1666",
+    "content-hash": "a84a0df8c2da37df898c37ab2fbd1c0c",
     "packages": [
         {
             "name": "brick/math",

--- a/database/migrations/2025_09_17_014528_add_source_fields_to_posts_table.php
+++ b/database/migrations/2025_09_17_014528_add_source_fields_to_posts_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->enum('source_type', ['manual', 'link'])
+                ->default('manual')
+                ->after('status')
+                ->index();
+            $table->string('source_url')
+                ->nullable()
+                ->after('source_type');
+            $table->longText('fetched_html')
+                ->nullable()
+                ->after('content_en');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn(['source_type', 'source_url', 'fetched_html']);
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "csie_fk",
+    "name": "csie_web",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -27,6 +27,7 @@
                 "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
                 "concurrently": "^9.0.1",
+                "dompurify": "^3.2.6",
                 "globals": "^15.14.0",
                 "laravel-vite-plugin": "^2.0",
                 "lucide-react": "^0.475.0",
@@ -2666,6 +2667,13 @@
                 "@types/react": "^19.0.0"
             }
         },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.39.1",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
@@ -3605,6 +3613,15 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+            "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
+        "dompurify": "^3.2.6",
         "globals": "^15.14.0",
         "laravel-vite-plugin": "^2.0",
         "lucide-react": "^0.475.0",

--- a/resources/js/pages/bulletins/show.tsx
+++ b/resources/js/pages/bulletins/show.tsx
@@ -1,5 +1,6 @@
 import PublicLayout from '@/layouts/public-layout';
 import { Head, Link, usePage } from '@inertiajs/react';
+import DOMPurify from 'dompurify';
 import type { SharedData } from '@/types';
 
 interface Props {
@@ -12,14 +13,20 @@ export default function BulletinShow({ post }: Props) {
     const t = (key: string, fallback?: string) =>
         key.split('.').reduce((acc: any, k: string) => (acc && acc[k] !== undefined ? acc[k] : undefined), i18n?.common) ?? fallback ?? key;
 
+    const rawHtml = post.source_type === 'link' ? post.fetched_html ?? '' : post.content ?? '';
+    const sanitizedHtml = DOMPurify.sanitize(rawHtml);
+    const hasContent = sanitizedHtml.trim().length > 0;
+
     return (
         <PublicLayout>
             <Head title={post.title} />
             <section className="mx-auto max-w-4xl space-y-4 p-4">
                 <h1 className="text-2xl font-bold">{post.title}</h1>
-                {/* 顯示公告內容 */}
-                {post.content && (
-                    <div className="prose" dangerouslySetInnerHTML={{ __html: post.content }} />
+                {/* 依來源顯示內容並進行 HTML 消毒 */}
+                {hasContent ? (
+                    <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />
+                ) : (
+                    <p className="text-sm text-gray-500">{t('bulletin.empty', 'This bulletin has no visible content.')}</p>
                 )}
                 <Link href="/bulletins" className="text-blue-600 hover:underline">
                     {t('bulletin.back', 'Back')}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -51,6 +51,8 @@ Route::middleware(['auth', 'verified'])->prefix('admin')->name('admin.')->group(
 
     // 公告管理
     Route::resource('post-categories', AdminPostCategoryController::class);
+    Route::post('posts/fetch-preview', [AdminPostController::class, 'fetchPreview'])
+        ->name('posts.fetch-preview');
     Route::resource('posts', AdminPostController::class);
 
     // 聯絡我們管理


### PR DESCRIPTION
## 摘要
- 新增 posts 資料表來源欄位與 PostContentFetcher 服務，支援以 Guzzle 擷取外部 HTML 並過濾危險標籤
- 調整後台公告建立與編輯流程，依輸入方式驗證欄位、觸發遠端抓取並帶回預覽
- 前台公告詳情改用 DOMPurify 消毒輸出，並依來源切換顯示手動內容或擷取結果

## 測試
- `php artisan test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ca11b8ff7c8323838574d28adcd0a0