### PR TITLE
feat(admin): add post detail page and shared form

### DIFF
--- a/resources/js/pages/admin/posts/components/post-form.tsx
+++ b/resources/js/pages/admin/posts/components/post-form.tsx
@@ -1,0 +1,455 @@
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import type { SharedData } from '@/types';
+import { Link, useForm, usePage } from '@inertiajs/react';
+import type { InertiaFormProps } from '@inertiajs/react/types/useForm';
+import DOMPurify from 'dompurify';
+import { Calendar, Loader2 } from 'lucide-react';
+import type { FormEventHandler } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+export interface PostCategory {
+    id: number;
+    name: string;
+    name_en: string;
+    slug: string;
+}
+
+export interface PostFormValues {
+    title: {
+        'zh-TW': string;
+        en: string;
+    };
+    content: {
+        'zh-TW': string;
+        en: string;
+    };
+    category_id: string;
+    status: 'draft' | 'published' | 'archived';
+    pinned: boolean;
+    publish_at: string;
+    source_type: 'manual' | 'link';
+    source_url: string;
+}
+
+export interface StatusOption {
+    value: 'draft' | 'published' | 'archived';
+    labelZh: string;
+    labelEn: string;
+}
+
+interface PostFormProps {
+    categories: PostCategory[];
+    cancelUrl: string;
+    mode: 'create' | 'edit';
+    initialValues: PostFormValues;
+    statusOptions: StatusOption[];
+    initialPreviewHtml?: string;
+    onSubmit: (form: InertiaFormProps<PostFormValues>) => void;
+}
+
+const emptyContent = {
+    'zh-TW': '',
+    en: '',
+};
+
+const getSubmitLabels = (isZh: boolean, mode: 'create' | 'edit') => {
+    if (mode === 'create') {
+        return {
+            idle: isZh ? '建立公告' : 'Create Post',
+            processing: isZh ? '建立中...' : 'Creating...'
+        };
+    }
+
+    return {
+        idle: isZh ? '更新公告' : 'Update Post',
+        processing: isZh ? '更新中...' : 'Updating...'
+    };
+};
+
+export default function PostForm({
+    categories,
+    cancelUrl,
+    mode,
+    initialValues,
+    statusOptions,
+    initialPreviewHtml = '',
+    onSubmit,
+}: PostFormProps) {
+    const { locale } = usePage<SharedData>().props;
+    const isZh = locale === 'zh-TW';
+
+    const form = useForm<PostFormValues>({
+        title: {
+            'zh-TW': initialValues.title['zh-TW'],
+            en: initialValues.title.en,
+        },
+        content: {
+            'zh-TW': initialValues.content['zh-TW'],
+            en: initialValues.content.en,
+        },
+        category_id: initialValues.category_id,
+        status: initialValues.status,
+        pinned: initialValues.pinned,
+        publish_at: initialValues.publish_at,
+        source_type: initialValues.source_type,
+        source_url: initialValues.source_url,
+    });
+
+    const { data, setData, errors, processing } = form;
+
+    const [previewHtml, setPreviewHtml] = useState<string>(initialPreviewHtml);
+    const [previewError, setPreviewError] = useState<string | null>(null);
+    const [previewLoading, setPreviewLoading] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (data.source_type === 'manual') {
+            setPreviewHtml('');
+            setPreviewError(null);
+        }
+    }, [data.source_type]);
+
+    useEffect(() => {
+        if (!data.source_url.trim()) {
+            setPreviewHtml('');
+        }
+    }, [data.source_url]);
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+        onSubmit(form);
+    };
+
+    const handleSourceTypeChange = (value: string) => {
+        const newValue = value === 'link' ? 'link' : 'manual';
+
+        setData('source_type', newValue);
+
+        if (newValue === 'manual') {
+            setData('source_url', '');
+            setPreviewHtml('');
+            setPreviewError(null);
+        } else {
+            setData('content', { ...emptyContent });
+        }
+    };
+
+    const handleFetchPreview = async () => {
+        if (data.source_type !== 'link') {
+            return;
+        }
+
+        const csrfToken = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content;
+
+        if (!csrfToken) {
+            setPreviewError('無法取得安全性驗證資訊，請重新整理頁面後再試。');
+            return;
+        }
+
+        if (!data.source_url.trim()) {
+            setPreviewError('請先輸入完整的來源網址。');
+            return;
+        }
+
+        setPreviewLoading(true);
+        setPreviewError(null);
+
+        try {
+            const response = await fetch('/admin/posts/fetch-preview', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-CSRF-TOKEN': csrfToken,
+                },
+                credentials: 'same-origin',
+                body: JSON.stringify({
+                    source_url: data.source_url,
+                }),
+            });
+
+            const result = await response.json();
+
+            if (!response.ok) {
+                const message =
+                    result?.message ??
+                    result?.errors?.source_url?.[0] ??
+                    (isZh ? '抓取內容失敗，請稍後再試。' : 'Failed to fetch content.');
+
+                throw new Error(message);
+            }
+
+            setPreviewHtml(result.html ?? '');
+        } catch (error) {
+            const message =
+                error instanceof Error
+                    ? error.message
+                    : isZh
+                        ? '抓取內容失敗，請稍後再試。'
+                        : 'Failed to fetch remote content.';
+            setPreviewError(message);
+            setPreviewHtml('');
+        } finally {
+            setPreviewLoading(false);
+        }
+    };
+
+    const submitLabels = useMemo(() => getSubmitLabels(isZh, mode), [isZh, mode]);
+
+    return (
+        <form onSubmit={submit}>
+            <div className="space-y-8">
+                <Card className="border-gray-200 bg-white shadow-sm">
+                    <CardHeader className="border-b border-gray-100 bg-gray-50/50">
+                        <CardTitle className="flex items-center gap-2 text-gray-900">
+                            <Calendar className="h-5 w-5 text-blue-600" />
+                            {isZh ? '基本資訊' : 'Basic Information'}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-6 p-8">
+                        <div className="space-y-4">
+                            <Label htmlFor="title-zh" className="text-sm font-medium text-gray-900">
+                                {isZh ? '標題 (中文)' : 'Title (Chinese)'}
+                            </Label>
+                            <Input
+                                id="title-zh"
+                                value={data.title['zh-TW']}
+                                onChange={(event) =>
+                                    setData('title', {
+                                        ...data.title,
+                                        'zh-TW': event.target.value,
+                                    })
+                                }
+                                placeholder={isZh ? '請輸入中文標題' : 'Enter Chinese title'}
+                            />
+                            <InputError message={errors['title.zh-TW']} />
+                        </div>
+
+                        <div className="space-y-4">
+                            <Label htmlFor="title-en" className="text-sm font-medium text-gray-900">
+                                {isZh ? '標題 (英文)' : 'Title (English)'}
+                            </Label>
+                            <Input
+                                id="title-en"
+                                value={data.title.en}
+                                onChange={(event) =>
+                                    setData('title', {
+                                        ...data.title,
+                                        en: event.target.value,
+                                    })
+                                }
+                                placeholder={isZh ? '請輸入英文標題' : 'Enter English title'}
+                            />
+                            <InputError message={errors['title.en']} />
+                        </div>
+
+                        <div className="space-y-4">
+                            <Label htmlFor="category" className="text-sm font-medium text-gray-900">
+                                {isZh ? '分類' : 'Category'}
+                            </Label>
+                            <Select
+                                id="category"
+                                value={data.category_id}
+                                onChange={(event) => setData('category_id', event.target.value)}
+                            >
+                                <option value="">{isZh ? '請選擇分類' : 'Select category'}</option>
+                                {categories.map((category) => (
+                                    <option key={category.id} value={category.id}>
+                                        {isZh ? category.name : category.name_en}
+                                    </option>
+                                ))}
+                            </Select>
+                            <InputError message={errors.category_id} />
+                        </div>
+
+                        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                            <div className="space-y-4">
+                                <Label htmlFor="status" className="text-sm font-medium text-gray-900">
+                                    {isZh ? '狀態' : 'Status'}
+                                </Label>
+                                <Select
+                                    id="status"
+                                    value={data.status}
+                                    onChange={(event) => setData('status', event.target.value as PostFormValues['status'])}
+                                >
+                                    {statusOptions.map((option) => (
+                                        <option key={option.value} value={option.value}>
+                                            {isZh ? option.labelZh : option.labelEn}
+                                        </option>
+                                    ))}
+                                </Select>
+                            </div>
+
+                            <div className="space-y-4">
+                                <Label htmlFor="publish_at" className="text-sm font-medium text-gray-900">
+                                    {isZh ? '發布時間' : 'Publish Date'}
+                                </Label>
+                                <Input
+                                    id="publish_at"
+                                    type="datetime-local"
+                                    value={data.publish_at}
+                                    onChange={(event) => setData('publish_at', event.target.value)}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="pt-2">
+                            <div className="flex items-center space-x-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
+                                <Checkbox
+                                    id="pinned"
+                                    checked={data.pinned}
+                                    onCheckedChange={(checked) => setData('pinned', Boolean(checked))}
+                                />
+                                <Label htmlFor="pinned" className="text-sm font-medium text-gray-900">
+                                    {isZh ? '置頂公告' : 'Pin this post'}
+                                </Label>
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card className="border-gray-200 bg-white shadow-sm">
+                    <CardHeader className="border-b border-gray-100 bg-gray-50/50">
+                        <CardTitle className="text-gray-900">{isZh ? '內容' : 'Content'}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-6 p-8">
+                        <div className="grid gap-6 md:grid-cols-2">
+                            <div className="space-y-4">
+                                <Label htmlFor="source_type" className="text-sm font-medium text-gray-900">
+                                    {isZh ? '輸入方式' : 'Input Source'}
+                                </Label>
+                                <Select
+                                    id="source_type"
+                                    value={data.source_type}
+                                    onChange={(event) => handleSourceTypeChange(event.target.value)}
+                                >
+                                    <option value="manual">{isZh ? '手動輸入' : 'Manual'}</option>
+                                    <option value="link">{isZh ? '外部連結' : 'Link'}</option>
+                                </Select>
+                                <InputError message={errors.source_type} />
+                            </div>
+
+                            {data.source_type === 'link' && (
+                                <div className="space-y-4">
+                                    <Label htmlFor="source_url" className="text-sm font-medium text-gray-900">
+                                        {isZh ? '來源網址' : 'Source URL'}
+                                    </Label>
+                                    <div className="flex flex-col gap-2 sm:flex-row">
+                                        <Input
+                                            id="source_url"
+                                            value={data.source_url}
+                                            onChange={(event) => setData('source_url', event.target.value)}
+                                            placeholder={isZh ? '請輸入外部連結' : 'Enter the external link'}
+                                        />
+                                        <Button
+                                            type="button"
+                                            variant="secondary"
+                                            onClick={handleFetchPreview}
+                                            disabled={previewLoading}
+                                        >
+                                            {previewLoading ? (
+                                                <span className="flex items-center gap-2">
+                                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                                    {isZh ? '抓取中' : 'Fetching'}
+                                                </span>
+                                            ) : (
+                                                isZh ? '抓取內容' : 'Fetch Content'
+                                            )}
+                                        </Button>
+                                    </div>
+                                    <InputError message={errors.source_url} />
+                                    {previewError && <p className="text-sm text-red-600">{previewError}</p>}
+                                </div>
+                            )}
+                        </div>
+
+                        {data.source_type === 'manual' ? (
+                            <>
+                                <div className="space-y-4">
+                                    <Label htmlFor="content-zh" className="text-sm font-medium text-gray-900">
+                                        {isZh ? '內容 (中文)' : 'Content (Chinese)'}
+                                    </Label>
+                                    <Textarea
+                                        id="content-zh"
+                                        className="min-h-[200px]"
+                                        value={data.content['zh-TW']}
+                                        onChange={(event) =>
+                                            setData('content', {
+                                                ...data.content,
+                                                'zh-TW': event.target.value,
+                                            })
+                                        }
+                                        placeholder={isZh ? '請輸入中文內容' : 'Enter Chinese content'}
+                                    />
+                                    <InputError message={errors['content.zh-TW']} />
+                                </div>
+
+                                <div className="space-y-4">
+                                    <Label htmlFor="content-en" className="text-sm font-medium text-gray-900">
+                                        {isZh ? '內容 (英文)' : 'Content (English)'}
+                                    </Label>
+                                    <Textarea
+                                        id="content-en"
+                                        className="min-h-[200px]"
+                                        value={data.content.en}
+                                        onChange={(event) =>
+                                            setData('content', {
+                                                ...data.content,
+                                                en: event.target.value,
+                                            })
+                                        }
+                                        placeholder={isZh ? '請輸入英文內容' : 'Enter English content'}
+                                    />
+                                    <InputError message={errors['content.en']} />
+                                </div>
+                            </>
+                        ) : (
+                            <div className="space-y-4">
+                                <Label className="text-sm font-medium text-gray-900">
+                                    {isZh ? '抓取內容預覽' : 'Fetched Preview'}
+                                </Label>
+                                {previewHtml ? (
+                                    <div
+                                        className="prose max-w-none rounded-lg border border-gray-200 bg-gray-50 p-4"
+                                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(previewHtml) }}
+                                    />
+                                ) : (
+                                    <p className="text-sm text-gray-500">
+                                        {isZh
+                                            ? '輸入網址後點擊「抓取內容」即可預覽遠端內容，儲存時會同步寫入公告。'
+                                            : 'Provide the link and click “Fetch Content” to preview what will be saved.'}
+                                    </p>
+                                )}
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+
+                <div className="flex items-center justify-end space-x-4 rounded-lg border border-gray-200 bg-white p-6">
+                    <Link href={cancelUrl}>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            className="border-gray-300 text-gray-700 transition-colors duration-200 hover:border-gray-400 hover:bg-gray-50"
+                        >
+                            {isZh ? '取消' : 'Cancel'}
+                        </Button>
+                    </Link>
+                    <Button
+                        type="submit"
+                        disabled={processing}
+                        className="bg-blue-600 text-white transition-colors duration-200 shadow-sm hover:bg-blue-700 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        {processing ? submitLabels.processing : submitLabels.idle}
+                    </Button>
+                </div>
+            </div>
+        </form>
+    );
+}

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -1,25 +1,11 @@
 import PostController from '@/actions/App/Http/Controllers/Admin/PostController';
-import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select } from '@/components/ui/select';
-import { Textarea } from '@/components/ui/textarea';
 import AppLayout from '@/layouts/app-layout';
-import { type SharedData } from '@/types';
-import { Head, Link, useForm, usePage } from '@inertiajs/react';
-import DOMPurify from 'dompurify';
-import { ArrowLeft, Calendar, Loader2 } from 'lucide-react';
-import { FormEventHandler, useEffect, useState } from 'react';
-
-interface PostCategory {
-    id: number;
-    name: string;
-    name_en: string;
-    slug: string;
-}
+import type { SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
+import type { InertiaFormProps } from '@inertiajs/react/types/useForm';
+import { ArrowLeft } from 'lucide-react';
+import PostForm, { type PostCategory, type PostFormValues, type StatusOption } from './components/post-form';
 
 interface CreatePostProps {
     categories: PostCategory[];
@@ -29,7 +15,7 @@ export default function CreatePost({ categories }: CreatePostProps) {
     const { locale } = usePage<SharedData>().props;
     const isZh = locale === 'zh-TW';
 
-    const { data, setData, post, processing, errors } = useForm({
+    const initialValues: PostFormValues = {
         title: {
             'zh-TW': '',
             en: '',
@@ -44,100 +30,17 @@ export default function CreatePost({ categories }: CreatePostProps) {
         publish_at: '',
         source_type: 'manual',
         source_url: '',
-    });
-
-    const [previewHtml, setPreviewHtml] = useState<string>('');
-    const [previewError, setPreviewError] = useState<string | null>(null);
-    const [previewLoading, setPreviewLoading] = useState<boolean>(false);
-
-    useEffect(() => {
-        if (data.source_type === 'manual') {
-            setPreviewHtml('');
-            setPreviewError(null);
-        }
-    }, [data.source_type]);
-
-    useEffect(() => {
-        if (!data.source_url.trim()) {
-            setPreviewHtml('');
-        }
-    }, [data.source_url]);
-
-    const handleSourceTypeChange = (value: string) => {
-        setData('source_type', value);
-
-        if (value === 'manual') {
-            setData('source_url', '');
-        } else {
-            setData('content.zh-TW', '');
-            setData('content.en', '');
-        }
     };
 
-    const handleFetchPreview = async () => {
-        if (data.source_type !== 'link') {
-            return;
-        }
+    const statusOptions: StatusOption[] = [
+        { value: 'draft', labelZh: '草稿', labelEn: 'Draft' },
+        { value: 'published', labelZh: '已發布', labelEn: 'Published' },
+    ];
 
-        const csrfToken = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content;
-
-        if (!csrfToken) {
-            setPreviewError('無法取得安全性驗證資訊，請重新整理頁面後再試。');
-            return;
-        }
-
-        if (!data.source_url.trim()) {
-            setPreviewError('請先輸入完整的來源網址。');
-            return;
-        }
-
-        setPreviewLoading(true);
-        setPreviewError(null);
-
-        try {
-            const response = await fetch('/admin/posts/fetch-preview', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    'X-CSRF-TOKEN': csrfToken,
-                },
-                credentials: 'same-origin',
-                body: JSON.stringify({
-                    source_url: data.source_url,
-                }),
-            });
-
-            const result = await response.json();
-
-            if (!response.ok) {
-                const message =
-                    result?.message ??
-                    result?.errors?.source_url?.[0] ??
-                    (isZh ? '抓取內容失敗，請稍後再試。' : 'Failed to fetch content.');
-
-                throw new Error(message);
-            }
-
-            setPreviewHtml(result.html ?? '');
-        } catch (error) {
-            const message =
-                error instanceof Error
-                    ? error.message
-                    : isZh
-                        ? '抓取內容失敗，請稍後再試。'
-                        : 'Failed to fetch remote content.';
-            setPreviewError(message);
-            setPreviewHtml('');
-        } finally {
-            setPreviewLoading(false);
-        }
-    };
-
-    const submit: FormEventHandler = (e) => {
-        e.preventDefault();
-        post(PostController.store().url, {
+    const handleSubmit = (form: InertiaFormProps<PostFormValues>) => {
+        form.post(PostController.store().url, {
             onError: (formErrors) => {
+                // 繫結表單錯誤以便開發時追蹤
                 console.error('Form errors:', formErrors);
             },
         });
@@ -151,240 +54,32 @@ export default function CreatePost({ categories }: CreatePostProps) {
                 <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
                     <div className="flex items-center gap-4">
                         <Link href={PostController.index().url}>
-                            <Button variant="ghost" size="sm" className="text-gray-600 hover:text-gray-900 hover:bg-gray-100">
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                            >
                                 <ArrowLeft className="h-4 w-4" />
                             </Button>
                         </Link>
                         <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">{isZh ? '建立公告' : 'Create Post'}</h1>
-                            <p className="mt-2 text-gray-600">{isZh ? '建立新的公告或新聞' : 'Create a new announcement or news post'}</p>
+                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                                {isZh ? '建立公告' : 'Create Post'}
+                            </h1>
+                            <p className="mt-2 text-gray-600">
+                                {isZh ? '建立新的公告或新聞' : 'Create a new announcement or news post'}
+                            </p>
                         </div>
                     </div>
 
-                    <form onSubmit={submit}>
-                        <div className="space-y-8">
-                            <Card className="bg-white shadow-sm border-gray-200">
-                                <CardHeader className="border-b border-gray-100 bg-gray-50/50">
-                                    <CardTitle className="flex items-center gap-2 text-gray-900">
-                                        <Calendar className="h-5 w-5 text-blue-600" />
-                                        {isZh ? '基本資訊' : 'Basic Information'}
-                                    </CardTitle>
-                                </CardHeader>
-                                <CardContent className="space-y-6 p-8">
-                                    <div className="space-y-4">
-                                        <Label htmlFor="title-zh" className="text-sm font-medium text-gray-900">
-                                            {isZh ? '標題 (中文)' : 'Title (Chinese)'}
-                                        </Label>
-                                        <Input
-                                            id="title-zh"
-                                            value={data.title['zh-TW']}
-                                            onChange={(e) => setData('title.zh-TW', e.target.value)}
-                                            placeholder={isZh ? '請輸入中文標題' : 'Enter Chinese title'}
-                                        />
-                                        <InputError message={errors['title.zh-TW']} />
-                                    </div>
-
-                                    <div className="space-y-4">
-                                        <Label htmlFor="title-en" className="text-sm font-medium text-gray-900">
-                                            {isZh ? '標題 (英文)' : 'Title (English)'}
-                                        </Label>
-                                        <Input
-                                            id="title-en"
-                                            value={data.title.en}
-                                            onChange={(e) => setData('title.en', e.target.value)}
-                                            placeholder={isZh ? '請輸入英文標題' : 'Enter English title'}
-                                        />
-                                        <InputError message={errors['title.en']} />
-                                    </div>
-
-                                    <div className="space-y-4">
-                                        <Label htmlFor="category" className="text-sm font-medium text-gray-900">
-                                            {isZh ? '分類' : 'Category'}
-                                        </Label>
-                                        <Select
-                                            id="category"
-                                            value={data.category_id}
-                                            onChange={(e) => setData('category_id', e.target.value)}
-                                        >
-                                            <option value="">{isZh ? '請選擇分類' : 'Select category'}</option>
-                                            {categories.map((category) => (
-                                                <option key={category.id} value={category.id}>
-                                                    {isZh ? category.name : category.name_en}
-                                                </option>
-                                            ))}
-                                        </Select>
-                                        <InputError message={errors.category_id} />
-                                    </div>
-
-                                    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-                                        <div className="space-y-4">
-                                            <Label htmlFor="status" className="text-sm font-medium text-gray-900">
-                                                {isZh ? '狀態' : 'Status'}
-                                            </Label>
-                                            <Select
-                                                id="status"
-                                                value={data.status}
-                                                onChange={(e) => setData('status', e.target.value)}
-                                            >
-                                                <option value="draft">{isZh ? '草稿' : 'Draft'}</option>
-                                                <option value="published">{isZh ? '已發布' : 'Published'}</option>
-                                            </Select>
-                                        </div>
-
-                                        <div className="space-y-4">
-                                            <Label htmlFor="publish_at" className="text-sm font-medium text-gray-900">
-                                                {isZh ? '發布時間' : 'Publish Date'}
-                                            </Label>
-                                            <Input
-                                                id="publish_at"
-                                                type="datetime-local"
-                                                value={data.publish_at}
-                                                onChange={(e) => setData('publish_at', e.target.value)}
-                                            />
-                                        </div>
-                                    </div>
-
-                                    <div className="pt-2">
-                                        <div className="flex items-center space-x-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
-                                            <Checkbox
-                                                id="pinned"
-                                                checked={data.pinned}
-                                                onCheckedChange={(checked) => setData('pinned', !!checked)}
-                                            />
-                                            <Label htmlFor="pinned" className="text-sm font-medium text-gray-900">
-                                                {isZh ? '置頂公告' : 'Pin this post'}
-                                            </Label>
-                                        </div>
-                                    </div>
-                                </CardContent>
-                            </Card>
-
-                            <Card className="bg-white shadow-sm border-gray-200">
-                                <CardHeader className="border-b border-gray-100 bg-gray-50/50">
-                                    <CardTitle className="text-gray-900">{isZh ? '內容' : 'Content'}</CardTitle>
-                                </CardHeader>
-                                <CardContent className="space-y-6 p-8">
-                                    <div className="grid gap-6 md:grid-cols-2">
-                                        <div className="space-y-4">
-                                            <Label htmlFor="source_type" className="text-sm font-medium text-gray-900">
-                                                {isZh ? '輸入方式' : 'Input Source'}
-                                            </Label>
-                                            <Select
-                                                id="source_type"
-                                                value={data.source_type}
-                                                onChange={(e) => handleSourceTypeChange(e.target.value)}
-                                            >
-                                                <option value="manual">{isZh ? '手動輸入' : 'Manual'}</option>
-                                                <option value="link">{isZh ? '外部連結' : 'Link'}</option>
-                                            </Select>
-                                            <InputError message={errors.source_type} />
-                                        </div>
-
-                                        {data.source_type === 'link' && (
-                                            <div className="space-y-4">
-                                                <Label htmlFor="source_url" className="text-sm font-medium text-gray-900">
-                                                    {isZh ? '來源網址' : 'Source URL'}
-                                                </Label>
-                                                <div className="flex flex-col gap-2 sm:flex-row">
-                                                    <Input
-                                                        id="source_url"
-                                                        value={data.source_url}
-                                                        onChange={(e) => setData('source_url', e.target.value)}
-                                                        placeholder={isZh ? '請輸入外部連結' : 'Enter the external link'}
-                                                    />
-                                                    <Button
-                                                        type="button"
-                                                        variant="secondary"
-                                                        onClick={handleFetchPreview}
-                                                        disabled={previewLoading}
-                                                    >
-                                                        {previewLoading ? (
-                                                            <span className="flex items-center gap-2">
-                                                                <Loader2 className="h-4 w-4 animate-spin" />
-                                                                {isZh ? '抓取中' : 'Fetching'}
-                                                            </span>
-                                                        ) : (
-                                                            isZh ? '抓取內容' : 'Fetch Content'
-                                                        )}
-                                                    </Button>
-                                                </div>
-                                                <InputError message={errors.source_url} />
-                                                {previewError && <p className="text-sm text-red-600">{previewError}</p>}
-                                            </div>
-                                        )}
-                                    </div>
-
-                                    {data.source_type === 'manual' ? (
-                                        <>
-                                            <div className="space-y-4">
-                                                <Label htmlFor="content-zh" className="text-sm font-medium text-gray-900">
-                                                    {isZh ? '內容 (中文)' : 'Content (Chinese)'}
-                                                </Label>
-                                                <Textarea
-                                                    id="content-zh"
-                                                    className="min-h-[200px]"
-                                                    value={data.content['zh-TW']}
-                                                    onChange={(e) => setData('content.zh-TW', e.target.value)}
-                                                    placeholder={isZh ? '請輸入中文內容' : 'Enter Chinese content'}
-                                                />
-                                                <InputError message={errors['content.zh-TW']} />
-                                            </div>
-
-                                            <div className="space-y-4">
-                                                <Label htmlFor="content-en" className="text-sm font-medium text-gray-900">
-                                                    {isZh ? '內容 (英文)' : 'Content (English)'}
-                                                </Label>
-                                                <Textarea
-                                                    id="content-en"
-                                                    className="min-h-[200px]"
-                                                    value={data.content.en}
-                                                    onChange={(e) => setData('content.en', e.target.value)}
-                                                    placeholder={isZh ? '請輸入英文內容' : 'Enter English content'}
-                                                />
-                                                <InputError message={errors['content.en']} />
-                                            </div>
-                                        </>
-                                    ) : (
-                                        <div className="space-y-4">
-                                            <Label className="text-sm font-medium text-gray-900">
-                                                {isZh ? '抓取內容預覽' : 'Fetched Preview'}
-                                            </Label>
-                                            {previewHtml ? (
-                                                <div
-                                                    className="prose max-w-none rounded-lg border border-gray-200 bg-gray-50 p-4"
-                                                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(previewHtml) }}
-                                                />
-                                            ) : (
-                                                <p className="text-sm text-gray-500">
-                                                    {isZh
-                                                        ? '輸入網址後點擊「抓取內容」即可預覽遠端內容，儲存時會同步寫入公告。'
-                                                        : 'Provide the link and click “Fetch Content” to preview what will be saved.'}
-                                                </p>
-                                            )}
-                                        </div>
-                                    )}
-                                </CardContent>
-                            </Card>
-
-                            <div className="flex items-center justify-end space-x-4 rounded-lg border border-gray-200 bg-white p-6">
-                                <Link href={PostController.index().url}>
-                                    <Button
-                                        variant="outline"
-                                        className="border-gray-300 text-gray-700 transition-colors duration-200 hover:border-gray-400 hover:bg-gray-50"
-                                    >
-                                        {isZh ? '取消' : 'Cancel'}
-                                    </Button>
-                                </Link>
-                                <Button
-                                    type="submit"
-                                    disabled={processing}
-                                    className="bg-blue-600 text-white transition-colors duration-200 shadow-sm hover:bg-blue-700 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50"
-                                >
-                                    {processing ? (isZh ? '建立中...' : 'Creating...') : isZh ? '建立公告' : 'Create Post'}
-                                </Button>
-                            </div>
-                        </div>
-                    </form>
+                    <PostForm
+                        categories={categories}
+                        cancelUrl={PostController.index().url}
+                        mode="create"
+                        initialValues={initialValues}
+                        statusOptions={statusOptions}
+                        onSubmit={handleSubmit}
+                    />
                 </div>
             </div>
         </AppLayout>

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -1,25 +1,11 @@
 import PostController from '@/actions/App/Http/Controllers/Admin/PostController';
-import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select } from '@/components/ui/select';
-import { Textarea } from '@/components/ui/textarea';
 import AppLayout from '@/layouts/app-layout';
-import { type SharedData } from '@/types';
-import { Head, Link, useForm, usePage } from '@inertiajs/react';
-import DOMPurify from 'dompurify';
-import { ArrowLeft, Calendar, Loader2 } from 'lucide-react';
-import { FormEventHandler, useEffect, useState } from 'react';
-
-interface PostCategory {
-    id: number;
-    name: string;
-    name_en: string;
-    slug: string;
-}
+import type { SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
+import type { InertiaFormProps } from '@inertiajs/react/types/useForm';
+import { ArrowLeft } from 'lucide-react';
+import PostForm, { type PostCategory, type PostFormValues, type StatusOption } from './components/post-form';
 
 interface AdminPost {
     id: number;
@@ -60,7 +46,7 @@ export default function EditPost({ post, categories }: EditPostProps) {
     const { locale } = usePage<SharedData>().props;
     const isZh = locale === 'zh-TW';
 
-    const { data, setData, put, processing, errors } = useForm({
+    const initialValues: PostFormValues = {
         title: {
             'zh-TW': post.title ?? '',
             en: post.title_en ?? '',
@@ -71,108 +57,24 @@ export default function EditPost({ post, categories }: EditPostProps) {
         },
         category_id: String(post.category_id ?? ''),
         status: post.status ?? 'draft',
-        pinned: !!post.pinned,
+        pinned: Boolean(post.pinned),
         publish_at: formatPublishAt(post.publish_at),
-        source_type: post.source_type ?? 'manual',
+        source_type: (post.source_type ?? 'manual') as 'manual' | 'link',
         source_url: post.source_url ?? '',
-    });
-
-    const [previewHtml, setPreviewHtml] = useState<string>(
-        post.source_type === 'link' ? post.fetched_html ?? '' : ''
-    );
-    const [previewError, setPreviewError] = useState<string | null>(null);
-    const [previewLoading, setPreviewLoading] = useState<boolean>(false);
-
-    useEffect(() => {
-        if (data.source_type === 'manual') {
-            setPreviewHtml('');
-            setPreviewError(null);
-        }
-    }, [data.source_type]);
-
-    useEffect(() => {
-        if (!data.source_url.trim()) {
-            setPreviewHtml('');
-        }
-    }, [data.source_url]);
-
-    const handleSourceTypeChange = (value: string) => {
-        setData('source_type', value);
-
-        if (value === 'manual') {
-            setData('source_url', '');
-            setPreviewHtml('');
-            setPreviewError(null);
-        } else {
-            setData('content.zh-TW', '');
-            setData('content.en', '');
-        }
     };
 
-    const handleFetchPreview = async () => {
-        if (data.source_type !== 'link') {
-            return;
-        }
+    const initialPreviewHtml = post.source_type === 'link' ? post.fetched_html ?? '' : '';
 
-        const csrfToken = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content;
+    const statusOptions: StatusOption[] = [
+        { value: 'draft', labelZh: '草稿', labelEn: 'Draft' },
+        { value: 'published', labelZh: '已發布', labelEn: 'Published' },
+        { value: 'archived', labelZh: '已封存', labelEn: 'Archived' },
+    ];
 
-        if (!csrfToken) {
-            setPreviewError('無法取得安全性驗證資訊，請重新整理頁面後再試。');
-            return;
-        }
-
-        if (!data.source_url.trim()) {
-            setPreviewError('請先輸入完整的來源網址。');
-            return;
-        }
-
-        setPreviewLoading(true);
-        setPreviewError(null);
-
-        try {
-            const response = await fetch('/admin/posts/fetch-preview', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    'X-CSRF-TOKEN': csrfToken,
-                },
-                credentials: 'same-origin',
-                body: JSON.stringify({
-                    source_url: data.source_url,
-                }),
-            });
-
-            const result = await response.json();
-
-            if (!response.ok) {
-                const message =
-                    result?.message ??
-                    result?.errors?.source_url?.[0] ??
-                    (isZh ? '抓取內容失敗，請稍後再試。' : 'Failed to fetch content.');
-
-                throw new Error(message);
-            }
-
-            setPreviewHtml(result.html ?? '');
-        } catch (error) {
-            const message =
-                error instanceof Error
-                    ? error.message
-                    : isZh
-                        ? '抓取內容失敗，請稍後再試。'
-                        : 'Failed to fetch remote content.';
-            setPreviewError(message);
-            setPreviewHtml('');
-        } finally {
-            setPreviewLoading(false);
-        }
-    };
-
-    const submit: FormEventHandler = (e) => {
-        e.preventDefault();
-        put(PostController.update(post.id).url, {
+    const handleSubmit = (form: InertiaFormProps<PostFormValues>) => {
+        form.put(PostController.update(post.id).url, {
             onError: (formErrors) => {
+                // 繫結表單錯誤以便開發時追蹤
                 console.error('Form errors:', formErrors);
             },
         });
@@ -186,241 +88,33 @@ export default function EditPost({ post, categories }: EditPostProps) {
                 <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
                     <div className="flex items-center gap-4">
                         <Link href={PostController.index().url}>
-                            <Button variant="ghost" size="sm" className="text-gray-600 hover:text-gray-900 hover:bg-gray-100">
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                            >
                                 <ArrowLeft className="h-4 w-4" />
                             </Button>
                         </Link>
                         <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">{isZh ? '編輯公告' : 'Edit Post'}</h1>
-                            <p className="mt-2 text-gray-600">{isZh ? '調整公告內容與顯示設定' : 'Update the announcement details.'}</p>
+                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                                {isZh ? '編輯公告' : 'Edit Post'}
+                            </h1>
+                            <p className="mt-2 text-gray-600">
+                                {isZh ? '調整公告內容與顯示設定' : 'Update the announcement details.'}
+                            </p>
                         </div>
                     </div>
 
-                    <form onSubmit={submit}>
-                        <div className="space-y-8">
-                            <Card className="bg-white shadow-sm border-gray-200">
-                                <CardHeader className="border-b border-gray-100 bg-gray-50/50">
-                                    <CardTitle className="flex items-center gap-2 text-gray-900">
-                                        <Calendar className="h-5 w-5 text-blue-600" />
-                                        {isZh ? '基本資訊' : 'Basic Information'}
-                                    </CardTitle>
-                                </CardHeader>
-                                <CardContent className="space-y-6 p-8">
-                                    <div className="space-y-4">
-                                        <Label htmlFor="title-zh" className="text-sm font-medium text-gray-900">
-                                            {isZh ? '標題 (中文)' : 'Title (Chinese)'}
-                                        </Label>
-                                        <Input
-                                            id="title-zh"
-                                            value={data.title['zh-TW']}
-                                            onChange={(e) => setData('title.zh-TW', e.target.value)}
-                                            placeholder={isZh ? '請輸入中文標題' : 'Enter Chinese title'}
-                                        />
-                                        <InputError message={errors['title.zh-TW']} />
-                                    </div>
-
-                                    <div className="space-y-4">
-                                        <Label htmlFor="title-en" className="text-sm font-medium text-gray-900">
-                                            {isZh ? '標題 (英文)' : 'Title (English)'}
-                                        </Label>
-                                        <Input
-                                            id="title-en"
-                                            value={data.title.en}
-                                            onChange={(e) => setData('title.en', e.target.value)}
-                                            placeholder={isZh ? '請輸入英文標題' : 'Enter English title'}
-                                        />
-                                        <InputError message={errors['title.en']} />
-                                    </div>
-
-                                    <div className="space-y-4">
-                                        <Label htmlFor="category" className="text-sm font-medium text-gray-900">
-                                            {isZh ? '分類' : 'Category'}
-                                        </Label>
-                                        <Select
-                                            id="category"
-                                            value={data.category_id}
-                                            onChange={(e) => setData('category_id', e.target.value)}
-                                        >
-                                            <option value="">{isZh ? '請選擇分類' : 'Select category'}</option>
-                                            {categories.map((category) => (
-                                                <option key={category.id} value={category.id}>
-                                                    {isZh ? category.name : category.name_en}
-                                                </option>
-                                            ))}
-                                        </Select>
-                                        <InputError message={errors.category_id} />
-                                    </div>
-
-                                    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-                                        <div className="space-y-4">
-                                            <Label htmlFor="status" className="text-sm font-medium text-gray-900">
-                                                {isZh ? '狀態' : 'Status'}
-                                            </Label>
-                                            <Select
-                                                id="status"
-                                                value={data.status}
-                                                onChange={(e) => setData('status', e.target.value)}
-                                            >
-                                                <option value="draft">{isZh ? '草稿' : 'Draft'}</option>
-                                                <option value="published">{isZh ? '已發布' : 'Published'}</option>
-                                                <option value="archived">{isZh ? '已封存' : 'Archived'}</option>
-                                            </Select>
-                                        </div>
-
-                                        <div className="space-y-4">
-                                            <Label htmlFor="publish_at" className="text-sm font-medium text-gray-900">
-                                                {isZh ? '發布時間' : 'Publish Date'}
-                                            </Label>
-                                            <Input
-                                                id="publish_at"
-                                                type="datetime-local"
-                                                value={data.publish_at}
-                                                onChange={(e) => setData('publish_at', e.target.value)}
-                                            />
-                                        </div>
-                                    </div>
-
-                                    <div className="pt-2">
-                                        <div className="flex items-center space-x-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
-                                            <Checkbox
-                                                id="pinned"
-                                                checked={data.pinned}
-                                                onCheckedChange={(checked) => setData('pinned', !!checked)}
-                                            />
-                                            <Label htmlFor="pinned" className="text-sm font-medium text-gray-900">
-                                                {isZh ? '置頂公告' : 'Pin this post'}
-                                            </Label>
-                                        </div>
-                                    </div>
-                                </CardContent>
-                            </Card>
-
-                            <Card className="bg-white shadow-sm border-gray-200">
-                                <CardHeader className="border-b border-gray-100 bg-gray-50/50">
-                                    <CardTitle className="text-gray-900">{isZh ? '內容' : 'Content'}</CardTitle>
-                                </CardHeader>
-                                <CardContent className="space-y-6 p-8">
-                                    <div className="grid gap-6 md:grid-cols-2">
-                                        <div className="space-y-4">
-                                            <Label htmlFor="source_type" className="text-sm font-medium text-gray-900">
-                                                {isZh ? '輸入方式' : 'Input Source'}
-                                            </Label>
-                                            <Select
-                                                id="source_type"
-                                                value={data.source_type}
-                                                onChange={(e) => handleSourceTypeChange(e.target.value)}
-                                            >
-                                                <option value="manual">{isZh ? '手動輸入' : 'Manual'}</option>
-                                                <option value="link">{isZh ? '外部連結' : 'Link'}</option>
-                                            </Select>
-                                            <InputError message={errors.source_type} />
-                                        </div>
-
-                                        {data.source_type === 'link' && (
-                                            <div className="space-y-4">
-                                                <Label htmlFor="source_url" className="text-sm font-medium text-gray-900">
-                                                    {isZh ? '來源網址' : 'Source URL'}
-                                                </Label>
-                                                <div className="flex flex-col gap-2 sm:flex-row">
-                                                    <Input
-                                                        id="source_url"
-                                                        value={data.source_url}
-                                                        onChange={(e) => setData('source_url', e.target.value)}
-                                                        placeholder={isZh ? '請輸入外部連結' : 'Enter the external link'}
-                                                    />
-                                                    <Button
-                                                        type="button"
-                                                        variant="secondary"
-                                                        onClick={handleFetchPreview}
-                                                        disabled={previewLoading}
-                                                    >
-                                                        {previewLoading ? (
-                                                            <span className="flex items-center gap-2">
-                                                                <Loader2 className="h-4 w-4 animate-spin" />
-                                                                {isZh ? '抓取中' : 'Fetching'}
-                                                            </span>
-                                                        ) : (
-                                                            isZh ? '抓取內容' : 'Fetch Content'
-                                                        )}
-                                                    </Button>
-                                                </div>
-                                                <InputError message={errors.source_url} />
-                                                {previewError && <p className="text-sm text-red-600">{previewError}</p>}
-                                            </div>
-                                        )}
-                                    </div>
-
-                                    {data.source_type === 'manual' ? (
-                                        <>
-                                            <div className="space-y-4">
-                                                <Label htmlFor="content-zh" className="text-sm font-medium text-gray-900">
-                                                    {isZh ? '內容 (中文)' : 'Content (Chinese)'}
-                                                </Label>
-                                                <Textarea
-                                                    id="content-zh"
-                                                    className="min-h-[200px]"
-                                                    value={data.content['zh-TW']}
-                                                    onChange={(e) => setData('content.zh-TW', e.target.value)}
-                                                    placeholder={isZh ? '請輸入中文內容' : 'Enter Chinese content'}
-                                                />
-                                                <InputError message={errors['content.zh-TW']} />
-                                            </div>
-
-                                            <div className="space-y-4">
-                                                <Label htmlFor="content-en" className="text-sm font-medium text-gray-900">
-                                                    {isZh ? '內容 (英文)' : 'Content (English)'}
-                                                </Label>
-                                                <Textarea
-                                                    id="content-en"
-                                                    className="min-h-[200px]"
-                                                    value={data.content.en}
-                                                    onChange={(e) => setData('content.en', e.target.value)}
-                                                    placeholder={isZh ? '請輸入英文內容' : 'Enter English content'}
-                                                />
-                                                <InputError message={errors['content.en']} />
-                                            </div>
-                                        </>
-                                    ) : (
-                                        <div className="space-y-4">
-                                            <Label className="text-sm font-medium text-gray-900">
-                                                {isZh ? '抓取內容預覽' : 'Fetched Preview'}
-                                            </Label>
-                                            {previewHtml ? (
-                                                <div
-                                                    className="prose max-w-none rounded-lg border border-gray-200 bg-gray-50 p-4"
-                                                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(previewHtml) }}
-                                                />
-                                            ) : (
-                                                <p className="text-sm text-gray-500">
-                                                    {isZh
-                                                        ? '輸入網址後點擊「抓取內容」即可預覽遠端內容，儲存時會同步寫入公告。'
-                                                        : 'Provide the link and click “Fetch Content” to preview what will be saved.'}
-                                                </p>
-                                            )}
-                                        </div>
-                                    )}
-                                </CardContent>
-                            </Card>
-
-                            <div className="flex items-center justify-end space-x-4 rounded-lg border border-gray-200 bg-white p-6">
-                                <Link href={PostController.index().url}>
-                                    <Button
-                                        variant="outline"
-                                        className="border-gray-300 text-gray-700 transition-colors duration-200 hover:border-gray-400 hover:bg-gray-50"
-                                    >
-                                        {isZh ? '取消' : 'Cancel'}
-                                    </Button>
-                                </Link>
-                                <Button
-                                    type="submit"
-                                    disabled={processing}
-                                    className="bg-blue-600 text-white transition-colors duration-200 shadow-sm hover:bg-blue-700 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50"
-                                >
-                                    {processing ? (isZh ? '更新中...' : 'Updating...') : isZh ? '更新公告' : 'Update Post'}
-                                </Button>
-                            </div>
-                        </div>
-                    </form>
+                    <PostForm
+                        categories={categories}
+                        cancelUrl={PostController.index().url}
+                        mode="edit"
+                        initialValues={initialValues}
+                        initialPreviewHtml={initialPreviewHtml}
+                        statusOptions={statusOptions}
+                        onSubmit={handleSubmit}
+                    />
                 </div>
             </div>
         </AppLayout>

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -1,0 +1,330 @@
+import PostController from '@/actions/App/Http/Controllers/Admin/PostController';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import AppLayout from '@/layouts/app-layout';
+import type { SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
+import DOMPurify from 'dompurify';
+import { ArrowLeft, Calendar, Clock, Download, ExternalLink, LinkIcon, Paperclip, User } from 'lucide-react';
+
+interface Attachment {
+    id: number;
+    title?: string | null;
+    file_url?: string | null;
+    external_url?: string | null;
+    mime_type?: string | null;
+    file_size?: number | null;
+}
+
+interface PostCategory {
+    id: number;
+    name: string;
+    name_en: string;
+}
+
+interface Creator {
+    id: number;
+    name: string;
+    email?: string | null;
+}
+
+interface AdminPostDetail {
+    id: number;
+    title: string;
+    title_en: string;
+    status: 'draft' | 'published' | 'archived';
+    publish_at: string | null;
+    pinned: boolean;
+    category: PostCategory;
+    creator?: Creator | null;
+    content?: string | null;
+    content_en?: string | null;
+    source_type?: 'manual' | 'link';
+    source_url?: string | null;
+    fetched_html?: string | null;
+    attachments: Attachment[];
+    created_at?: string | null;
+    updated_at?: string | null;
+}
+
+interface ShowPostProps {
+    post: AdminPostDetail;
+}
+
+const statusLabels: Record<AdminPostDetail['status'], { zh: string; en: string }> = {
+    draft: { zh: '草稿', en: 'Draft' },
+    published: { zh: '已發布', en: 'Published' },
+    archived: { zh: '已封存', en: 'Archived' },
+};
+
+const formatDateTime = (value: string | null, locale: string) => {
+    if (!value) {
+        return locale === 'zh-TW' ? '未設定' : 'Not set';
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleString(locale === 'zh-TW' ? 'zh-TW' : 'en-US', {
+        hour12: false,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+};
+
+const formatFileSize = (bytes?: number | null) => {
+    if (!bytes || bytes <= 0) {
+        return '-';
+    }
+
+    const units = ['B', 'KB', 'MB', 'GB'];
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / Math.pow(1024, exponent);
+    return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};
+
+const buildAttachmentViewUrl = (attachment: Attachment) => `/attachments/${attachment.id}`;
+const buildAttachmentDownloadUrl = (attachment: Attachment) => `/attachments/${attachment.id}/download`;
+
+export default function ShowPost({ post }: ShowPostProps) {
+    const { locale } = usePage<SharedData>().props;
+    const isZh = locale === 'zh-TW';
+
+    const statusBadge = (
+        <Badge variant={post.status === 'published' ? 'default' : post.status === 'draft' ? 'secondary' : 'outline'}>
+            {isZh ? statusLabels[post.status].zh : statusLabels[post.status].en}
+        </Badge>
+    );
+
+    const sanitizedHtml = DOMPurify.sanitize(post.fetched_html ?? '');
+    const hasRemoteContent = post.source_type === 'link';
+
+    const hasZhContent = Boolean(post.content && post.content.trim().length > 0);
+    const hasEnContent = Boolean(post.content_en && post.content_en.trim().length > 0);
+
+    return (
+        <AppLayout>
+            <Head title={isZh ? '公告詳情' : 'Post Detail'} />
+
+            <div className="min-h-screen bg-gray-50">
+                <div className="mx-auto max-w-5xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
+                    <div className="flex items-center gap-4">
+                        <Link href={PostController.index().url}>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                            >
+                                <ArrowLeft className="h-4 w-4" />
+                            </Button>
+                        </Link>
+                        <div>
+                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                                {isZh ? post.title : post.title_en || post.title}
+                            </h1>
+                            <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-gray-600">
+                                <span className="inline-flex items-center gap-1">
+                                    <Calendar className="h-4 w-4" />
+                                    {isZh ? '發布時間' : 'Published at'}: {formatDateTime(post.publish_at, locale)}
+                                </span>
+                                <span className="inline-flex items-center gap-1">
+                                    <User className="h-4 w-4" />
+                                    {post.creator?.name ?? (isZh ? '系統' : 'System')}
+                                </span>
+                                <span>{statusBadge}</span>
+                                {post.pinned && (
+                                    <Badge variant="default" className="bg-amber-500 hover:bg-amber-600">
+                                        {isZh ? '置頂' : 'Pinned'}
+                                    </Badge>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    <Card className="border-gray-200 bg-white shadow-sm">
+                        <CardHeader className="border-b border-gray-100 bg-gray-50/50">
+                            <CardTitle className="flex items-center gap-2 text-gray-900">
+                                <Clock className="h-5 w-5 text-blue-600" />
+                                {isZh ? '基本資訊' : 'Basic Information'}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="grid gap-6 p-8 md:grid-cols-2">
+                            <div>
+                                <p className="text-sm font-medium text-gray-500">{isZh ? '分類' : 'Category'}</p>
+                                <p className="mt-1 text-base text-gray-900">
+                                    {isZh ? post.category?.name : post.category?.name_en}
+                                </p>
+                            </div>
+                            <div>
+                                <p className="text-sm font-medium text-gray-500">{isZh ? '英文標題' : 'English Title'}</p>
+                                <p className="mt-1 text-base text-gray-900">{post.title_en || '—'}</p>
+                            </div>
+                            <div>
+                                <p className="text-sm font-medium text-gray-500">{isZh ? '來源類型' : 'Source Type'}</p>
+                                <p className="mt-1 text-base text-gray-900">
+                                    {post.source_type === 'link'
+                                        ? isZh
+                                            ? '外部連結'
+                                            : 'Link'
+                                        : isZh
+                                            ? '手動輸入'
+                                            : 'Manual'}
+                                </p>
+                            </div>
+                            <div>
+                                <p className="text-sm font-medium text-gray-500">{isZh ? '來源網址' : 'Source URL'}</p>
+                                {post.source_url ? (
+                                    <a
+                                        href={post.source_url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="mt-1 inline-flex items-center gap-1 text-blue-600 hover:underline"
+                                    >
+                                        <LinkIcon className="h-4 w-4" />
+                                        {post.source_url}
+                                    </a>
+                                ) : (
+                                    <p className="mt-1 text-base text-gray-900">—</p>
+                                )}
+                            </div>
+                            <div>
+                                <p className="text-sm font-medium text-gray-500">{isZh ? '建立時間' : 'Created at'}</p>
+                                <p className="mt-1 text-base text-gray-900">
+                                    {formatDateTime(post.created_at ?? null, locale)}
+                                </p>
+                            </div>
+                            <div>
+                                <p className="text-sm font-medium text-gray-500">{isZh ? '最後更新' : 'Last Updated'}</p>
+                                <p className="mt-1 text-base text-gray-900">
+                                    {formatDateTime(post.updated_at ?? null, locale)}
+                                </p>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card className="border-gray-200 bg-white shadow-sm">
+                        <CardHeader className="border-b border-gray-100 bg-gray-50/50">
+                            <CardTitle className="flex items-center gap-2 text-gray-900">
+                                <ExternalLink className="h-5 w-5 text-blue-600" />
+                                {isZh ? '公告內容' : 'Post Content'}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-6 p-8">
+                            {hasRemoteContent ? (
+                                <div className="space-y-4">
+                                    {post.source_url && (
+                                        <a
+                                            href={post.source_url}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+                                        >
+                                            <LinkIcon className="h-4 w-4" />
+                                            {isZh ? '前往來源' : 'Open Source'}
+                                        </a>
+                                    )}
+                                    {sanitizedHtml ? (
+                                        <div
+                                            className="prose max-w-none rounded-lg border border-gray-200 bg-gray-50 p-4"
+                                            dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+                                        />
+                                    ) : (
+                                        <p className="text-sm text-gray-500">
+                                            {isZh ? '目前沒有可供預覽的遠端內容。' : 'No remote content available for preview.'}
+                                        </p>
+                                    )}
+                                </div>
+                            ) : (
+                                <div className="space-y-6">
+                                    <div>
+                                        <p className="text-sm font-medium text-gray-500">{isZh ? '中文內容' : 'Chinese Content'}</p>
+                                        {hasZhContent ? (
+                                            <div className="mt-2 whitespace-pre-line rounded-lg border border-gray-200 bg-gray-50 p-4 text-gray-800">
+                                                {post.content}
+                                            </div>
+                                        ) : (
+                                            <p className="mt-2 text-sm text-gray-500">
+                                                {isZh ? '尚未填寫中文內容。' : 'No Chinese content provided.'}
+                                            </p>
+                                        )}
+                                    </div>
+                                    <div>
+                                        <p className="text-sm font-medium text-gray-500">{isZh ? '英文內容' : 'English Content'}</p>
+                                        {hasEnContent ? (
+                                            <div className="mt-2 whitespace-pre-line rounded-lg border border-gray-200 bg-gray-50 p-4 text-gray-800">
+                                                {post.content_en}
+                                            </div>
+                                        ) : (
+                                            <p className="mt-2 text-sm text-gray-500">
+                                                {isZh ? '尚未填寫英文內容。' : 'No English content provided.'}
+                                            </p>
+                                        )}
+                                    </div>
+                                </div>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    <Card className="border-gray-200 bg-white shadow-sm">
+                        <CardHeader className="border-b border-gray-100 bg-gray-50/50">
+                            <CardTitle className="flex items-center gap-2 text-gray-900">
+                                <Paperclip className="h-5 w-5 text-blue-600" />
+                                {isZh ? '附件' : 'Attachments'}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4 p-8">
+                            {post.attachments && post.attachments.length > 0 ? (
+                                <div className="space-y-3">
+                                    {post.attachments.map((attachment) => (
+                                        <div
+                                            key={attachment.id}
+                                            className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 sm:flex-row sm:items-center sm:justify-between"
+                                        >
+                                            <div className="space-y-1">
+                                                <p className="text-sm font-medium text-gray-900">
+                                                    {attachment.title || `${isZh ? '附件' : 'Attachment'} #${attachment.id}`}
+                                                </p>
+                                                <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500">
+                                                    {attachment.mime_type && <Badge variant="outline">{attachment.mime_type}</Badge>}
+                                                    <span>{formatFileSize(attachment.file_size)}</span>
+                                                </div>
+                                            </div>
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <a
+                                                    href={buildAttachmentViewUrl(attachment)}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="inline-flex items-center gap-2 rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 transition hover:border-gray-400 hover:bg-white"
+                                                >
+                                                    <ExternalLink className="h-4 w-4" />
+                                                    {isZh ? '檢視' : 'View'}
+                                                </a>
+                                                <a
+                                                    href={buildAttachmentDownloadUrl(attachment)}
+                                                    className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-3 py-1 text-sm text-white transition hover:bg-blue-700"
+                                                >
+                                                    <Download className="h-4 w-4" />
+                                                    {isZh ? '下載' : 'Download'}
+                                                </a>
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-sm text-gray-500">
+                                    {isZh ? '此公告目前沒有附件。' : 'No attachments have been uploaded for this post.'}
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}


### PR DESCRIPTION
## Summary
- add a shared admin post form component for create/edit flows with remote link fetch support
- reuse the form in create and edit pages with proper initialization and submission handlers
- add an admin post detail page that shows metadata, content, and downloadable attachments

## Testing
- npm run build *(fails: php artisan wayfinder:generate requires vendor/autoload.php which is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca169bf03c832392aa0f885e966c08