### PR TITLE
調整後台佈局白底並統一頁面背景

### DIFF
--- a/resources/js/components/app-content.tsx
+++ b/resources/js/components/app-content.tsx
@@ -1,17 +1,22 @@
 import { SidebarInset } from '@/components/ui/sidebar';
+import { cn } from '@/lib/utils';
 import * as React from 'react';
 
 interface AppContentProps extends React.ComponentProps<'main'> {
     variant?: 'header' | 'sidebar';
 }
 
-export function AppContent({ variant = 'header', children, ...props }: AppContentProps) {
+export function AppContent({ variant = 'header', children, className, ...props }: AppContentProps) {
     if (variant === 'sidebar') {
-        return <SidebarInset {...props}>{children}</SidebarInset>;
+        return (
+            <SidebarInset className={cn('bg-neutral-100 text-gray-900', className)} {...props}>
+                {children}
+            </SidebarInset>
+        );
     }
 
     return (
-        <main className="mx-auto flex h-full w-full max-w-7xl flex-1 flex-col gap-4 rounded-xl" {...props}>
+        <main className={cn('mx-auto flex h-full w-full max-w-7xl flex-1 flex-col gap-4 rounded-xl', className)} {...props}>
             {children}
         </main>
     );

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -2,7 +2,6 @@ import { AppContent } from '@/components/app-content';
 import { AppShell } from '@/components/app-shell';
 import { AppSidebar } from '@/components/app-sidebar';
 import { AppSidebarHeader } from '@/components/app-sidebar-header';
-import { GlassPanel, GlassSurface } from '@/components/glass';
 import { type BreadcrumbItem } from '@/types';
 import AdminFooter from '@/components/admin-footer';
 import { type PropsWithChildren } from 'react';
@@ -11,39 +10,19 @@ export default function AppSidebarLayout({ children, breadcrumbs = [] }: PropsWi
     return (
         <AppShell variant="sidebar">
             <AppSidebar />
-            <AppContent
-                variant="sidebar"
-                className="relative overflow-x-hidden bg-[var(--surface-base)]/80 text-black transition-colors duration-300"
-            >
-                <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-                    <div className="absolute -top-32 right-0 h-72 w-72 rounded-full bg-primary/15 blur-3xl" aria-hidden />
-                    <div className="absolute left-[-20%] top-1/3 h-80 w-80 rotate-12 rounded-full bg-[#4dd5c8]/10 blur-[140px]" aria-hidden />
-                    <div className="absolute -bottom-24 right-24 h-72 w-72 rounded-full bg-[#fca311]/12 blur-[120px]" aria-hidden />
-                </div>
-
+            <AppContent variant="sidebar" className="relative overflow-x-hidden bg-neutral-100 text-black">
                 <div className="relative flex min-h-svh flex-col gap-6 pb-10">
                     <AppSidebarHeader breadcrumbs={breadcrumbs} />
 
-                    <GlassSurface
-                        as="section"
-                        shimmer
-                        spotlight
-                        bleedShadow
-                        className="mx-6 flex flex-1 flex-col gap-8 border border-white/10 px-0 py-0 md:mx-8"
-                    >
+                    <section className="mx-6 flex flex-1 flex-col gap-8 rounded-xl bg-white px-0 py-0 shadow-sm md:mx-8">
                         <div className="flex flex-1 flex-col gap-8 px-6 py-6 md:px-8">
                             {children}
                         </div>
-                    </GlassSurface>
+                    </section>
 
-                    <GlassPanel
-                        as="footer"
-                        shimmer
-                        interactive={false}
-                        className="mx-6 flex items-center justify-center gap-3 border border-white/15 px-6 py-4 text-xs text-neutral-600 md:mx-8"
-                    >
+                    <footer className="mx-6 flex items-center justify-center gap-3 rounded-xl bg-white px-6 py-4 text-xs text-neutral-600 shadow-sm md:mx-8">
                         <AdminFooter />
-                    </GlassPanel>
+                    </footer>
                 </div>
             </AppContent>
         </AppShell>

--- a/resources/js/pages/admin/posts/create.tsx
+++ b/resources/js/pages/admin/posts/create.tsx
@@ -53,37 +53,35 @@ export default function CreatePost({ categories }: CreatePostProps) {
         <AppLayout>
             <Head title={isZh ? '建立公告' : 'Create Post'} />
 
-            <div className="min-h-screen bg-gray-50">
-                <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex items-center gap-4">
-                        <Link href={PostController.index().url}>
-                            <Button
-                                variant="ghost"
-                                size="sm"
-                                className="text-gray-600 hover:bg-gray-100 hover:text-gray-900"
-                            >
-                                <ArrowLeft className="h-4 w-4" />
-                            </Button>
-                        </Link>
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                                {isZh ? '建立公告' : 'Create Post'}
-                            </h1>
-                            <p className="mt-2 text-gray-600">
-                                {isZh ? '建立新的公告或新聞' : 'Create a new announcement or news post'}
-                            </p>
-                        </div>
+            <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
+                <div className="flex items-center gap-4">
+                    <Link href={PostController.index().url}>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                        </Button>
+                    </Link>
+                    <div>
+                        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                            {isZh ? '建立公告' : 'Create Post'}
+                        </h1>
+                        <p className="mt-2 text-gray-600">
+                            {isZh ? '建立新的公告或新聞' : 'Create a new announcement or news post'}
+                        </p>
                     </div>
-
-                    <PostForm
-                        categories={categories}
-                        cancelUrl={PostController.index().url}
-                        mode="create"
-                        initialValues={initialValues}
-                        statusOptions={statusOptions}
-                        onSubmit={handleSubmit}
-                    />
                 </div>
+
+                <PostForm
+                    categories={categories}
+                    cancelUrl={PostController.index().url}
+                    mode="create"
+                    initialValues={initialValues}
+                    statusOptions={statusOptions}
+                    onSubmit={handleSubmit}
+                />
             </div>
         </AppLayout>
     );

--- a/resources/js/pages/admin/posts/edit.tsx
+++ b/resources/js/pages/admin/posts/edit.tsx
@@ -86,39 +86,37 @@ export default function EditPost({ post, categories }: EditPostProps) {
         <AppLayout>
             <Head title={isZh ? '編輯公告' : 'Edit Post'} />
 
-            <div className="min-h-screen bg-gray-50">
-                <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex items-center gap-4">
-                        <Link href={PostController.index().url}>
-                            <Button
-                                variant="ghost"
-                                size="sm"
-                                className="text-gray-600 hover:bg-gray-100 hover:text-gray-900"
-                            >
-                                <ArrowLeft className="h-4 w-4" />
-                            </Button>
-                        </Link>
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                                {isZh ? '編輯公告' : 'Edit Post'}
-                            </h1>
-                            <p className="mt-2 text-gray-600">
-                                {isZh ? '調整公告內容與顯示設定' : 'Update the announcement details.'}
-                            </p>
-                        </div>
+            <div className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
+                <div className="flex items-center gap-4">
+                    <Link href={PostController.index().url}>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                        </Button>
+                    </Link>
+                    <div>
+                        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                            {isZh ? '編輯公告' : 'Edit Post'}
+                        </h1>
+                        <p className="mt-2 text-gray-600">
+                            {isZh ? '調整公告內容與顯示設定' : 'Update the announcement details.'}
+                        </p>
                     </div>
-
-                    <PostForm
-                        categories={categories}
-                        cancelUrl={PostController.index().url}
-                        mode="edit"
-                        initialValues={initialValues}
-                        initialPreviewHtml={initialPreviewHtml}
-                        statusOptions={statusOptions}
-                        existingAttachments={post.attachments ?? []}
-                        onSubmit={handleSubmit}
-                    />
                 </div>
+
+                <PostForm
+                    categories={categories}
+                    cancelUrl={PostController.index().url}
+                    mode="edit"
+                    initialValues={initialValues}
+                    initialPreviewHtml={initialPreviewHtml}
+                    statusOptions={statusOptions}
+                    existingAttachments={post.attachments ?? []}
+                    onSubmit={handleSubmit}
+                />
             </div>
         </AppLayout>
     );

--- a/resources/js/pages/admin/posts/show.tsx
+++ b/resources/js/pages/admin/posts/show.tsx
@@ -111,209 +111,207 @@ export default function ShowPost({ post }: ShowPostProps) {
         <AppLayout>
             <Head title={isZh ? '公告詳情' : 'Post Detail'} />
 
-            <div className="min-h-screen bg-gray-50">
-                <div className="mx-auto max-w-5xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex items-center gap-4">
-                        <Link href={PostController.index().url}>
-                            <Button
-                                variant="ghost"
-                                size="sm"
-                                className="text-gray-600 hover:bg-gray-100 hover:text-gray-900"
-                            >
-                                <ArrowLeft className="h-4 w-4" />
-                            </Button>
-                        </Link>
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                                {isZh ? post.title : post.title_en || post.title}
-                            </h1>
-                            <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-gray-600">
-                                <span className="inline-flex items-center gap-1">
-                                    <Calendar className="h-4 w-4" />
-                                    {isZh ? '發布時間' : 'Published at'}: {formatDateTime(String(post.publish_at ?? ''), locale)}
-                                </span>
-                                <span className="inline-flex items-center gap-1">
-                                    <User className="h-4 w-4" />
-                                    {post.creator?.name ?? (isZh ? '系統' : 'System')}
-                                </span>
-                                <span>{statusBadge}</span>
-                                {post.pinned && (
-                                    <Badge variant="default" className="bg-amber-500 hover:bg-amber-600">
-                                        {isZh ? '置頂' : 'Pinned'}
-                                    </Badge>
-                                )}
-                            </div>
+            <div className="mx-auto max-w-5xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
+                <div className="flex items-center gap-4">
+                    <Link href={PostController.index().url}>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                        </Button>
+                    </Link>
+                    <div>
+                        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                            {isZh ? post.title : post.title_en || post.title}
+                        </h1>
+                        <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-gray-600">
+                            <span className="inline-flex items-center gap-1">
+                                <Calendar className="h-4 w-4" />
+                                {isZh ? '發布時間' : 'Published at'}: {formatDateTime(String(post.publish_at ?? ''), locale)}
+                            </span>
+                            <span className="inline-flex items-center gap-1">
+                                <User className="h-4 w-4" />
+                                {post.creator?.name ?? (isZh ? '系統' : 'System')}
+                            </span>
+                            <span>{statusBadge}</span>
+                            {post.pinned && (
+                                <Badge variant="default" className="bg-amber-500 hover:bg-amber-600">
+                                    {isZh ? '置頂' : 'Pinned'}
+                                </Badge>
+                            )}
                         </div>
                     </div>
+                </div>
 
-                    <Card className="border-gray-200 bg-white shadow-sm">
-                        <CardHeader className="border-b border-gray-100 bg-gray-50/50">
-                            <CardTitle className="flex items-center gap-2 text-gray-900">
-                                <Clock className="h-5 w-5 text-blue-600" />
-                                {isZh ? '基本資訊' : 'Basic Information'}
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="grid gap-6 p-8 md:grid-cols-2">
-                            <div>
-                                <p className="text-sm font-medium text-gray-500">{isZh ? '分類' : 'Category'}</p>
-                                <p className="mt-1 text-base text-gray-900">
-                                    {isZh ? post.category?.name : post.category?.name_en}
-                                </p>
-                            </div>
-                            <div>
-                                <p className="text-sm font-medium text-gray-500">{isZh ? '英文標題' : 'English Title'}</p>
-                                <p className="mt-1 text-base text-gray-900">{post.title_en || '—'}</p>
-                            </div>
-                            <div>
-                                <p className="text-sm font-medium text-gray-500">{isZh ? '來源類型' : 'Source Type'}</p>
-                                <p className="mt-1 text-base text-gray-900">
-                                    {post.source_type === 'link'
-                                        ? isZh
-                                            ? '外部連結'
-                                            : 'Link'
-                                        : isZh
-                                            ? '手動輸入'
-                                            : 'Manual'}
-                                </p>
-                            </div>
-                            <div>
-                                <p className="text-sm font-medium text-gray-500">{isZh ? '來源網址' : 'Source URL'}</p>
-                                {post.source_url ? (
+                <Card className="border-gray-200 bg-white shadow-sm">
+                    <CardHeader className="border-b border-gray-100 bg-gray-50/50">
+                        <CardTitle className="flex items-center gap-2 text-gray-900">
+                            <Clock className="h-5 w-5 text-blue-600" />
+                            {isZh ? '基本資訊' : 'Basic Information'}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="grid gap-6 p-8 md:grid-cols-2">
+                        <div>
+                            <p className="text-sm font-medium text-gray-500">{isZh ? '分類' : 'Category'}</p>
+                            <p className="mt-1 text-base text-gray-900">
+                                {isZh ? post.category?.name : post.category?.name_en}
+                            </p>
+                        </div>
+                        <div>
+                            <p className="text-sm font-medium text-gray-500">{isZh ? '英文標題' : 'English Title'}</p>
+                            <p className="mt-1 text-base text-gray-900">{post.title_en || '—'}</p>
+                        </div>
+                        <div>
+                            <p className="text-sm font-medium text-gray-500">{isZh ? '來源類型' : 'Source Type'}</p>
+                            <p className="mt-1 text-base text-gray-900">
+                                {post.source_type === 'link'
+                                    ? isZh
+                                        ? '外部連結'
+                                        : 'Link'
+                                    : isZh
+                                        ? '手動輸入'
+                                        : 'Manual'}
+                            </p>
+                        </div>
+                        <div>
+                            <p className="text-sm font-medium text-gray-500">{isZh ? '來源網址' : 'Source URL'}</p>
+                            {post.source_url ? (
+                                <a
+                                    href={post.source_url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="mt-1 inline-flex items-center gap-1 text-blue-600 hover:underline"
+                                >
+                                    <LinkIcon className="h-4 w-4" />
+                                    {post.source_url}
+                                </a>
+                            ) : (
+                                <p className="mt-1 text-base text-gray-900">—</p>
+                            )}
+                        </div>
+                        <div>
+                            <p className="text-sm font-medium text-gray-500">{isZh ? '建立時間' : 'Created at'}</p>
+                            <p className="mt-1 text-base text-gray-900">
+                                {formatDateTime(String(post.created_at ?? ''), locale)}
+                            </p>
+                        </div>
+                        <div>
+                            <p className="text-sm font-medium text-gray-500">{isZh ? '最後更新' : 'Last Updated'}</p>
+                            <p className="mt-1 text-base text-gray-900">
+                                {formatDateTime(String(post.updated_at ?? ''), locale)}
+                            </p>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card className="border-gray-200 bg-white shadow-sm">
+                    <CardHeader className="border-b border-gray-100 bg-gray-50/50">
+                        <CardTitle className="flex items-center gap-2 text-gray-900">
+                            <ExternalLink className="h-5 w-5 text-blue-600" />
+                            {isZh ? '公告內容' : 'Post Content'}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-6 p-8">
+                        {hasRemoteContent ? (
+                            <div className="space-y-4">
+                                {post.source_url && (
                                     <a
                                         href={post.source_url}
                                         target="_blank"
                                         rel="noopener noreferrer"
-                                        className="mt-1 inline-flex items-center gap-1 text-blue-600 hover:underline"
+                                        className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
                                     >
                                         <LinkIcon className="h-4 w-4" />
-                                        {post.source_url}
+                                        {isZh ? '前往來源' : 'Open Source'}
                                     </a>
-                                ) : (
-                                    <p className="mt-1 text-base text-gray-900">—</p>
                                 )}
+                                <p className="text-sm text-gray-500">{isZh ? '系統不再儲存外部 HTML，請按「前往來源」查看原始內容。' : 'External HTML is no longer stored. Click "Open Source" to view the original.'}</p>
                             </div>
-                            <div>
-                                <p className="text-sm font-medium text-gray-500">{isZh ? '建立時間' : 'Created at'}</p>
-                                <p className="mt-1 text-base text-gray-900">
-                                    {formatDateTime(String(post.created_at ?? ''), locale)}
-                                </p>
-                            </div>
-                            <div>
-                                <p className="text-sm font-medium text-gray-500">{isZh ? '最後更新' : 'Last Updated'}</p>
-                                <p className="mt-1 text-base text-gray-900">
-                                    {formatDateTime(String(post.updated_at ?? ''), locale)}
-                                </p>
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    <Card className="border-gray-200 bg-white shadow-sm">
-                        <CardHeader className="border-b border-gray-100 bg-gray-50/50">
-                            <CardTitle className="flex items-center gap-2 text-gray-900">
-                                <ExternalLink className="h-5 w-5 text-blue-600" />
-                                {isZh ? '公告內容' : 'Post Content'}
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-6 p-8">
-                            {hasRemoteContent ? (
-                                <div className="space-y-4">
-                                    {post.source_url && (
-                                        <a
-                                            href={post.source_url}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
-                                        >
-                                            <LinkIcon className="h-4 w-4" />
-                                            {isZh ? '前往來源' : 'Open Source'}
-                                        </a>
+                        ) : (
+                            <div className="space-y-6">
+                                <div>
+                                    <p className="text-sm font-medium text-gray-500">{isZh ? '中文內容' : 'Chinese Content'}</p>
+                                    {hasZhContent ? (
+                                        <div className="mt-2 whitespace-pre-line rounded-lg border border-gray-200 bg-gray-50 p-4 text-gray-800">
+                                            {post.content}
+                                        </div>
+                                    ) : (
+                                        <p className="mt-2 text-sm text-gray-500">
+                                            {isZh ? '尚未填寫中文內容。' : 'No Chinese content provided.'}
+                                        </p>
                                     )}
-                                    <p className="text-sm text-gray-500">{isZh ? '系統不再儲存外部 HTML，請按「前往來源」查看原始內容。' : 'External HTML is no longer stored. Click "Open Source" to view the original.'}</p>
                                 </div>
-                            ) : (
-                                <div className="space-y-6">
-                                    <div>
-                                        <p className="text-sm font-medium text-gray-500">{isZh ? '中文內容' : 'Chinese Content'}</p>
-                                        {hasZhContent ? (
-                                            <div className="mt-2 whitespace-pre-line rounded-lg border border-gray-200 bg-gray-50 p-4 text-gray-800">
-                                                {post.content}
-                                            </div>
-                                        ) : (
-                                            <p className="mt-2 text-sm text-gray-500">
-                                                {isZh ? '尚未填寫中文內容。' : 'No Chinese content provided.'}
-                                            </p>
-                                        )}
-                                    </div>
-                                    <div>
-                                        <p className="text-sm font-medium text-gray-500">{isZh ? '英文內容' : 'English Content'}</p>
-                                        {hasEnContent ? (
-                                            <div className="mt-2 whitespace-pre-line rounded-lg border border-gray-200 bg-gray-50 p-4 text-gray-800">
-                                                {post.content_en}
-                                            </div>
-                                        ) : (
-                                            <p className="mt-2 text-sm text-gray-500">
-                                                {isZh ? '尚未填寫英文內容。' : 'No English content provided.'}
-                                            </p>
-                                        )}
-                                    </div>
+                                <div>
+                                    <p className="text-sm font-medium text-gray-500">{isZh ? '英文內容' : 'English Content'}</p>
+                                    {hasEnContent ? (
+                                        <div className="mt-2 whitespace-pre-line rounded-lg border border-gray-200 bg-gray-50 p-4 text-gray-800">
+                                            {post.content_en}
+                                        </div>
+                                    ) : (
+                                        <p className="mt-2 text-sm text-gray-500">
+                                            {isZh ? '尚未填寫英文內容。' : 'No English content provided.'}
+                                        </p>
+                                    )}
                                 </div>
-                            )}
-                        </CardContent>
-                    </Card>
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
 
-                    <Card className="border-gray-200 bg-white shadow-sm">
-                        <CardHeader className="border-b border-gray-100 bg-gray-50/50">
-                            <CardTitle className="flex items-center gap-2 text-gray-900">
-                                <Paperclip className="h-5 w-5 text-blue-600" />
-                                {isZh ? '附件' : 'Attachments'}
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-4 p-8">
-                            {post.attachments && post.attachments.length > 0 ? (
-                                <div className="space-y-3">
-                                    {post.attachments.map((attachment) => (
-                                        <div
-                                            key={attachment.id}
-                                            className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 sm:flex-row sm:items-center sm:justify-between"
-                                        >
-                                            <div className="space-y-1">
-                                                <p className="text-sm font-medium text-gray-900">
-                                                    {attachment.title || `${isZh ? '附件' : 'Attachment'} #${attachment.id}`}
-                                                </p>
-                                                <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500">
-                                                    {attachment.mime_type && <Badge variant="outline">{attachment.mime_type}</Badge>}
-                                                    <span>{formatFileSize(attachment.file_size)}</span>
-                                                </div>
-                                            </div>
-                                            <div className="flex flex-wrap items-center gap-2">
-                                                <a
-                                                    href={buildAttachmentViewUrl(attachment)}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    className="inline-flex items-center gap-2 rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 transition hover:border-gray-400 hover:bg-white"
-                                                >
-                                                    <ExternalLink className="h-4 w-4" />
-                                                    {isZh ? '檢視' : 'View'}
-                                                </a>
-                                                <a
-                                                    href={buildAttachmentDownloadUrl(attachment)}
-                                                    className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-3 py-1 text-sm text-white transition hover:bg-blue-700"
-                                                >
-                                                    <Download className="h-4 w-4" />
-                                                    {isZh ? '下載' : 'Download'}
-                                                </a>
+                <Card className="border-gray-200 bg-white shadow-sm">
+                    <CardHeader className="border-b border-gray-100 bg-gray-50/50">
+                        <CardTitle className="flex items-center gap-2 text-gray-900">
+                            <Paperclip className="h-5 w-5 text-blue-600" />
+                            {isZh ? '附件' : 'Attachments'}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-4 p-8">
+                        {post.attachments && post.attachments.length > 0 ? (
+                            <div className="space-y-3">
+                                {post.attachments.map((attachment) => (
+                                    <div
+                                        key={attachment.id}
+                                        className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 sm:flex-row sm:items-center sm:justify-between"
+                                    >
+                                        <div className="space-y-1">
+                                            <p className="text-sm font-medium text-gray-900">
+                                                {attachment.title || `${isZh ? '附件' : 'Attachment'} #${attachment.id}`}
+                                            </p>
+                                            <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500">
+                                                {attachment.mime_type && <Badge variant="outline">{attachment.mime_type}</Badge>}
+                                                <span>{formatFileSize(attachment.file_size)}</span>
                                             </div>
                                         </div>
-                                    ))}
-                                </div>
-                            ) : (
-                                <p className="text-sm text-gray-500">
-                                    {isZh ? '此公告目前沒有附件。' : 'No attachments have been uploaded for this post.'}
-                                </p>
-                            )}
-                        </CardContent>
-                    </Card>
-                </div>
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <a
+                                                href={buildAttachmentViewUrl(attachment)}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="inline-flex items-center gap-2 rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 transition hover:border-gray-400 hover:bg-white"
+                                            >
+                                                <ExternalLink className="h-4 w-4" />
+                                                {isZh ? '檢視' : 'View'}
+                                            </a>
+                                            <a
+                                                href={buildAttachmentDownloadUrl(attachment)}
+                                                className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-3 py-1 text-sm text-white transition hover:bg-blue-700"
+                                            >
+                                                <Download className="h-4 w-4" />
+                                                {isZh ? '下載' : 'Download'}
+                                            </a>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <p className="text-sm text-gray-500">
+                                {isZh ? '此公告目前沒有附件。' : 'No attachments have been uploaded for this post.'}
+                            </p>
+                        )}
+                    </CardContent>
+                </Card>
             </div>
         </AppLayout>
     );

--- a/resources/js/pages/admin/teachers/create.tsx
+++ b/resources/js/pages/admin/teachers/create.tsx
@@ -23,30 +23,28 @@ export default function CreateTeacher({ users }: CreateTeacherProps) {
         <AppLayout>
             <Head title="新增教師" />
 
-            <div className="min-h-screen bg-gray-50">
-                <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-                    {/* 頁首 */}
-                    <div className="mb-6">
-                        <Link
-                            href={TeacherController.index().url}
-                            className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
-                        >
-                            <ChevronLeft className="mr-1 h-4 w-4" />
-                            返回師資列表
-                        </Link>
-                        <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-900">
-                            新增教師
-                        </h1>
-                        <p className="mt-1 text-gray-600">
-                            建立新的教師資料和個人資訊
-                        </p>
-                    </div>
+            <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+                {/* 頁首 */}
+                <div className="mb-6">
+                    <Link
+                        href={TeacherController.index().url}
+                        className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+                    >
+                        <ChevronLeft className="mr-1 h-4 w-4" />
+                        返回師資列表
+                    </Link>
+                    <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-900">
+                        新增教師
+                    </h1>
+                    <p className="mt-1 text-gray-600">
+                        建立新的教師資料和個人資訊
+                    </p>
+                </div>
 
-                    {/* 表單 */}
-                    <div className="rounded-lg bg-white shadow">
-                        <div className="p-6">
-                            <TeacherForm users={users} onSubmit={handleSubmit} />
-                        </div>
+                {/* 表單 */}
+                <div className="rounded-lg bg-white shadow">
+                    <div className="p-6">
+                        <TeacherForm users={users} onSubmit={handleSubmit} />
                     </div>
                 </div>
             </div>

--- a/resources/js/pages/admin/teachers/edit.tsx
+++ b/resources/js/pages/admin/teachers/edit.tsx
@@ -54,30 +54,28 @@ export default function EditTeacher({ teacher, users }: EditTeacherProps) {
         <AppLayout>
             <Head title={`編輯教師 - ${teacher.name}`} />
 
-            <div className="min-h-screen bg-gray-50">
-                <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-                    {/* 頁首 */}
-                    <div className="mb-6">
-                        <Link
-                            href={TeacherController.index().url}
-                            className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
-                        >
-                            <ChevronLeft className="mr-1 h-4 w-4" />
-                            返回師資列表
-                        </Link>
-                        <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-900">
-                            編輯教師 - {teacher.name}
-                        </h1>
-                        <p className="mt-1 text-gray-600">
-                            修改教師資料和個人資訊
-                        </p>
-                    </div>
+            <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+                {/* 頁首 */}
+                <div className="mb-6">
+                    <Link
+                        href={TeacherController.index().url}
+                        className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+                    >
+                        <ChevronLeft className="mr-1 h-4 w-4" />
+                        返回師資列表
+                    </Link>
+                    <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-900">
+                        編輯教師 - {teacher.name}
+                    </h1>
+                    <p className="mt-1 text-gray-600">
+                        修改教師資料和個人資訊
+                    </p>
+                </div>
 
-                    {/* 表單 */}
-                    <div className="rounded-lg bg-white shadow">
-                        <div className="p-6">
-                            <TeacherForm teacher={teacher} users={users} onSubmit={handleSubmit} />
-                        </div>
+                {/* 表單 */}
+                <div className="rounded-lg bg-white shadow">
+                    <div className="p-6">
+                        <TeacherForm teacher={teacher} users={users} onSubmit={handleSubmit} />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- 移除舊有玻璃質感與彩色光暈，改用白底陰影呈現側欄版面與頁尾
- 更新 AppContent 使側欄模式維持實心底色，避免透明動畫
- 調整公告與師資主要頁面，改由佈局統一控制背景色

## Testing
- 未執行測試（非必要）

------
https://chatgpt.com/codex/tasks/task_e_68ccbb7ab1b48323829dd302f6de60be