### PR TITLE
feat: unify admin faculty and staff management view

### DIFF
--- a/app/Http/Controllers/Admin/TeacherController.php
+++ b/app/Http/Controllers/Admin/TeacherController.php
@@ -13,16 +13,13 @@ class TeacherController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request)
     {
-        $teachers = Teacher::with(['user', 'labs'])
-            ->orderBy('sort_order')
-            ->orderBy('name')
-            ->paginate(20);
-
-        return Inertia::render('admin/teachers/index', [
-            'teachers' => $teachers,
-        ]);
+        // 導向新的統一列表頁，維持查詢參數（例如分頁或語系）
+        return redirect()->route('admin.staff.index', array_merge(
+            $request->query(),
+            ['tab' => 'teachers']
+        ));
     }
 
     /**

--- a/resources/js/components/admin/staff-list.tsx
+++ b/resources/js/components/admin/staff-list.tsx
@@ -1,0 +1,242 @@
+import StaffController from '@/actions/App/Http/Controllers/Admin/StaffController';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { type SharedData } from '@/types';
+import { Link, useForm, usePage } from '@inertiajs/react';
+import { ArrowRightLeft, BadgeInfo, Mail, Phone, RotateCcw, Trash2, Users } from 'lucide-react';
+
+export interface StaffListItem {
+    id: number;
+    name: string;
+    name_en?: string | null;
+    position?: string | null;
+    position_en?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    photo_url?: string | null;
+    bio?: string | null;
+    bio_en?: string | null;
+    sort_order?: number | null;
+    visible?: boolean;
+    deleted_at?: string | null;
+}
+
+export interface StaffListProps {
+    staff: StaffListItem[];
+    trashed?: StaffListItem[];
+}
+
+export default function StaffList({ staff, trashed = [] }: StaffListProps) {
+    const { auth, locale } = usePage<SharedData>().props;
+    const isZh = locale === 'zh-TW';
+    const { delete: destroy, patch } = useForm();
+
+    const formatPosition = (member: StaffListItem) => {
+        const primary = member.position ?? null;
+        const secondary = member.position_en ?? null;
+        if (isZh) {
+            return primary ?? secondary ?? null;
+        }
+        return secondary ?? primary ?? null;
+    };
+
+    const formatDeletedAt = (value?: string | null) => {
+        if (!value) return '';
+        return new Date(value).toLocaleString(isZh ? 'zh-TW' : 'en-US');
+    };
+
+    const handleDelete = (member: StaffListItem) => {
+        if (
+            confirm(
+                isZh
+                    ? `確定要將「${member.name}」移至刪除名單嗎？`
+                    : `Move "${member.name}" to trash?`
+            )
+        ) {
+            destroy(StaffController.destroy(member.id).url, {
+                preserveScroll: true,
+                preserveState: true,
+            });
+        }
+    };
+
+    const handleRestore = (member: StaffListItem) => {
+        patch(StaffController.restore(member.id).url, {
+            preserveScroll: true,
+            preserveState: true,
+        });
+    };
+
+    const handleForceDelete = (member: StaffListItem) => {
+        if (
+            confirm(
+                isZh
+                    ? `確定要永久刪除「${member.name}」？此動作無法復原。`
+                    : `Permanently remove "${member.name}"? This cannot be undone.`
+            )
+        ) {
+            destroy(StaffController.forceDelete(member.id).url, {
+                preserveScroll: true,
+                preserveState: true,
+            });
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <Card className="bg-white shadow-sm">
+                <CardHeader className="border-b border-gray-200">
+                    <CardTitle className="flex items-center gap-2 text-gray-900">
+                        <Users className="h-5 w-5 text-blue-600" />
+                        {isZh ? '職員列表' : 'Staff List'}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent className="p-6">
+                    {staff.length === 0 ? (
+                        <div className="py-12 text-center">
+                            <Users className="mx-auto h-12 w-12 text-gray-300" />
+                            <h3 className="mt-2 text-sm font-semibold text-gray-900">
+                                {isZh ? '尚無職員資料' : 'No staff yet'}
+                            </h3>
+                            <p className="mt-1 text-sm text-gray-500">
+                                {isZh ? '新增職員以建立名單' : 'Add your first staff member to populate this list'}
+                            </p>
+                        </div>
+                    ) : (
+                        <ul className="divide-y divide-gray-200">
+                            {staff.map((member) => {
+                                const positionLabel = formatPosition(member);
+                                return (
+                                    <li
+                                        key={member.id}
+                                        className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between"
+                                    >
+                                        <div className="space-y-1">
+                                            <p className="text-base font-semibold text-gray-900">
+                                                {member.name}
+                                                {member.name_en && (
+                                                    <span className="ml-2 text-sm font-normal text-gray-500">
+                                                        ({member.name_en})
+                                                    </span>
+                                                )}
+                                            </p>
+                                            <div className="flex flex-wrap items-center gap-3 text-sm text-gray-500">
+                                                {positionLabel && <span>{positionLabel}</span>}
+                                                {member.email && (
+                                                    <a
+                                                        href={`mailto:${member.email}`}
+                                                        className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+                                                    >
+                                                        <Mail className="h-4 w-4" />
+                                                        {member.email}
+                                                    </a>
+                                                )}
+                                                {member.phone && (
+                                                    <span className="inline-flex items-center gap-1">
+                                                        <Phone className="h-4 w-4 text-gray-400" />
+                                                        {member.phone}
+                                                    </span>
+                                                )}
+                                                {!positionLabel && !member.email && !member.phone && (
+                                                    <span className="inline-flex items-center gap-1 text-gray-400">
+                                                        <BadgeInfo className="h-4 w-4" />
+                                                        {isZh ? '尚未提供詳細資訊' : 'No additional details provided'}
+                                                    </span>
+                                                )}
+                                            </div>
+                                        </div>
+
+                                        {auth.user.role === 'admin' && (
+                                            <div className="flex items-center gap-2 sm:ml-4">
+                                                <Link href={StaffController.edit(member.id).url}>
+                                                    <Button variant="outline" size="sm">
+                                                        {isZh ? '編輯' : 'Edit'}
+                                                    </Button>
+                                                </Link>
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    className="text-red-600 hover:text-red-800"
+                                                    onClick={() => handleDelete(member)}
+                                                >
+                                                    <Trash2 className="mr-1 h-4 w-4" />
+                                                    {isZh ? '刪除' : 'Remove'}
+                                                </Button>
+                                            </div>
+                                        )}
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    )}
+                </CardContent>
+            </Card>
+
+            <Card className="bg-white shadow-sm">
+                <CardHeader className="border-b border-gray-200">
+                    <CardTitle className="flex items-center gap-2 text-gray-900">
+                        <Trash2 className="h-5 w-5 text-red-600" />
+                        {isZh ? '刪除名單' : 'Trash Bin'}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent className="p-6">
+                    {trashed.length === 0 ? (
+                        <p className="text-sm text-gray-500">
+                            {isZh
+                                ? '目前沒有待復原或永久刪除的職員資料。'
+                                : 'There are no archived staff members awaiting review.'}
+                        </p>
+                    ) : (
+                        <ul className="divide-y divide-gray-200">
+                            {trashed.map((member) => (
+                                <li
+                                    key={member.id}
+                                    className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between"
+                                >
+                                    <div className="space-y-1">
+                                        <p className="text-base font-semibold text-gray-900">
+                                            {member.name}
+                                            {member.name_en && (
+                                                <span className="ml-2 text-sm font-normal text-gray-500">
+                                                    ({member.name_en})
+                                                </span>
+                                            )}
+                                        </p>
+                                        <div className="flex flex-wrap items-center gap-3 text-sm text-gray-500">
+                                            <span className="inline-flex items-center gap-1">
+                                                <ArrowRightLeft className="h-4 w-4 text-gray-400" />
+                                                {isZh ? '刪除於：' : 'Deleted at: '} {formatDeletedAt(member.deleted_at)}
+                                            </span>
+                                            {member.position && <span>{formatPosition(member)}</span>}
+                                        </div>
+                                    </div>
+
+                                    <div className="flex items-center gap-2 sm:ml-4">
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="text-blue-600 hover:text-blue-800"
+                                            onClick={() => handleRestore(member)}
+                                        >
+                                            <RotateCcw className="mr-1 h-4 w-4" />
+                                            {isZh ? '復原' : 'Restore'}
+                                        </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="text-red-600 hover:text-red-800"
+                                            onClick={() => handleForceDelete(member)}
+                                        >
+                                            <Trash2 className="mr-1 h-4 w-4" />
+                                            {isZh ? '永久刪除' : 'Delete permanently'}
+                                        </Button>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/resources/js/components/admin/teacher-list.tsx
+++ b/resources/js/components/admin/teacher-list.tsx
@@ -1,0 +1,252 @@
+import * as TeacherController from '@/actions/App/Http/Controllers/Admin/TeacherController';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { type SharedData } from '@/types';
+import { Link, useForm, usePage } from '@inertiajs/react';
+import { Edit, EyeOff, Mail, MapPin, Phone, Trash2, Users } from 'lucide-react';
+
+export interface TeacherListItem {
+    id: number;
+    name: string;
+    name_en?: string | null;
+    title: string;
+    title_en?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    office?: string | null;
+    job_title?: string | null;
+    photo_url?: string | null;
+    bio?: string | null;
+    bio_en?: string | null;
+    expertise?: string | null;
+    expertise_en?: string | null;
+    education?: string | null;
+    education_en?: string | null;
+    sort_order: number;
+    visible: boolean;
+    user?: {
+        id: number;
+        name: string;
+        email: string;
+    } | null;
+    labs?: Array<{
+        id: number;
+        name: string;
+        name_en?: string | null;
+    }>;
+}
+
+export interface TeacherListPaginationLink {
+    url: string | null;
+    label: string;
+    active: boolean;
+}
+
+export interface TeacherListPaginationMeta {
+    total: number;
+    [key: string]: unknown;
+}
+
+export interface TeacherListProps {
+    teachers: {
+        data: TeacherListItem[];
+        links?: TeacherListPaginationLink[];
+        meta: TeacherListPaginationMeta;
+    };
+}
+
+export default function TeacherList({ teachers }: TeacherListProps) {
+    const { auth, locale } = usePage<SharedData>().props;
+    const isZh = locale === 'zh-TW';
+    const { delete: destroy } = useForm();
+
+    const getName = (teacher: TeacherListItem) => {
+        return isZh ? teacher.name : teacher.name_en || teacher.name;
+    };
+
+    const getTitle = (teacher: TeacherListItem) => {
+        return isZh ? teacher.title : teacher.title_en || teacher.title;
+    };
+
+    const handleDelete = (teacher: TeacherListItem) => {
+        if (
+            confirm(
+                isZh
+                    ? `確定要刪除教師「${getName(teacher)}」嗎？`
+                    : `Delete teacher "${getName(teacher)}"?`
+            )
+        ) {
+            destroy(TeacherController.destroy(teacher.id).url, {
+                preserveScroll: true,
+                preserveState: true,
+            });
+        }
+    };
+
+    return (
+        <Card className="bg-white shadow-sm">
+            <CardHeader className="border-b border-gray-200">
+                <CardTitle className="flex items-center gap-2 text-gray-900">
+                    <Users className="h-5 w-5 text-blue-600" />
+                    {isZh ? '教師列表' : 'Faculty List'}
+                    <Badge variant="secondary" className="ml-2">
+                        {teachers.meta.total} {isZh ? '位教師' : 'teachers'}
+                    </Badge>
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="p-6">
+                {teachers.data.length === 0 ? (
+                    <div className="py-12 text-center">
+                        <Users className="mx-auto h-12 w-12 text-gray-300" />
+                        <h3 className="mt-2 text-sm font-semibold text-gray-900">
+                            {isZh ? '尚無教師資料' : 'No teachers yet'}
+                        </h3>
+                        <p className="mt-1 text-sm text-gray-500">
+                            {isZh ? '新增教師以建立名單' : 'Add your first teacher to populate this list'}
+                        </p>
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        {teachers.data.map((teacher) => (
+                            <div
+                                key={teacher.id}
+                                className="flex flex-col gap-4 rounded-lg border border-gray-200 p-4 sm:flex-row sm:items-start"
+                            >
+                                <div className="flex-shrink-0">
+                                    {teacher.photo_url ? (
+                                        <img
+                                            src={teacher.photo_url}
+                                            alt={getName(teacher)}
+                                            className="h-16 w-16 rounded-full object-cover"
+                                        />
+                                    ) : (
+                                        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-100">
+                                            <Users className="h-8 w-8 text-gray-400" />
+                                        </div>
+                                    )}
+                                </div>
+
+                                <div className="flex-1 space-y-2">
+                                    <div className="flex items-start justify-between">
+                                        <div>
+                                            <h3 className="text-lg font-semibold text-gray-900">
+                                                {getName(teacher)}
+                                                {!teacher.visible && (
+                                                    <EyeOff className="ml-2 inline h-4 w-4 text-gray-400" />
+                                                )}
+                                            </h3>
+                                            <p className="text-sm font-medium text-blue-600">
+                                                {getTitle(teacher)}
+                                            </p>
+                                            {teacher.job_title && (
+                                                <p className="text-sm text-gray-500">{teacher.job_title}</p>
+                                            )}
+                                        </div>
+                                        <Badge variant={teacher.visible ? 'default' : 'secondary'}>
+                                            {teacher.visible
+                                                ? isZh
+                                                    ? '公開'
+                                                    : 'Visible'
+                                                : isZh
+                                                ? '隱藏'
+                                                : 'Hidden'}
+                                        </Badge>
+                                    </div>
+
+                                    <div className="flex flex-wrap gap-4 text-sm text-gray-600">
+                                        {teacher.email && (
+                                            <div className="flex items-center gap-1">
+                                                <Mail className="h-4 w-4" />
+                                                <a href={`mailto:${teacher.email}`} className="hover:text-blue-600">
+                                                    {teacher.email}
+                                                </a>
+                                            </div>
+                                        )}
+                                        {teacher.phone && (
+                                            <div className="flex items-center gap-1">
+                                                <Phone className="h-4 w-4" />
+                                                {teacher.phone}
+                                            </div>
+                                        )}
+                                        {teacher.office && (
+                                            <div className="flex items-center gap-1">
+                                                <MapPin className="h-4 w-4" />
+                                                {teacher.office}
+                                            </div>
+                                        )}
+                                    </div>
+
+                                    {teacher.bio && (
+                                        <div className="text-sm text-gray-600">
+                                            <p className="line-clamp-2">
+                                                {isZh ? teacher.bio : teacher.bio_en || teacher.bio}
+                                            </p>
+                                        </div>
+                                    )}
+
+                                    {teacher.labs && teacher.labs.length > 0 && (
+                                        <div className="flex flex-wrap gap-1">
+                                            {teacher.labs.map((lab) => (
+                                                <Badge key={lab.id} variant="outline" className="text-xs">
+                                                    {isZh ? lab.name : lab.name_en || lab.name}
+                                                </Badge>
+                                            ))}
+                                        </div>
+                                    )}
+                                </div>
+
+                                <div className="flex items-center gap-2 sm:ml-4">
+                                    <Link href={TeacherController.edit(teacher.id).url}>
+                                        <Button variant="outline" size="sm">
+                                            <Edit className="mr-1 h-4 w-4" />
+                                            {isZh ? '編輯' : 'Edit'}
+                                        </Button>
+                                    </Link>
+                                    {auth.user.role === 'admin' && (
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="text-red-600 hover:text-red-800"
+                                            onClick={() => handleDelete(teacher)}
+                                        >
+                                            <Trash2 className="mr-1 h-4 w-4" />
+                                            {isZh ? '刪除' : 'Delete'}
+                                        </Button>
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {teachers.links && teachers.links.length > 3 && (
+                    <div className="mt-6 flex justify-center">
+                        <nav className="flex items-center gap-1">
+                            {teachers.links.map((link, index) => (
+                                <div key={index}>
+                                    {link.url ? (
+                                        <Link
+                                            href={link.url}
+                                            className={`px-3 py-1 text-sm ${
+                                                link.active
+                                                    ? 'bg-blue-600 text-white'
+                                                    : 'text-gray-600 hover:bg-gray-100'
+                                            } rounded`}
+                                            dangerouslySetInnerHTML={{ __html: link.label }}
+                                        />
+                                    ) : (
+                                        <span
+                                            className="px-3 py-1 text-sm text-gray-400"
+                                            dangerouslySetInnerHTML={{ __html: link.label }}
+                                        />
+                                    )}
+                                </div>
+                            ))}
+                        </nav>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -38,7 +38,7 @@ export function AppSidebar() {
             icon: Megaphone,
         },
         {
-            title: isZh ? '師資管理' : 'Faculty',
+            title: isZh ? '師資與職員' : 'Faculty & Staff',
             href: '/admin/staff',
             icon: UserCheck,
         },

--- a/resources/js/pages/admin/teachers/index.tsx
+++ b/resources/js/pages/admin/teachers/index.tsx
@@ -1,78 +1,13 @@
 import * as TeacherController from '@/actions/App/Http/Controllers/Admin/TeacherController';
+import TeacherList, { type TeacherListProps } from '@/components/admin/teacher-list';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import AppLayout from '@/layouts/app-layout';
-import { Head, Link, useForm, usePage } from '@inertiajs/react';
-import { Users, Mail, Phone, MapPin, Eye, EyeOff, Edit, Trash2 } from 'lucide-react';
 import { type SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
 
-interface Teacher {
-    id: number;
-    name: string;
-    name_en?: string | null;
-    title: string;
-    title_en?: string | null;
-    email?: string | null;
-    phone?: string | null;
-    office?: string | null;
-    job_title?: string | null;
-    photo_url?: string | null;
-    bio?: string | null;
-    bio_en?: string | null;
-    expertise?: string | null;
-    expertise_en?: string | null;
-    education?: string | null;
-    education_en?: string | null;
-    sort_order: number;
-    visible: boolean;
-    user?: {
-        id: number;
-        name: string;
-        email: string;
-    } | null;
-    labs?: Array<{
-        id: number;
-        name: string;
-        name_en?: string;
-    }>;
-}
-
-interface TeachersIndexProps {
-    teachers: {
-        data: Teacher[];
-        links: any[];
-        meta: any;
-    };
-}
-
-export default function TeachersIndex({ teachers }: TeachersIndexProps) {
+export default function TeachersIndex({ teachers }: TeacherListProps) {
     const { auth, locale } = usePage<SharedData>().props;
     const isZh = locale === 'zh-TW';
-    const { delete: destroy } = useForm();
-
-    const getName = (teacher: Teacher) => {
-        return isZh ? teacher.name : (teacher.name_en || teacher.name);
-    };
-
-    const getTitle = (teacher: Teacher) => {
-        return isZh ? teacher.title : (teacher.title_en || teacher.title);
-    };
-
-    const handleDelete = (teacher: Teacher) => {
-        if (
-            confirm(
-                isZh
-                    ? `確定要刪除教師「${getName(teacher)}」嗎？`
-                    : `Delete teacher "${getName(teacher)}"?`
-            )
-        ) {
-            destroy(TeacherController.destroy(teacher.id).url, {
-                preserveScroll: true,
-                preserveState: true,
-            });
-        }
-    };
 
     return (
         <AppLayout>
@@ -87,8 +22,8 @@ export default function TeachersIndex({ teachers }: TeachersIndexProps) {
                             </h1>
                             <p className="mt-1 text-gray-600">
                                 {isZh
-                                    ? '管理系所教師資訊與個人資料'
-                                    : 'Manage department faculty information and profiles'}
+                                    ? '此頁面內容已整合至「師資與職員管理」，未來請改用新介面。'
+                                    : 'This view has been consolidated into the Faculty & Staff management workspace.'}
                             </p>
                         </div>
 
@@ -101,177 +36,7 @@ export default function TeachersIndex({ teachers }: TeachersIndexProps) {
                         )}
                     </div>
 
-                    <Card className="bg-white shadow-sm">
-                        <CardHeader className="border-b border-gray-200">
-                            <CardTitle className="flex items-center gap-2 text-gray-900">
-                                <Users className="h-5 w-5 text-blue-600" />
-                                {isZh ? '教師列表' : 'Faculty List'}
-                                <Badge variant="secondary" className="ml-2">
-                                    {teachers.meta.total} {isZh ? '位教師' : 'teachers'}
-                                </Badge>
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="p-6">
-                            {teachers.data.length === 0 ? (
-                                <div className="py-12 text-center">
-                                    <Users className="mx-auto h-12 w-12 text-gray-300" />
-                                    <h3 className="mt-2 text-sm font-semibold text-gray-900">
-                                        {isZh ? '尚無教師資料' : 'No teachers yet'}
-                                    </h3>
-                                    <p className="mt-1 text-sm text-gray-500">
-                                        {isZh ? '新增教師以建立名單' : 'Add your first teacher to populate this list'}
-                                    </p>
-                                </div>
-                            ) : (
-                                <div className="space-y-4">
-                                    {teachers.data.map((teacher) => (
-                                        <div
-                                            key={teacher.id}
-                                            className="flex flex-col gap-4 rounded-lg border border-gray-200 p-4 sm:flex-row sm:items-start"
-                                        >
-                                            {/* 頭像 */}
-                                            <div className="flex-shrink-0">
-                                                {teacher.photo_url ? (
-                                                    <img
-                                                        src={teacher.photo_url}
-                                                        alt={getName(teacher)}
-                                                        className="h-16 w-16 rounded-full object-cover"
-                                                    />
-                                                ) : (
-                                                    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-100">
-                                                        <Users className="h-8 w-8 text-gray-400" />
-                                                    </div>
-                                                )}
-                                            </div>
-
-                                            {/* 基本資訊 */}
-                                            <div className="flex-1 space-y-2">
-                                                <div className="flex items-start justify-between">
-                                                    <div>
-                                                        <h3 className="text-lg font-semibold text-gray-900">
-                                                            {getName(teacher)}
-                                                            {!teacher.visible && (
-                                                                <EyeOff className="ml-2 inline h-4 w-4 text-gray-400" />
-                                                            )}
-                                                        </h3>
-                                                        <p className="text-sm font-medium text-blue-600">
-                                                            {getTitle(teacher)}
-                                                        </p>
-                                                        {teacher.job_title && (
-                                                            <p className="text-sm text-gray-500">
-                                                                {teacher.job_title}
-                                                            </p>
-                                                        )}
-                                                    </div>
-                                                    <Badge variant={teacher.visible ? "default" : "secondary"}>
-                                                        {teacher.visible
-                                                            ? (isZh ? '公開' : 'Visible')
-                                                            : (isZh ? '隱藏' : 'Hidden')
-                                                        }
-                                                    </Badge>
-                                                </div>
-
-                                                {/* 聯絡資訊 */}
-                                                <div className="flex flex-wrap gap-4 text-sm text-gray-600">
-                                                    {teacher.email && (
-                                                        <div className="flex items-center gap-1">
-                                                            <Mail className="h-4 w-4" />
-                                                            <a
-                                                                href={`mailto:${teacher.email}`}
-                                                                className="hover:text-blue-600"
-                                                            >
-                                                                {teacher.email}
-                                                            </a>
-                                                        </div>
-                                                    )}
-                                                    {teacher.phone && (
-                                                        <div className="flex items-center gap-1">
-                                                            <Phone className="h-4 w-4" />
-                                                            {teacher.phone}
-                                                        </div>
-                                                    )}
-                                                    {teacher.office && (
-                                                        <div className="flex items-center gap-1">
-                                                            <MapPin className="h-4 w-4" />
-                                                            {teacher.office}
-                                                        </div>
-                                                    )}
-                                                </div>
-
-                                                {/* Bio 預覽 */}
-                                                {teacher.bio && (
-                                                    <div className="text-sm text-gray-600">
-                                                        <p className="line-clamp-2">
-                                                            {isZh ? teacher.bio : (teacher.bio_en || teacher.bio)}
-                                                        </p>
-                                                    </div>
-                                                )}
-
-                                                {/* 實驗室 */}
-                                                {teacher.labs && teacher.labs.length > 0 && (
-                                                    <div className="flex flex-wrap gap-1">
-                                                        {teacher.labs.map((lab) => (
-                                                            <Badge key={lab.id} variant="outline" className="text-xs">
-                                                                {isZh ? lab.name : (lab.name_en || lab.name)}
-                                                            </Badge>
-                                                        ))}
-                                                    </div>
-                                                )}
-                                            </div>
-
-                                            {/* 操作按鈕 */}
-                                            <div className="flex items-center gap-2 sm:ml-4">
-                                                <Link href={TeacherController.edit(teacher.id).url}>
-                                                    <Button variant="outline" size="sm">
-                                                        <Edit className="mr-1 h-4 w-4" />
-                                                        {isZh ? '編輯' : 'Edit'}
-                                                    </Button>
-                                                </Link>
-                                                {auth.user.role === 'admin' && (
-                                                    <Button
-                                                        variant="outline"
-                                                        size="sm"
-                                                        className="text-red-600 hover:text-red-800"
-                                                        onClick={() => handleDelete(teacher)}
-                                                    >
-                                                        <Trash2 className="mr-1 h-4 w-4" />
-                                                        {isZh ? '刪除' : 'Delete'}
-                                                    </Button>
-                                                )}
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-
-                            {/* 分頁 */}
-                            {teachers.links && teachers.links.length > 3 && (
-                                <div className="mt-6 flex justify-center">
-                                    <nav className="flex items-center gap-1">
-                                        {teachers.links.map((link, index) => (
-                                            <div key={index}>
-                                                {link.url ? (
-                                                    <Link
-                                                        href={link.url}
-                                                        className={`px-3 py-1 text-sm ${link.active
-                                                                ? 'bg-blue-600 text-white'
-                                                                : 'text-gray-600 hover:bg-gray-100'
-                                                            } rounded`}
-                                                        dangerouslySetInnerHTML={{ __html: link.label }}
-                                                    />
-                                                ) : (
-                                                    <span
-                                                        className="px-3 py-1 text-sm text-gray-400"
-                                                        dangerouslySetInnerHTML={{ __html: link.label }}
-                                                    />
-                                                )}
-                                            </div>
-                                        ))}
-                                    </nav>
-                                </div>
-                            )}
-                        </CardContent>
-                    </Card>
+                    <TeacherList teachers={teachers} />
                 </div>
             </div>
         </AppLayout>


### PR DESCRIPTION
## Summary
- restructure `StaffController@index` to expose normalized staff and teacher data with eager-loaded relations
- introduce reusable `TeacherList` and `StaffList` components and update the admin staff page to present faculty/staff via tabs
- redirect `TeacherController@index` to the unified listing and refresh sidebar labeling to reflect the combined workspace

## Testing
- `npm run types`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68ccbd6c8744832395d7bff1765859e0