### PR TITLE
Add shared rich text editor for teacher profiles

### DIFF
--- a/resources/js/components/admin/rich-text-editor.tsx
+++ b/resources/js/components/admin/rich-text-editor.tsx
@@ -1,0 +1,192 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { isRichTextEmpty, sanitizeRichText } from '@/lib/rich-text';
+import { useEffect, useRef, useState } from 'react';
+
+interface RichTextEditorProps {
+    id: string;
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    className?: string;
+    disabled?: boolean;
+}
+
+function applyCommand(command: string, value?: string) {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    document.execCommand(command, false, value);
+}
+
+function normalizeHtml(html: string): string {
+    const sanitized = sanitizeRichText(html);
+    return sanitized;
+}
+
+export default function RichTextEditor({
+    id,
+    value,
+    onChange,
+    placeholder = '請輸入內容...',
+    className,
+    disabled = false,
+}: RichTextEditorProps) {
+    const editorRef = useRef<HTMLDivElement>(null);
+    const [isFocused, setIsFocused] = useState(false);
+    const lastValueRef = useRef('');
+
+    useEffect(() => {
+        const editor = editorRef.current;
+        if (!editor) return;
+
+        const normalized = value ?? '';
+
+        if (isFocused) {
+            lastValueRef.current = normalized;
+            return;
+        }
+
+        if (lastValueRef.current !== normalized) {
+            editor.innerHTML = normalized;
+            lastValueRef.current = normalized;
+        }
+    }, [value, isFocused]);
+
+    const emitChange = (html: string) => {
+        const normalized = normalizeHtml(html);
+        lastValueRef.current = normalized;
+        onChange(normalized);
+    };
+
+    const handleInput = (event: React.FormEvent<HTMLDivElement>) => {
+        emitChange(event.currentTarget.innerHTML);
+    };
+
+    const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+        setIsFocused(false);
+        emitChange(event.currentTarget.innerHTML);
+    };
+
+    const handleFocus = () => {
+        setIsFocused(true);
+    };
+
+    const handlePaste = (event: React.ClipboardEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        const text = event.clipboardData.getData('text/plain');
+        if (typeof document !== 'undefined') {
+            document.execCommand('insertText', false, text);
+        }
+    };
+
+    const handleToolbar = (command: 'bold' | 'italic' | 'underline' | 'insertUnorderedList' | 'createLink') => {
+        const editor = editorRef.current;
+        if (!editor) return;
+
+        editor.focus();
+
+        if (command === 'createLink') {
+            const selection = window.getSelection()?.toString();
+            const defaultValue = selection || 'https://';
+            const url = prompt('輸入連結網址', defaultValue);
+            if (!url) {
+                return;
+            }
+            applyCommand('createLink', url);
+            return;
+        }
+
+        applyCommand(command);
+    };
+
+    const isEmpty = isRichTextEmpty(value);
+
+    return (
+        <div className={cn('space-y-2', className)}>
+            <div className="flex flex-wrap gap-1 rounded border bg-muted/40 p-2">
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
+                    disabled={disabled}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => handleToolbar('bold')}
+                >
+                    <strong>B</strong>
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
+                    disabled={disabled}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => handleToolbar('italic')}
+                >
+                    <em>I</em>
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
+                    disabled={disabled}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => handleToolbar('underline')}
+                >
+                    <u>U</u>
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
+                    disabled={disabled}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => handleToolbar('insertUnorderedList')}
+                >
+                    •
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
+                    disabled={disabled}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => handleToolbar('createLink')}
+                >
+                    🔗
+                </Button>
+            </div>
+            <div className="relative">
+                {!isFocused && isEmpty && (
+                    <span className="pointer-events-none absolute left-3 top-2 text-sm text-muted-foreground">
+                        {placeholder}
+                    </span>
+                )}
+                <div
+                    id={id}
+                    ref={editorRef}
+                    className={cn(
+                        'min-h-[160px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/30',
+                        'prose prose-sm max-w-none text-muted-foreground [&_ul]:list-disc [&_ol]:list-decimal [&_li]:ml-5 [&_a]:text-primary [&_a]:underline',
+                        disabled && 'pointer-events-none opacity-70'
+                    )}
+                    contentEditable={!disabled}
+                    role="textbox"
+                    aria-multiline="true"
+                    data-placeholder={placeholder}
+                    suppressContentEditableWarning
+                    onInput={handleInput}
+                    onBlur={handleBlur}
+                    onFocus={handleFocus}
+                    onPaste={handlePaste}
+                />
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/admin/teacher-form.tsx
+++ b/resources/js/components/admin/teacher-form.tsx
@@ -1,8 +1,8 @@
+import RichTextEditor from '@/components/admin/rich-text-editor';
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useForm } from '@inertiajs/react';
 import { FormEventHandler, useState } from 'react';
@@ -106,141 +106,33 @@ export default function TeacherForm({ teacher, users = [], onSubmit }: TeacherFo
             visible: teacher.visible ?? true,
             ...(teacher.id ? { _method: 'put' } : {}),
         };
-    }; const form = useForm<TeacherFormData>(transformTeacherData(teacher));
+    };
+    const form = useForm<TeacherFormData>(transformTeacherData(teacher));
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
         onSubmit(form);
     };
 
-    // 簡易富文本編輯器功能
-    const formatText = (field: keyof TeacherFormData, format: string) => {
-        const textarea = document.getElementById(field as string) as HTMLTextAreaElement;
-        if (!textarea) return;
-
-        const start = textarea.selectionStart;
-        const end = textarea.selectionEnd;
-        const selectedText = textarea.value.substring(start, end);
-
-        let formattedText = '';
-        switch (format) {
-            case 'bold':
-                formattedText = `**${selectedText || '粗體文字'}**`;
-                break;
-            case 'italic':
-                formattedText = `*${selectedText || '斜體文字'}*`;
-                break;
-            case 'underline':
-                formattedText = `__${selectedText || '底線文字'}__`;
-                break;
-            case 'list':
-                formattedText = `\n- ${selectedText || '列表項目'}`;
-                break;
-            case 'link':
-                formattedText = `[${selectedText || '連結文字'}](http://example.com)`;
-                break;
-        }
-
-        const newValue =
-            textarea.value.substring(0, start) +
-            formattedText +
-            textarea.value.substring(end);
-
-        form.setData(field as keyof TeacherFormData, newValue);
-
-        // 設定游標位置
-        setTimeout(() => {
-            textarea.focus();
-            textarea.setSelectionRange(start + formattedText.length, start + formattedText.length);
-        }, 0);
-    };
-
-    const insertText = (field: keyof TeacherFormData, text: string) => {
-        const currentValue = form.data[field] as string || '';
-        form.setData(field, currentValue + text);
-    };
-
-    const TextEditor = ({ field, label, rows = 6 }: {
-        field: keyof TeacherFormData;
-        label: string;
-        rows?: number;
-    }) => {
-        const value = form.data[field] as string || '';
+    const renderRichTextField = (
+        field: keyof TeacherFormData,
+        label: string,
+        placeholder: string,
+        helpText: string
+    ) => {
+        const value = (form.data[field] as string) || '';
 
         return (
             <div className="space-y-2">
                 <Label htmlFor={field as string}>{label}</Label>
-
-                {/* 簡易工具列 */}
-                <div className="flex flex-wrap gap-1 rounded border bg-gray-50 p-2">
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => formatText(field, 'bold')}
-                        className="h-8 px-2 text-xs"
-                    >
-                        <strong>B</strong>
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => formatText(field, 'italic')}
-                        className="h-8 px-2 text-xs"
-                    >
-                        <em>I</em>
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => formatText(field, 'underline')}
-                        className="h-8 px-2 text-xs"
-                    >
-                        <u>U</u>
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => formatText(field, 'list')}
-                        className="h-8 px-2 text-xs"
-                    >
-                        •
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => formatText(field, 'link')}
-                        className="h-8 px-2 text-xs"
-                    >
-                        🔗
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => insertText(field, '\n\n---\n\n')}
-                        className="h-8 px-2 text-xs"
-                    >
-                        ───
-                    </Button>
-                </div>
-
-                <Textarea
+                <RichTextEditor
                     id={field as string}
-                    rows={rows}
                     value={value}
-                    onChange={(e) => form.setData(field, e.target.value)}
-                    className="min-h-[150px] font-mono text-sm"
-                    placeholder="請輸入內容..."
+                    placeholder={placeholder}
+                    onChange={(html) => form.setData(field, html)}
                 />
                 <InputError message={form.errors[field]} />
-                <p className="text-xs text-gray-500">
-                    支援 Markdown 語法：**粗體** *斜體* __底線__ [連結](網址) - 列表
-                </p>
+                <p className="text-xs text-gray-500">{helpText}</p>
             </div>
         );
     };
@@ -411,9 +303,24 @@ export default function TeacherForm({ teacher, users = [], onSubmit }: TeacherFo
                                         <InputError message={form.errors.title} />
                                     </div>
 
-                                    <TextEditor field="bio" label="個人簡介" rows={8} />
-                                    <TextEditor field="expertise" label="專長領域" rows={4} />
-                                    <TextEditor field="education" label="學歷" rows={4} />
+                                    {renderRichTextField(
+                                        'bio',
+                                        '個人簡介',
+                                        '請輸入個人簡介...',
+                                        '支援粗體、斜體、底線、項目符號與超連結。'
+                                    )}
+                                    {renderRichTextField(
+                                        'expertise',
+                                        '專長領域',
+                                        '請輸入專長領域...',
+                                        '建議以條列或段落形式說明，支援基本格式與連結。'
+                                    )}
+                                    {renderRichTextField(
+                                        'education',
+                                        '學歷',
+                                        '請輸入學歷資訊...',
+                                        '可使用段落或列表呈現學歷，支援基本格式與連結。'
+                                    )}
                                 </div>
                             )}
 
@@ -439,9 +346,24 @@ export default function TeacherForm({ teacher, users = [], onSubmit }: TeacherFo
                                         <InputError message={form.errors.title_en} />
                                     </div>
 
-                                    <TextEditor field="bio_en" label="Biography" rows={8} />
-                                    <TextEditor field="expertise_en" label="Expertise" rows={4} />
-                                    <TextEditor field="education_en" label="Education" rows={4} />
+                                    {renderRichTextField(
+                                        'bio_en',
+                                        'Biography',
+                                        'Enter biography...',
+                                        'Supports bold, italic, underline, bullet list, and hyperlinks.'
+                                    )}
+                                    {renderRichTextField(
+                                        'expertise_en',
+                                        'Expertise',
+                                        'Describe the areas of expertise...',
+                                        'Use paragraphs or lists to highlight expertise. Basic formatting and links are supported.'
+                                    )}
+                                    {renderRichTextField(
+                                        'education_en',
+                                        'Education',
+                                        'List academic background...',
+                                        'Provide education history with paragraphs or bullet points. Formatting and links are supported.'
+                                    )}
                                 </div>
                             )}
                         </CardContent>

--- a/resources/js/components/admin/teacher-list.tsx
+++ b/resources/js/components/admin/teacher-list.tsx
@@ -108,11 +108,14 @@ export default function TeacherList({ teachers }: TeacherListProps) {
                     </div>
                 ) : (
                     <div className="space-y-4">
-                        {teachers.data.map((teacher) => (
-                            <div
-                                key={teacher.id}
-                                className="flex flex-col gap-4 rounded-lg border border-gray-200 p-4 sm:flex-row sm:items-start"
-                            >
+                        {teachers.data.map((teacher) => {
+                            const bioHtml = isZh ? teacher.bio : teacher.bio_en || teacher.bio;
+
+                            return (
+                                <div
+                                    key={teacher.id}
+                                    className="flex flex-col gap-4 rounded-lg border border-gray-200 p-4 sm:flex-row sm:items-start"
+                                >
                                 <div className="flex-shrink-0">
                                     {teacher.photo_url ? (
                                         <img
@@ -177,12 +180,11 @@ export default function TeacherList({ teachers }: TeacherListProps) {
                                         )}
                                     </div>
 
-                                    {teacher.bio && (
-                                        <div className="text-sm text-gray-600">
-                                            <p className="line-clamp-2">
-                                                {isZh ? teacher.bio : teacher.bio_en || teacher.bio}
-                                            </p>
-                                        </div>
+                                    {bioHtml && (
+                                        <div
+                                            className="line-clamp-3 text-sm text-gray-600 [&>p]:m-0 [&>p]:leading-relaxed [&_ul]:my-1 [&_ul]:list-disc [&_ol]:my-1 [&_ol]:list-decimal [&_li]:ml-5 [&_a]:text-blue-600 [&_a]:underline"
+                                            dangerouslySetInnerHTML={{ __html: bioHtml }}
+                                        />
                                     )}
 
                                     {teacher.labs && teacher.labs.length > 0 && (
@@ -215,8 +217,9 @@ export default function TeacherList({ teachers }: TeacherListProps) {
                                         </Button>
                                     )}
                                 </div>
-                            </div>
-                        ))}
+                                </div>
+                            );
+                        })}
                     </div>
                 )}
 

--- a/resources/js/lib/rich-text.ts
+++ b/resources/js/lib/rich-text.ts
@@ -1,0 +1,197 @@
+const ALLOWED_TAGS = new Set(['p', 'br', 'strong', 'em', 'u', 'ul', 'ol', 'li', 'a', 'blockquote']);
+const BLOCK_TAGS = new Set(['p', 'ul', 'ol', 'li', 'blockquote']);
+
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function sanitizeUrl(href: string | null | undefined): string {
+    if (!href) {
+        return '';
+    }
+
+    const trimmed = href.trim();
+
+    if (!trimmed) {
+        return '';
+    }
+
+    if (/^javascript:/i.test(trimmed)) {
+        return '';
+    }
+
+    if (/^(https?:|mailto:|#)/i.test(trimmed)) {
+        return trimmed;
+    }
+
+    return `https://${trimmed}`;
+}
+
+function hasBlockChild(element: Element): boolean {
+    return Array.from(element.childNodes).some((node) => {
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            return false;
+        }
+
+        let tag = (node as Element).tagName.toLowerCase();
+
+        if (tag === 'b') tag = 'strong';
+        if (tag === 'i') tag = 'em';
+
+        if (tag === 'div') {
+            return true;
+        }
+
+        return BLOCK_TAGS.has(tag);
+    });
+}
+
+function sanitizeChildren(element: Element | DocumentFragment): string {
+    let result = '';
+
+    element.childNodes.forEach((node) => {
+        result += sanitizeNode(node);
+    });
+
+    return result;
+}
+
+function sanitizeNode(node: Node): string {
+    if (node.nodeType === Node.TEXT_NODE) {
+        const text = node.textContent ?? '';
+        return escapeHtml(text);
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+        return '';
+    }
+
+    const element = node as Element;
+    let tag = element.tagName.toLowerCase();
+
+    if (tag === 'b') tag = 'strong';
+    if (tag === 'i') tag = 'em';
+
+    if (tag === 'span' || tag === 'font') {
+        return sanitizeChildren(element);
+    }
+
+    if (tag === 'div') {
+        const children = sanitizeChildren(element);
+        if (!children.trim()) {
+            return '';
+        }
+
+        if (hasBlockChild(element)) {
+            return children;
+        }
+
+        return `<p>${children}</p>`;
+    }
+
+    if (tag === 'br') {
+        return '<br />';
+    }
+
+    if (!ALLOWED_TAGS.has(tag)) {
+        return sanitizeChildren(element);
+    }
+
+    let attributes = '';
+
+    if (tag === 'a') {
+        const href = sanitizeUrl(element.getAttribute('href'));
+        if (!href) {
+            return sanitizeChildren(element);
+        }
+
+        attributes = ` href="${href}"`;
+
+        if (!href.startsWith('#') && !href.startsWith('mailto:')) {
+            attributes += ' target="_blank" rel="noopener noreferrer"';
+        }
+    }
+
+    const children = sanitizeChildren(element);
+
+    if (tag === 'p') {
+        const text = children.replace(/<br\s*\/>/gi, '').trim();
+        if (!text) {
+            return '';
+        }
+    }
+
+    if ((tag === 'ul' || tag === 'ol') && !children.trim()) {
+        return '';
+    }
+
+    if (tag === 'li') {
+        const content = children.trim();
+        if (!content) {
+            return '';
+        }
+        return `<li>${content}</li>`;
+    }
+
+    return `<${tag}${attributes}>${children}</${tag}>`;
+}
+
+export function sanitizeRichText(value: string): string {
+    if (typeof document === 'undefined') {
+        return value;
+    }
+
+    const container = document.createElement('div');
+    container.innerHTML = value ?? '';
+
+    const sanitized = sanitizeChildren(container).trim();
+
+    if (!sanitized) {
+        return '';
+    }
+
+    if (!/^(<p|<ul|<ol|<blockquote|<strong|<em|<u|<a|<br)/i.test(sanitized)) {
+        return `<p>${sanitized}</p>`;
+    }
+
+    return sanitized;
+}
+
+export function isRichTextEmpty(value?: string | null): boolean {
+    if (!value) {
+        return true;
+    }
+
+    const normalized = value
+        .replace(/<br\s*\/>/gi, '')
+        .replace(/<p>\s*<\/p>/gi, '')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/<[^>]+>/g, '')
+        .trim();
+
+    return normalized === '';
+}
+
+export function richTextToPlainText(value?: string | null): string {
+    if (!value) {
+        return '';
+    }
+
+    const withBreaks = value
+        .replace(/<\/?p>/gi, '\n')
+        .replace(/<\/?li>/gi, '\n')
+        .replace(/<br\s*\/?\s*>/gi, '\n');
+
+    if (typeof window !== 'undefined' && typeof window.DOMParser !== 'undefined') {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(withBreaks, 'text/html');
+        return (doc.body.textContent ?? '').replace(/\s+\n/g, '\n').trim();
+    }
+
+    return withBreaks.replace(/<[^>]+>/g, ' ').replace(/&nbsp;/gi, ' ').replace(/\s+/g, ' ').trim();
+}

--- a/resources/js/pages/people/index.tsx
+++ b/resources/js/pages/people/index.tsx
@@ -5,6 +5,7 @@ import type { SharedData } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import { useMemo, useState } from 'react';
 import { ArrowRight, Mail, MapPin, Phone, Search, Users } from 'lucide-react';
+import { isRichTextEmpty, richTextToPlainText } from '@/lib/rich-text';
 
 interface LocaleRecord {
     ['zh-TW']?: string | null;
@@ -51,7 +52,9 @@ function pickLocale(locale: string, value?: LocaleRecord, fallback = ''): string
 }
 
 function toTags(text: string, limit = 3): string[] {
-    return text
+    const plainText = richTextToPlainText(text);
+
+    return plainText
         .split(/[,\n\r]+/)
         .map((item) => item.trim())
         .filter(Boolean)
@@ -257,9 +260,23 @@ export default function PeopleIndex({ people, filters, statistics }: PeopleIndex
                                                 </span>
                                             )}
                                         </div>
-                                        <p className="text-sm text-neutral-600 md:text-base">
-                                            {pickLocale(isZh ? 'zh-TW' : 'en', primaryPerson.expertise, '')}
-                                        </p>
+                                        {(() => {
+                                            const expertiseHtml = pickLocale(
+                                                isZh ? 'zh-TW' : 'en',
+                                                primaryPerson.expertise,
+                                                ''
+                                            );
+                                            if (isRichTextEmpty(expertiseHtml)) {
+                                                return null;
+                                            }
+
+                                            return (
+                                                <div
+                                                    className="text-sm text-neutral-600 md:text-base [&>p]:m-0 [&>p]:leading-relaxed [&_ul]:my-2 [&_ul]:list-disc [&_ol]:my-2 [&_ol]:list-decimal [&_li]:ml-5 [&_a]:text-primary [&_a]:underline"
+                                                    dangerouslySetInnerHTML={{ __html: expertiseHtml }}
+                                                />
+                                            );
+                                        })()}
                                         {(primaryPerson.labs ?? []).length > 0 && (
                                             <div className="mt-auto flex flex-wrap items-center gap-2 text-xs text-primary">
                                                 <Users className="size-4" />

--- a/resources/js/pages/people/show.tsx
+++ b/resources/js/pages/people/show.tsx
@@ -5,13 +5,13 @@ import { Head, Link, usePage } from '@inertiajs/react';
 import {
     ArrowLeft,
     ArrowRight,
-    GraduationCap,
     LinkIcon,
     Mail,
     MapPin,
     Phone,
     Users,
 } from 'lucide-react';
+import { isRichTextEmpty } from '@/lib/rich-text';
 
 interface LocaleRecord {
     ['zh-TW']?: string | string[] | null;
@@ -55,15 +55,6 @@ function pickLocale(locale: string, record?: LocaleRecord, fallback = ''): strin
     return value ?? alt ?? fallback;
 }
 
-function normalizeList(value: string | string[] | undefined): string[] {
-    if (!value) return [];
-    if (Array.isArray(value)) return value.filter((item) => Boolean(item)).map((item) => item.toString().trim());
-    return value
-        .split(/[,\n\r]+/)
-        .map((item) => item.trim())
-        .filter(Boolean);
-}
-
 export default function PeopleShow({ person }: PeopleShowProps) {
     const page = usePage<SharedData>();
     const locale = page.props.locale ?? 'zh-TW';
@@ -71,9 +62,9 @@ export default function PeopleShow({ person }: PeopleShowProps) {
 
     const name = pickLocale(isZh ? 'zh-TW' : 'en', person.name, '') as string;
     const title = pickLocale(isZh ? 'zh-TW' : 'en', person.title, '') as string;
-    const bio = pickLocale(isZh ? 'zh-TW' : 'en', person.bio, '') as string;
-    const expertiseList = normalizeList(pickLocale(isZh ? 'zh-TW' : 'en', person.expertise));
-    const educationList = normalizeList(pickLocale(isZh ? 'zh-TW' : 'en', person.education));
+    const bioHtml = pickLocale(isZh ? 'zh-TW' : 'en', person.bio, '') as string;
+    const expertiseHtml = pickLocale(isZh ? 'zh-TW' : 'en', person.expertise, '') as string;
+    const educationHtml = pickLocale(isZh ? 'zh-TW' : 'en', person.education, '') as string;
 
     const labs = (person.labs ?? []).map((lab) => ({
         code: lab.code,
@@ -142,37 +133,33 @@ export default function PeopleShow({ person }: PeopleShowProps) {
             <section className="section-padding">
                 <div className="content-container grid gap-10 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
                     <article ref={contentRef} className="space-y-8">
-                        {bio ? (
+                        {!isRichTextEmpty(bioHtml) && (
                             <div className="rounded-3xl border border-neutral-200 bg-surface-soft p-8 shadow-sm">
                                 <h2 className="text-lg font-semibold text-neutral-900">{isZh ? '個人簡介' : 'Biography'}</h2>
-                                <p className="mt-4 whitespace-pre-line text-neutral-700">{bio}</p>
-                            </div>
-                        ) : null}
-
-                        {expertiseList.length > 0 && (
-                            <div className="rounded-3xl border border-neutral-200 bg-surface-soft p-8 shadow-sm">
-                                <h2 className="text-lg font-semibold text-neutral-900">{isZh ? '研究專長' : 'Expertise'}</h2>
-                                <div className="mt-4 flex flex-wrap gap-2">
-                                    {expertiseList.map((item, index) => (
-                                        <span key={`tag-${index}`} className="rounded-full bg-primary/10 px-4 py-2 text-sm font-medium text-primary">
-                                            {item}
-                                        </span>
-                                    ))}
-                                </div>
+                                <div
+                                    className="mt-4 space-y-3 text-neutral-700 [&>p]:m-0 [&>p]:leading-relaxed [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-6 [&_a]:text-primary [&_a]:underline"
+                                    dangerouslySetInnerHTML={{ __html: bioHtml }}
+                                />
                             </div>
                         )}
 
-                        {educationList.length > 0 && (
+                        {!isRichTextEmpty(expertiseHtml) && (
+                            <div className="rounded-3xl border border-neutral-200 bg-surface-soft p-8 shadow-sm">
+                                <h2 className="text-lg font-semibold text-neutral-900">{isZh ? '研究專長' : 'Expertise'}</h2>
+                                <div
+                                    className="mt-4 space-y-3 text-neutral-700 [&>p]:m-0 [&>p]:leading-relaxed [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-6 [&_a]:text-primary [&_a]:underline"
+                                    dangerouslySetInnerHTML={{ __html: expertiseHtml }}
+                                />
+                            </div>
+                        )}
+
+                        {!isRichTextEmpty(educationHtml) && (
                             <div className="rounded-3xl border border-neutral-200 bg-surface-soft p-8 shadow-sm">
                                 <h2 className="text-lg font-semibold text-neutral-900">{isZh ? '學歷' : 'Education'}</h2>
-                                <ul className="mt-4 space-y-2 text-neutral-700">
-                                    {educationList.map((item, index) => (
-                                        <li key={`edu-${index}`} className="flex items-start gap-2">
-                                            <GraduationCap className="mt-1 size-4 text-primary" />
-                                            <span>{item}</span>
-                                        </li>
-                                    ))}
-                                </ul>
+                                <div
+                                    className="mt-4 space-y-3 text-neutral-700 [&>p]:m-0 [&>p]:leading-relaxed [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-6 [&_a]:text-primary [&_a]:underline"
+                                    dangerouslySetInnerHTML={{ __html: educationHtml }}
+                                />
                             </div>
                         )}
 

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -6,6 +6,7 @@ import type { SharedData } from '@/types';
 import { Head, Link, usePage } from '@inertiajs/react';
 import { ArrowRight, CalendarDays, ChevronLeft, ChevronRight, MapPin, Mail, Phone, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { isRichTextEmpty } from '@/lib/rich-text';
 import { getPageLayout } from '@/styles/page-layouts';
 import { useRef } from 'react';
 
@@ -654,6 +655,7 @@ export default function Welcome() {
                                         const name = pickLocale(localeKey, teacher.name, '');
                                         const title = pickLocale(localeKey, teacher.title, '');
                                         const expertise = pickLocale(localeKey, teacher.expertise, '');
+                                        const hasExpertise = !isRichTextEmpty(expertise);
                                         const profileHref = teacher.slug ? `/people/${teacher.slug}` : '/people';
 
                                         return (
@@ -686,8 +688,11 @@ export default function Welcome() {
                                                         )}
                                                     </div>
                                                 </div>
-                                                {expertise && (
-                                                    <p className="mt-4 text-sm text-neutral-600 line-clamp-3">{expertise}</p>
+                                                {hasExpertise && (
+                                                    <div
+                                                        className="mt-4 line-clamp-3 text-sm text-neutral-600 [&>p]:m-0 [&>p]:leading-relaxed [&_ul]:my-1 [&_ul]:list-disc [&_ol]:my-1 [&_ol]:list-decimal [&_li]:ml-5 [&_a]:text-primary [&_a]:underline"
+                                                        dangerouslySetInnerHTML={{ __html: expertise }}
+                                                    />
                                                 )}
                                                 <span className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-primary">
                                                     {isZh ? '詳細介紹' : 'View profile'}


### PR DESCRIPTION
## Summary
- add a reusable admin rich-text editor component with HTML sanitization helpers
- switch the teacher form to use the new editor and store controlled HTML per locale
- render teacher biography and expertise HTML in admin cards and public faculty pages

## Testing
- npm run build *(fails: `php artisan wayfinder:generate --with-form` missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc0088cc48323bc91325fd977861e