### PR TITLE
feat(admin): support attachment counts and filters

### DIFF
--- a/app/Http/Controllers/Admin/AttachmentController.php
+++ b/app/Http/Controllers/Admin/AttachmentController.php
@@ -30,6 +30,10 @@ class AttachmentController extends Controller
             $query->where('attachable_type', $attachableType);
         }
 
+        if ($request->filled('attachable_id')) {
+            $query->where('attachable_id', (int) $request->input('attachable_id'));
+        }
+
         $trashed = $request->input('trashed');
         if ($trashed === 'with') {
             $query->withTrashed();
@@ -54,7 +58,7 @@ class AttachmentController extends Controller
 
         return Inertia::render('admin/attachments/index', [
             'attachments' => $attachments,
-            'filters' => $request->only(['search', 'type', 'attachable_type', 'trashed', 'per_page']),
+            'filters' => $request->only(['search', 'type', 'attachable_type', 'attachable_id', 'trashed', 'per_page']),
             'typeOptions' => ['image', 'document', 'link'],
             'attachableTypeOptions' => $attachableTypes,
             'perPageOptions' => [10, 20, 50],

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -24,7 +24,8 @@ class PostController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Post::with(['category', 'creator']);
+        $query = Post::with(['category', 'creator'])
+            ->withCount('attachments');
 
         $search = trim((string) $request->input('search'));
         if ($search !== '') {


### PR DESCRIPTION
## Summary
- expose attachment counts from the post index query so the admin UI can surface file totals per announcement
- allow filtering attachments by attachable_id and highlight the active source in the library screen, including a friendlier empty-state message
- surface attachment counts and quick links in the posts index so admins can jump directly to related files

## Testing
- php artisan test *(fails: MissingAppKeyException because no .env/app key is available in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc2d24e24832389c4454fc5e032e6