### PR TITLE
feat: 標準化後台頁首樣式

### DIFF
--- a/resources/js/components/admin/admin-page-header.tsx
+++ b/resources/js/components/admin/admin-page-header.tsx
@@ -1,0 +1,81 @@
+import { cn } from '@/lib/utils';
+import { type LucideIcon } from 'lucide-react';
+import { Children, type ReactNode } from 'react';
+
+interface AdminPageHeaderProps {
+    title: ReactNode;
+    description?: ReactNode;
+    icon?: LucideIcon | ReactNode;
+    actions?: ReactNode | ReactNode[];
+    className?: string;
+    contentClassName?: string;
+}
+
+export default function AdminPageHeader({
+    title,
+    description,
+    icon,
+    actions,
+    className,
+    contentClassName,
+}: AdminPageHeaderProps) {
+    const iconContent = (() => {
+        if (!icon) {
+            return null;
+        }
+
+        if (typeof icon === 'function') {
+            const IconComponent = icon as LucideIcon;
+            return <IconComponent className="h-8 w-8 sm:h-10 sm:w-10" />;
+        }
+
+        return icon;
+    })();
+
+    const actionNodes = Children.toArray(actions);
+
+    return (
+        <header
+            className={cn(
+                'relative overflow-hidden rounded-3xl bg-gradient-to-r from-[#151f54] via-[#1f2a6d] to-[#050a30] text-white shadow-lg ring-1 ring-white/10',
+                className
+            )}
+        >
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,#ffffff24_0%,transparent_55%)] opacity-70" />
+
+            <div
+                className={cn(
+                    'relative flex flex-col gap-6 px-6 py-8 sm:px-8 md:px-10',
+                    contentClassName
+                )}
+            >
+                <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+                    <div className="flex flex-1 flex-col gap-4 sm:flex-row sm:items-center">
+                        {iconContent && (
+                            <div className="flex size-14 items-center justify-center rounded-2xl bg-white/15 text-white shadow-[0_12px_30px_-15px_rgba(21,31,84,0.95)] sm:size-16">
+                                {iconContent}
+                            </div>
+                        )}
+
+                        <div className="space-y-2">
+                            <h1 className="text-2xl font-semibold leading-tight tracking-tight sm:text-3xl">
+                                {title}
+                            </h1>
+                            {description ? (
+                                <p className="max-w-3xl text-sm leading-relaxed text-white/85 sm:text-base">
+                                    {description}
+                                </p>
+                            ) : null}
+                        </div>
+                    </div>
+
+                    {actionNodes.length > 0 ? (
+                        <div className="flex flex-wrap items-center gap-3">
+                            {actionNodes}
+                        </div>
+                    ) : null}
+                </div>
+            </div>
+        </header>
+    );
+}

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -10,17 +10,18 @@ export default function AppSidebarLayout({ children, breadcrumbs = [] }: PropsWi
     return (
         <AppShell variant="sidebar">
             <AppSidebar />
-            <AppContent variant="sidebar" className="relative overflow-x-hidden bg-neutral-100 text-black">
+            <AppContent
+                variant="sidebar"
+                className="relative overflow-x-hidden bg-[#f3f5ff] text-black"
+            >
                 <div className="relative flex min-h-svh flex-col gap-6 pb-10">
                     <AppSidebarHeader breadcrumbs={breadcrumbs} />
 
-                    <section className="mx-6 flex flex-1 flex-col gap-8 rounded-xl bg-white px-0 py-0 shadow-sm md:mx-8">
-                        <div className="flex flex-1 flex-col gap-8 px-6 py-6 md:px-8">
-                            {children}
-                        </div>
-                    </section>
+                    <main className="flex flex-1 flex-col gap-8 px-4 pb-6 sm:px-6 md:px-8">
+                        {children}
+                    </main>
 
-                    <footer className="mx-6 flex items-center justify-center gap-3 rounded-xl bg-white px-6 py-4 text-xs text-neutral-600 shadow-sm md:mx-8">
+                    <footer className="mx-4 flex items-center justify-center gap-3 rounded-2xl bg-white/90 px-4 py-4 text-xs text-neutral-600 shadow-sm ring-1 ring-black/5 sm:mx-6 md:mx-8">
                         <AdminFooter />
                     </footer>
                 </div>

--- a/resources/js/pages/admin/academics/index.tsx
+++ b/resources/js/pages/admin/academics/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import CourseController from '@/actions/App/Http/Controllers/Admin/CourseController';
 import ProgramController from '@/actions/App/Http/Controllers/Admin/ProgramController';
+import AdminPageHeader from '@/components/admin/admin-page-header';
 import CourseListPanel from '@/components/admin/academics/course-list-panel';
 import ProgramListPanel from '@/components/admin/academics/program-list-panel';
 import { Button } from '@/components/ui/button';
@@ -208,7 +209,7 @@ export default function AcademicsIndex({
         if (currentTab === 'courses') {
             return (
                 <Link href={CourseController.create().url}>
-                    <Button className="bg-blue-600 text-white hover:bg-blue-700">
+                    <Button className="bg-[#ffb401] text-[#151f54] hover:bg-[#e6a000]">
                         {isZh ? '新增課程' : 'Create Course'}
                     </Button>
                 </Link>
@@ -217,7 +218,7 @@ export default function AcademicsIndex({
 
         return (
             <Link href={ProgramController.create().url}>
-                <Button className="bg-blue-600 text-white hover:bg-blue-700">
+                <Button className="bg-[#ffb401] text-[#151f54] hover:bg-[#e6a000]">
                     {isZh ? '新增學程' : 'Create Program'}
                 </Button>
             </Link>
@@ -230,13 +231,12 @@ export default function AcademicsIndex({
 
             <div className="min-h-screen">
                 <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">{pageTitle}</h1>
-                            <p className="mt-1 text-gray-600">{pageDescription}</p>
-                        </div>
-                        {actionButton()}
-                    </div>
+                    <AdminPageHeader
+                        title={pageTitle}
+                        description={pageDescription}
+                        icon={GraduationCap}
+                        actions={actionButton()}
+                    />
 
                     <div>
                         <div className="flex flex-wrap items-center gap-2 border-b border-gray-200">

--- a/resources/js/pages/admin/attachments/index.tsx
+++ b/resources/js/pages/admin/attachments/index.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import AdminPageHeader from '@/components/admin/admin-page-header';
 import AppLayout from '@/layouts/app-layout';
 import { cn } from '@/lib/utils';
 import { type SharedData } from '@/types';
@@ -377,18 +378,15 @@ export default function AttachmentsIndex({
 
             <div className="min-h-screen">
                 <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                                {isZh ? '附件管理' : 'Attachment Library'}
-                            </h1>
-                            <p className="mt-1 text-gray-600">
-                                {isZh
-                                    ? '集中管理公告與頁面所使用的檔案資源'
-                                    : 'Centralize files and links referenced across the site'}
-                            </p>
-                        </div>
-                    </div>
+                    <AdminPageHeader
+                        title={isZh ? '附件管理' : 'Attachment Library'}
+                        description={
+                            isZh
+                                ? '集中管理公告與頁面所使用的檔案資源'
+                                : 'Centralize files and links referenced across the site'
+                        }
+                        icon={FileText}
+                    />
 
                     <Card className="bg-white shadow-sm">
                         <CardHeader className="border-b border-gray-200">

--- a/resources/js/pages/admin/contact-messages/index.tsx
+++ b/resources/js/pages/admin/contact-messages/index.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import AdminPageHeader from '@/components/admin/admin-page-header';
 import AppLayout from '@/layouts/app-layout';
 import { cn } from '@/lib/utils';
 import { type SharedData } from '@/types';
@@ -276,18 +277,15 @@ export default function ContactMessagesIndex({ messages, filters = {}, perPageOp
 
             <div className="min-h-screen">
                 <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                                {isZh ? '聯絡訊息' : 'Contact Messages'}
-                            </h1>
-                            <p className="mt-1 text-gray-600">
-                                {isZh
-                                    ? '集中處理來自聯絡表單的詢問與回覆狀態'
-                                    : 'Track and respond to contact form submissions efficiently'}
-                            </p>
-                        </div>
-                    </div>
+                    <AdminPageHeader
+                        title={isZh ? '聯絡訊息' : 'Contact Messages'}
+                        description={
+                            isZh
+                                ? '集中處理來自聯絡表單的詢問與回覆狀態'
+                                : 'Track and respond to contact form submissions efficiently'
+                        }
+                        icon={Inbox}
+                    />
 
                     <Card className="bg-white shadow-sm">
                         <CardHeader className="border-b border-gray-200">

--- a/resources/js/pages/admin/labs/index.tsx
+++ b/resources/js/pages/admin/labs/index.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import AdminPageHeader from '@/components/admin/admin-page-header';
 import AppLayout from '@/layouts/app-layout';
 import { cn } from '@/lib/utils';
 import { type SharedData } from '@/types';
@@ -273,26 +274,26 @@ export default function LabsIndex({ labs, teachers, filters = {}, perPageOptions
 
             <div className="min-h-screen">
                 <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                                {isZh ? '實驗室管理' : 'Labs Management'}
-                            </h1>
-                            <p className="mt-1 text-gray-600">
-                                {isZh
-                                    ? '管理所有系上實驗室資料與顯示狀態'
-                                    : 'Manage department labs, visibility, and key contacts'}
-                            </p>
-                        </div>
-
-                        {auth.user?.role === 'admin' && (
-                            <Link href={LabController.create().url}>
-                                <Button className="bg-blue-600 text-white hover:bg-blue-700">
-                                    {isZh ? '新增實驗室' : 'Create Lab'}
-                                </Button>
-                            </Link>
-                        )}
-                    </div>
+                    <AdminPageHeader
+                        title={isZh ? '實驗室管理' : 'Labs Management'}
+                        description={
+                            isZh
+                                ? '管理所有系上實驗室資料與顯示狀態'
+                                : 'Manage department labs, visibility, and key contacts'
+                        }
+                        icon={FlaskConical}
+                        actions={
+                            auth.user?.role === 'admin'
+                                ? (
+                                      <Link href={LabController.create().url}>
+                                          <Button className="bg-[#ffb401] text-[#151f54] hover:bg-[#e6a000]">
+                                              {isZh ? '新增實驗室' : 'Create Lab'}
+                                          </Button>
+                                      </Link>
+                                  )
+                                : undefined
+                        }
+                    />
 
                     <Card className="bg-white shadow-sm">
                         <CardHeader className="border-b border-gray-200">

--- a/resources/js/pages/admin/posts/index.tsx
+++ b/resources/js/pages/admin/posts/index.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import AdminPageHeader from '@/components/admin/admin-page-header';
 import AppLayout from '@/layouts/app-layout';
 import { cn } from '@/lib/utils';
 import { type SharedData } from '@/types';
@@ -285,18 +286,20 @@ export default function PostsIndex({ posts, categories, filters = {}, perPageOpt
 
             <div className="min-h-screen">
                 <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">{isZh ? '公告管理' : 'Posts Management'}</h1>
-                            <p className="mt-2 text-gray-600">{isZh ? '管理系統公告與新聞' : 'Manage system announcements and news'}</p>
-                        </div>
-
-                        {auth.user && (
-                            <Link href={PostController.create().url}>
-                                <Button className="bg-blue-600 text-white hover:bg-blue-700">{isZh ? '新增公告' : 'Create Post'}</Button>
-                            </Link>
-                        )}
-                    </div>
+                    <AdminPageHeader
+                        title={isZh ? '公告管理' : 'Posts Management'}
+                        description={isZh ? '管理系統公告與新聞' : 'Manage system announcements and news'}
+                        icon={Calendar}
+                        actions={
+                            auth.user ? (
+                                <Link href={PostController.create().url}>
+                                    <Button className="bg-[#ffb401] text-[#151f54] hover:bg-[#e6a000]">
+                                        {isZh ? '新增公告' : 'Create Post'}
+                                    </Button>
+                                </Link>
+                            ) : undefined
+                        }
+                    />
 
                     <Card className="bg-white shadow-sm">
                         <CardHeader className="border-b border-gray-200">

--- a/resources/js/pages/admin/staff/index.tsx
+++ b/resources/js/pages/admin/staff/index.tsx
@@ -1,5 +1,6 @@
 import StaffController from '@/actions/App/Http/Controllers/Admin/StaffController';
 import * as TeacherController from '@/actions/App/Http/Controllers/Admin/TeacherController';
+import AdminPageHeader from '@/components/admin/admin-page-header';
 import StaffList, { type StaffListItem } from '@/components/admin/staff-list';
 import TeacherList, { type TeacherListProps } from '@/components/admin/teacher-list';
 import { Button } from '@/components/ui/button';
@@ -86,22 +87,37 @@ export default function StaffIndex({ initialTab, staff, teachers }: StaffIndexPr
 
             <div className="min-h-screen">
                 <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                                {isZh ? '師資與職員管理' : 'Faculty & Staff Management'}
-                            </h1>
-                            <p className="mt-1 text-gray-600">
-                                {isZh
-                                    ? '集中維護教師與行政職員資料，並掌握公開狀態。'
-                                    : 'Keep faculty and staff information in one place with consistent visibility controls.'}
-                            </p>
-                        </div>
-
-                        <div className="hidden text-blue-600 sm:block">
-                            <Users className="h-10 w-10" />
-                        </div>
-                    </div>
+                    <AdminPageHeader
+                        title={isZh ? '師資與職員管理' : 'Faculty & Staff Management'}
+                        description={
+                            isZh
+                                ? '集中維護教師與行政職員資料，並掌握公開狀態。'
+                                : 'Keep faculty and staff information in one place with consistent visibility controls.'
+                        }
+                        icon={Users}
+                        actions={
+                            canCreate ? (
+                                <Link
+                                    href={
+                                        activeTab === 'teachers'
+                                            ? TeacherController.create().url
+                                            : StaffController.create().url
+                                    }
+                                >
+                                    <Button className="bg-[#ffb401] text-[#151f54] hover:bg-[#e6a000]">
+                                        {activeTab === 'teachers'
+                                            ? isZh
+                                                ? '新增教師'
+                                                : 'Add Teacher'
+                                            : isZh
+                                            ? '新增職員'
+                                            : 'Add Staff'}
+                                    </Button>
+                                </Link>
+                            )
+                            : undefined
+                        }
+                    />
 
                     {isTeacher && (
                         <div className="rounded-md border border-blue-100 bg-blue-50 p-4 text-sm text-blue-800">

--- a/resources/js/pages/admin/teachers/index.tsx
+++ b/resources/js/pages/admin/teachers/index.tsx
@@ -1,9 +1,11 @@
 import * as TeacherController from '@/actions/App/Http/Controllers/Admin/TeacherController';
+import AdminPageHeader from '@/components/admin/admin-page-header';
 import TeacherList, { type TeacherListProps } from '@/components/admin/teacher-list';
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/app-layout';
 import { type SharedData } from '@/types';
 import { Head, Link, usePage } from '@inertiajs/react';
+import { GraduationCap } from 'lucide-react';
 
 export default function TeachersIndex({ teachers }: TeacherListProps) {
     const { auth, locale } = usePage<SharedData>().props;
@@ -15,26 +17,26 @@ export default function TeachersIndex({ teachers }: TeacherListProps) {
 
             <div className="min-h-screen">
                 <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                                {isZh ? '師資管理' : 'Faculty Management'}
-                            </h1>
-                            <p className="mt-1 text-gray-600">
-                                {isZh
-                                    ? '此頁面內容已整合至「師資與職員管理」，未來請改用新介面。'
-                                    : 'This view has been consolidated into the Faculty & Staff management workspace.'}
-                            </p>
-                        </div>
-
-                        {auth.user.role === 'admin' && (
-                            <Link href={TeacherController.create().url}>
-                                <Button className="bg-blue-600 text-white hover:bg-blue-700">
-                                    {isZh ? '新增教師' : 'Add Teacher'}
-                                </Button>
-                            </Link>
-                        )}
-                    </div>
+                    <AdminPageHeader
+                        title={isZh ? '師資管理' : 'Faculty Management'}
+                        description={
+                            isZh
+                                ? '此頁面內容已整合至「師資與職員管理」，未來請改用新介面。'
+                                : 'This view has been consolidated into the Faculty & Staff management workspace.'
+                        }
+                        icon={GraduationCap}
+                        actions={
+                            auth.user.role === 'admin'
+                                ? (
+                                      <Link href={TeacherController.create().url}>
+                                          <Button className="bg-[#ffb401] text-[#151f54] hover:bg-[#e6a000]">
+                                              {isZh ? '新增教師' : 'Add Teacher'}
+                                          </Button>
+                                      </Link>
+                                  )
+                                : undefined
+                        }
+                    />
 
                     <TeacherList teachers={teachers} />
                 </div>

--- a/resources/js/pages/admin/users/index.tsx
+++ b/resources/js/pages/admin/users/index.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import UserController from '@/actions/App/Http/Controllers/Admin/UserController';
+import AdminPageHeader from '@/components/admin/admin-page-header';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -268,26 +269,26 @@ export default function UsersIndex({ users, filters = {}, roleOptions, statusOpt
 
             <div className="min-h-screen">
                 <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                                {isZh ? '使用者管理' : 'User Management'}
-                            </h1>
-                            <p className="mt-1 text-gray-600">
-                                {isZh
-                                    ? '管理後台使用者角色與帳號狀態'
-                                    : 'Manage admin portal user roles and account status'}
-                            </p>
-                        </div>
-
-                        {auth.user?.role === 'admin' && (
-                            <Link href={UserController.create().url}>
-                                <Button className="bg-blue-600 text-white hover:bg-blue-700">
-                                    {isZh ? '新增使用者' : 'Create User'}
-                                </Button>
-                            </Link>
-                        )}
-                    </div>
+                    <AdminPageHeader
+                        title={isZh ? '使用者管理' : 'User Management'}
+                        description={
+                            isZh
+                                ? '管理後台使用者角色與帳號狀態'
+                                : 'Manage admin portal user roles and account status'
+                        }
+                        icon={UserCircle2}
+                        actions={
+                            auth.user?.role === 'admin'
+                                ? (
+                                      <Link href={UserController.create().url}>
+                                          <Button className="bg-[#ffb401] text-[#151f54] hover:bg-[#e6a000]">
+                                              {isZh ? '新增使用者' : 'Create User'}
+                                          </Button>
+                                      </Link>
+                                  )
+                                : undefined
+                        }
+                    />
 
                     <Card className="bg-white shadow-sm">
                         <CardHeader className="border-b border-gray-200">


### PR DESCRIPTION
## Summary
- 建立 `AdminPageHeader` 元件，提供品牌化漸層頁首並支援 icon 與多個操作按鈕
- 將師資、學程課程、使用者、公告、實驗室、附件、聯絡訊息與教師列表等頁面改用共用頁首並套用品牌色按鈕
- 調整 `AppSidebarLayout` 的背景與邊距設定，讓新頁首與主要內容區塊自然銜接

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccf0ee5d4483239cc85a78bf63125e