### PR TITLE
chore: adjust app content background

### DIFF
--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -12,7 +12,7 @@ export default function AppSidebarLayout({ children, breadcrumbs = [] }: PropsWi
             <AppSidebar />
             <AppContent
                 variant="sidebar"
-                className="relative overflow-x-hidden bg-[#f3f5ff] text-black"
+                className="relative overflow-x-hidden bg-white text-black"
             >
                 <div className="relative flex min-h-svh flex-col gap-6 pb-10">
                     <AppSidebarHeader breadcrumbs={breadcrumbs} />


### PR DESCRIPTION
## Summary
- update the AppContent wrapper in the sidebar layout to use a white background
- verified the existing text color, footer ring, and sidebar shadow remain suitable with the new background

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce1b86bbd48323a8dcba1b8d8febab