### PR TITLE
refactor: lighten dashboard layout surfaces

### DIFF
--- a/resources/js/styles/page-layouts.ts
+++ b/resources/js/styles/page-layouts.ts
@@ -101,7 +101,7 @@ function makeHero(
 }
 
 const brandPalette = palettes.brand;
-const dashboardPalette = palettes.dashboard;
+const dashboardPalette = palettes.brand;
 const midnightPalette = palettes.midnight;
 const warmPalette = palettes.warm;
 const slatePalette = palettes.slate;
@@ -227,13 +227,12 @@ export const pageLayouts: Record<PageKey, PageLayoutPreset> = {
         hero: makeHero(heroVariants.immersive, {
             title: 'Operations hero',
             description:
-                'Full-width gradient hero with summary metrics chips and administrative CTA buttons. Sets tone distinct from card grid.',
-            primary: cn(heroVariants.immersive.primary ?? '', 'gap-5 md:gap-6'),
+                'Full-width hero with summary metrics chips and administrative CTA buttons, kept bright and minimal to complement the app shell.',
+            primary: cn(heroVariants.immersive.primary ?? '', 'gap-5 text-neutral-900 md:gap-6'),
             surfaces: {
                 base: cn(
-                    'relative overflow-hidden',
-                    'bg-gradient-to-br from-[#151f54]/95 via-[#1f2a6d]/88 to-[#0b102f]/92',
-                    'after:absolute after:inset-0 after:content-[""] after:bg-[radial-gradient(circle_at_top_right,rgba(255,180,1,0.28),transparent_60%)] after:mix-blend-screen',
+                    'relative overflow-hidden bg-white',
+                    'after:absolute after:inset-0 after:bg-[radial-gradient(circle_at_top_right,rgba(255,180,1,0.08),transparent_60%)] after:content-[""]',
                 ),
             },
             notes: ['Hero includes breadcrumbs via App layout header, keep text concise and use accent chips for KPIs.'],
@@ -243,16 +242,12 @@ export const pageLayouts: Record<PageKey, PageLayoutPreset> = {
                 title: 'KPI metric grid',
                 description:
                     'Adaptive four-column metric grid with accent chips and minimal borders. Uses negative top margin to overlap hero for depth.',
-                section: cn(
-                    sectionVariants.metrics.section,
-                    'relative isolate bg-[radial-gradient(circle_at_top,#151f54_0%,#0f153f_65%,#0b102f_100%)] text-white/80',
-                ),
+                section: cn(sectionVariants.metrics.section, 'relative isolate bg-gray-50 text-neutral-900'),
                 container: cn(sectionVariants.metrics.container, 'relative'),
-                wrapper: cn(sectionVariants.metrics.wrapper, '-mt-20 md:-mt-24'),
+                wrapper: cn(sectionVariants.metrics.wrapper, '-mt-16 md:-mt-20'),
                 surfaces: {
                     card: cn(
-                        surfaceTokens.card,
-                        'bg-white/92 px-6 py-6 text-[#151f54] shadow-[0_38px_120px_-70px_rgba(21,31,84,0.58)] ring-1 ring-white/35',
+                        'rounded-3xl border border-slate-200 bg-white px-6 py-6 text-[#151f54] shadow-sm transition-shadow duration-200 hover:shadow-md',
                     ),
                 },
             }),
@@ -260,34 +255,31 @@ export const pageLayouts: Record<PageKey, PageLayoutPreset> = {
                 title: 'Administrative quick actions',
                 description:
                     'Responsive matrix of navigation tiles with icon badges and directional affordance. Uses equal height tiles for consistency.',
-                section: cn(sectionVariants.standardWide.section, 'bg-[#101b4f] text-white'),
-                container: cn(sectionVariants.standardWide.container, 'space-y-6'),
+                section: cn(sectionVariants.standardWide.section, 'bg-white text-neutral-900'),
+                container: cn(sectionVariants.standardWide.container, 'space-y-8'),
                 wrapper: 'grid gap-6 md:grid-cols-2 xl:grid-cols-3',
                 surfaces: {
                     action: cn(
-                        'glass-tile glass-spotlight group relative flex h-full flex-col justify-between gap-6 px-6 py-6 text-white transition duration-300 hover:-translate-y-1.5',
-                        'border border-white/15 shadow-[0_48px_140px_-70px_rgba(13,19,63,0.78)]',
+                        'group relative flex h-full flex-col justify-between gap-6 rounded-3xl border border-slate-200 bg-white px-6 py-6 text-neutral-900 shadow-sm transition duration-300 hover:-translate-y-1.5 hover:shadow-lg',
                     ),
-                    badge: 'glass-chip border-white/25 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.3em] text-white/80',
+                    badge:
+                        'inline-flex items-center justify-center rounded-full border border-slate-200 bg-gray-50 px-3 py-1 text-xs uppercase tracking-[0.3em] text-slate-600',
                 },
             }),
             activity: makeSection(sectionVariants.denseList, {
                 title: 'Recent activity & workflows',
                 description:
                     'Two-column layout: left uses timeline list for bulletins, right employs checklist-style panels for tasks. Replaces identical card rows.',
-                section: cn(
-                    sectionVariants.denseList.section,
-                    'bg-gradient-to-br from-[#0f153f] via-[#111b4f] to-[#182a73] text-white/85',
-                ),
-                container: cn(sectionVariants.denseList.container, 'space-y-8'),
+                section: cn(sectionVariants.denseList.section, 'bg-gray-50 text-neutral-800'),
+                container: cn(sectionVariants.denseList.container, 'space-y-10'),
                 wrapper: 'grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]',
-                primary: cn(surfaceTokens.cardMuted, 'px-6 py-6 backdrop-blur-lg text-white/90'),
-                secondary: cn(surfaceTokens.cardMuted, 'px-6 py-6 backdrop-blur-lg text-white/90'),
+                primary: 'rounded-3xl border border-slate-200 bg-white px-6 py-6 shadow-sm',
+                secondary: 'rounded-3xl border border-slate-200 bg-white px-6 py-6 shadow-sm',
                 surfaces: {
                     timeline: cn(surfaceTokens.timeline),
-                    timelineItem: cn(surfaceTokens.timelineItem, 'before:bg-[#ffb401] after:bg-white/12'),
+                    timelineItem: cn(surfaceTokens.timelineItem, 'before:bg-[#ffb401] after:bg-slate-200'),
                     taskRow:
-                        'glass-tile flex items-center justify-between rounded-2xl border-[#ffb401]/25 bg-[#151f54]/35 px-5 py-3 text-white/85 backdrop-blur-md',
+                        'flex items-center justify-between rounded-2xl border border-slate-200 bg-gray-50 px-5 py-3 text-neutral-700 shadow-sm transition-colors duration-200 hover:bg-white',
                 },
                 notes: ['Keep timeline entries short; ensure icons align with the refreshed brand palette.'],
             }),


### PR DESCRIPTION
## Summary
- switch the admin dashboard layout to the brand palette and refresh the hero with light surfaces
- restyle the dashboard metrics, quick actions, and activity sections with white and gray backgrounds plus borders and shadows for structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce1b7b7d20832393cd5d29601517e8