### PR TITLE
refactor: refresh dashboard cards with brand palette

### DIFF
--- a/resources/js/components/admin/dashboard/quick-action-card.tsx
+++ b/resources/js/components/admin/dashboard/quick-action-card.tsx
@@ -1,0 +1,54 @@
+import { cn } from '@/lib/utils';
+import { palettes, type DashboardTone } from '@/styles/layout-system';
+import { Link } from '@inertiajs/react';
+import { ChevronRight } from 'lucide-react';
+import type { ComponentType } from 'react';
+import { getDashboardToneStyle } from './tone-styles';
+
+const brand = palettes.brand;
+
+export interface QuickActionCardProps {
+    title: string;
+    description: string;
+    href: string;
+    icon: ComponentType<any>;
+    tone?: DashboardTone;
+    className?: string;
+}
+
+export function QuickActionCard({ title, description, href, icon: Icon, tone = 'primary', className }: QuickActionCardProps) {
+    const toneStyle = getDashboardToneStyle(tone);
+
+    return (
+        <Link
+            href={href}
+            prefetch
+            className={cn(
+                'group relative flex h-full min-h-[208px] flex-col justify-between gap-6 rounded-3xl px-6 py-6 text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-lg',
+                brand.surface,
+                brand.border,
+                brand.textPrimary,
+                brand.focusRing,
+                toneStyle.borderColor,
+                className,
+            )}
+        >
+            <span className={cn('absolute inset-x-6 top-0 h-1 rounded-full', toneStyle.indicator)} aria-hidden />
+            <div className="flex items-start justify-between">
+                <span className={cn('inline-flex items-center rounded-xl p-3 transition-colors duration-200', toneStyle.icon)}>
+                    <Icon className="size-5" />
+                </span>
+                <ChevronRight
+                    className={cn(
+                        'size-5 transition-transform duration-200 group-hover:translate-x-1.5',
+                        toneStyle.arrow,
+                    )}
+                />
+            </div>
+            <div className="space-y-3">
+                <h3 className={cn('text-lg font-semibold tracking-tight', toneStyle.accent)}>{title}</h3>
+                <p className={cn('text-sm leading-relaxed', brand.textMuted)}>{description}</p>
+            </div>
+        </Link>
+    );
+}

--- a/resources/js/components/admin/dashboard/stat-card.tsx
+++ b/resources/js/components/admin/dashboard/stat-card.tsx
@@ -1,0 +1,62 @@
+import { cn } from '@/lib/utils';
+import { palettes, type DashboardTone } from '@/styles/layout-system';
+import { TrendingUp } from 'lucide-react';
+import type { ComponentType } from 'react';
+import { getDashboardToneStyle } from './tone-styles';
+
+const brand = palettes.brand;
+
+export interface StatCardProps {
+    title: string;
+    value: string;
+    icon: ComponentType<any>;
+    trend?: string;
+    tone?: DashboardTone;
+    className?: string;
+}
+
+export function StatCard({ title, value, icon: Icon, trend, tone = 'primary', className }: StatCardProps) {
+    const toneStyle = getDashboardToneStyle(tone);
+
+    return (
+        <article
+            className={cn(
+                'relative overflow-hidden rounded-3xl px-6 py-6 shadow-sm transition-shadow duration-200 hover:shadow-md',
+                brand.surface,
+                brand.border,
+                brand.textPrimary,
+                toneStyle.borderColor,
+                className,
+            )}
+        >
+            <span className={cn('absolute inset-x-6 top-0 h-1 rounded-full', toneStyle.indicator)} aria-hidden />
+            <span
+                className={cn(
+                    'pointer-events-none absolute -right-10 top-1/2 h-32 w-32 -translate-y-1/2 rounded-full blur-3xl',
+                    toneStyle.soft,
+                )}
+                aria-hidden
+            />
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-3">
+                    <p className={cn('text-xs font-semibold uppercase tracking-[0.32em]', brand.textMuted)}>{title}</p>
+                    <p className="text-4xl font-semibold text-[#151f54] md:text-5xl">{value}</p>
+                    {trend && (
+                        <span
+                            className={cn(
+                                'inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold',
+                                toneStyle.chip,
+                            )}
+                        >
+                            <TrendingUp className="size-3" />
+                            {trend}
+                        </span>
+                    )}
+                </div>
+                <span className={cn('inline-flex items-center justify-center rounded-2xl p-3', toneStyle.icon)}>
+                    <Icon className="size-5" />
+                </span>
+            </div>
+        </article>
+    );
+}

--- a/resources/js/components/admin/dashboard/tone-styles.ts
+++ b/resources/js/components/admin/dashboard/tone-styles.ts
@@ -1,0 +1,49 @@
+import { type DashboardTone } from '@/styles/layout-system';
+
+export type DashboardToneStyle = {
+    icon: string;
+    accent: string;
+    chip: string;
+    indicator: string;
+    arrow: string;
+    subtle: string;
+    borderColor: string;
+    soft: string;
+};
+
+export const dashboardToneStyles: Record<DashboardTone, DashboardToneStyle> = {
+    primary: {
+        icon: 'bg-[#151f54]/10 text-[#151f54]',
+        accent: 'text-[#151f54]',
+        chip: 'bg-[#151f54]/12 text-[#151f54]',
+        indicator: 'bg-[#151f54]/10',
+        arrow: 'text-[#151f54]',
+        subtle: 'text-[#3d4a87]',
+        borderColor: 'border-[#cdd6ff]',
+        soft: 'bg-[#151f54]/6',
+    },
+    secondary: {
+        icon: 'bg-[#ffb401]/15 text-[#8a6300]',
+        accent: 'text-[#8a6300]',
+        chip: 'bg-[#ffb401]/15 text-[#8a6300]',
+        indicator: 'bg-[#ffb401]/20',
+        arrow: 'text-[#8a6300]',
+        subtle: 'text-[#a17000]',
+        borderColor: 'border-[#f8e7b5]',
+        soft: 'bg-[#ffb401]/10',
+    },
+    accent: {
+        icon: 'bg-[#fff809]/18 text-[#7a6b00]',
+        accent: 'text-[#7a6b00]',
+        chip: 'bg-[#fff809]/18 text-[#7a6b00]',
+        indicator: 'bg-[#fff809]/22',
+        arrow: 'text-[#7a6b00]',
+        subtle: 'text-[#8f7c00]',
+        borderColor: 'border-[#f2eca4]',
+        soft: 'bg-[#fff809]/14',
+    },
+};
+
+export function getDashboardToneStyle(tone: DashboardTone) {
+    return dashboardToneStyles[tone] ?? dashboardToneStyles.primary;
+}

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,9 +1,11 @@
 import AppLayout from '@/layouts/app-layout';
-import { GlassChip, GlassPanel, GlassTile } from '@/components/glass';
+import { QuickActionCard } from '@/components/admin/dashboard/quick-action-card';
+import { StatCard } from '@/components/admin/dashboard/stat-card';
+import { getDashboardToneStyle } from '@/components/admin/dashboard/tone-styles';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { getPageLayout } from '@/styles/page-layouts';
-import { dashboardTones, type DashboardTone } from '@/styles/layout-system';
+import { palettes, type DashboardTone } from '@/styles/layout-system';
 import { dashboard } from '@/routes';
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import { Head, Link, usePage } from '@inertiajs/react';
@@ -15,7 +17,6 @@ import {
     GraduationCap,
     Users,
     Mail,
-    TrendingUp,
     Clock,
     Calendar,
     Eye,
@@ -23,7 +24,7 @@ import {
     Inbox,
     ShieldCheck,
 } from 'lucide-react';
-import { useMemo } from 'react';
+import { useMemo, type ComponentType } from 'react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -32,134 +33,14 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-type StatTone = DashboardTone;
-
-type QuickTone = DashboardTone;
-
-function StatCard({
-    title,
-    value,
-    icon: Icon,
-    trend,
-    tone = 'primary',
-    className,
-}: {
-    title: string;
-    value: string;
-    icon: React.ComponentType<any>;
-    trend?: string;
-    tone?: StatTone;
-    className?: string;
-}) {
-    const tonePalette = dashboardTones[tone].stat;
-    return (
-        <GlassPanel
-            as="article"
-            shimmer
-            float="slow"
-            className={cn(
-                'relative overflow-hidden px-6 py-6 transition-shadow duration-300',
-                tonePalette.surface,
-                tonePalette.hover,
-                className,
-            )}
-        >
-            <span
-                className={cn(
-                    'pointer-events-none absolute -right-12 -top-16 h-40 w-40 rounded-full blur-[120px]',
-                    tonePalette.aura,
-                )}
-                aria-hidden
-            />
-            <div className="flex items-start justify-between gap-4">
-                <div className="space-y-3">
-                    <p className="text-xs font-semibold uppercase tracking-[0.32em] text-[#151f54]/65">{title}</p>
-                    <p className="text-4xl font-semibold text-[#151f54] md:text-5xl">{value}</p>
-                    {trend && (
-                        <GlassChip
-                            className={cn(
-                                'inline-flex items-center gap-2 px-3 py-1 text-xs font-semibold',
-                                tonePalette.chip,
-                                tonePalette.trend,
-                            )}
-                        >
-                            <TrendingUp className="size-3" />
-                            {trend}
-                        </GlassChip>
-                    )}
-                </div>
-                <span
-                    className={cn(
-                        'glass-ring inline-flex items-center justify-center rounded-2xl p-3',
-                        tonePalette.icon,
-                    )}
-                >
-                    <Icon className="size-5" />
-                </span>
-            </div>
-        </GlassPanel>
-    );
-}
-
-function QuickActionCard({
-    title,
-    description,
-    href,
-    icon: Icon,
-    tone = 'primary',
-    className,
-}: {
-    title: string;
-    description: string;
-    href: string;
-    icon: React.ComponentType<any>;
-    tone?: QuickTone;
-    className?: string;
-}) {
-    const tonePalette = dashboardTones[tone].action;
-
-    return (
-        <GlassTile
-            as={Link}
-            shimmer
-            spotlight
-            bleedShadow
-            float="medium"
-            href={href}
-            prefetch
-            className={cn(
-                'group relative flex h-full min-h-[208px] flex-col justify-between gap-6 overflow-hidden px-6 py-6 focus:outline-none transition-all duration-300 hover:-translate-y-1.5',
-                tonePalette.surface,
-                tonePalette.hover,
-                className,
-            )}
-        >
-            <div className="flex items-start justify-between">
-                <span className={cn('glass-ring inline-flex items-center rounded-xl p-3', tonePalette.icon)}>
-                    <Icon className="size-5" />
-                </span>
-                <ChevronRight
-                    className={cn(
-                        'size-5 transition-transform duration-300 group-hover:translate-x-1.5',
-                        tonePalette.arrow,
-                    )}
-                />
-            </div>
-            <div className="space-y-3">
-                <h3 className="text-lg font-semibold tracking-tight text-white">{title}</h3>
-                <p className={cn('text-sm leading-relaxed', tonePalette.body)}>{description}</p>
-            </div>
-        </GlassTile>
-    );
-}
-
+const brandPalette = palettes.brand;
 
 type HeroActionVariant = 'primary' | 'secondary';
 
 type HeroAction = {
     label: string;
     href: string;
-    icon: React.ComponentType<any>;
+    icon: ComponentType<any>;
     variant?: HeroActionVariant;
 };
 
@@ -178,10 +59,11 @@ function DashboardHeroActions({ actions }: { actions?: HeroAction[] }) {
                         size="lg"
                         variant={variant === 'primary' ? 'default' : 'secondary'}
                         className={cn(
-                            'group shadow-lg transition hover:-translate-y-0.5 md:min-w-[200px]',
+                            'group shadow-sm transition hover:-translate-y-0.5 md:min-w-[200px]',
+                            brandPalette.focusRing,
                             variant === 'secondary'
-                                ? 'border border-white/20 bg-primary/15 text-white hover:bg-primary/25'
-                                : 'text-primary-foreground',
+                                ? 'border border-[#151f54]/20 bg-white text-[#151f54] hover:bg-[#eef1ff]'
+                                : 'bg-[#151f54] text-white hover:bg-[#1f2a6d]',
                         )}
                     >
                         <Link href={href} prefetch className="inline-flex items-center gap-2">
@@ -195,6 +77,74 @@ function DashboardHeroActions({ actions }: { actions?: HeroAction[] }) {
     );
 }
 
+type TaskSummaryItemConfig = {
+    icon: ComponentType<any>;
+    label: string;
+    count: number;
+    tone: DashboardTone;
+};
+
+type ScheduleItemConfig = {
+    icon: ComponentType<any>;
+    label: string;
+    time: string;
+    tone: DashboardTone;
+};
+
+function TaskSummaryItem({ icon: Icon, label, count, tone }: TaskSummaryItemConfig) {
+    const toneStyle = getDashboardToneStyle(tone);
+
+    return (
+        <div
+            className={cn(
+                'flex items-center justify-between gap-3 rounded-2xl px-4 py-3 text-sm font-medium shadow-sm transition-colors duration-200 hover:bg-white',
+                brandPalette.backgroundMuted,
+                brandPalette.border,
+                brandPalette.textPrimary,
+                toneStyle.borderColor,
+            )}
+        >
+            <span className="flex items-center gap-3">
+                <span className={cn('inline-flex items-center justify-center rounded-xl p-2', toneStyle.icon)}>
+                    <Icon className="size-4" />
+                </span>
+                <span>{label}</span>
+            </span>
+            <span
+                className={cn(
+                    'inline-flex items-center justify-center rounded-full px-3 py-1 text-xs font-semibold',
+                    toneStyle.chip,
+                )}
+            >
+                {count}
+            </span>
+        </div>
+    );
+}
+
+function UpcomingScheduleItem({ icon: Icon, label, time, tone }: ScheduleItemConfig) {
+    const toneStyle = getDashboardToneStyle(tone);
+
+    return (
+        <div
+            className={cn(
+                'flex items-center gap-3 rounded-2xl px-4 py-3 text-sm shadow-sm',
+                brandPalette.surface,
+                brandPalette.border,
+                brandPalette.textPrimary,
+                toneStyle.borderColor,
+            )}
+        >
+            <span className={cn('inline-flex items-center justify-center rounded-xl p-2', toneStyle.icon)}>
+                <Icon className="size-4" />
+            </span>
+            <div className="flex flex-col">
+                <span className="font-medium">{label}</span>
+                <span className={cn('text-xs', toneStyle.subtle)}>{time}</span>
+            </div>
+        </div>
+    );
+}
 
 export default function Dashboard() {
     const { auth, locale } = usePage<SharedData>().props;
@@ -241,8 +191,8 @@ export default function Dashboard() {
         title: string;
         description: string;
         href: string;
-        icon: React.ComponentType<any>;
-        tone: QuickTone;
+        icon: ComponentType<any>;
+        tone: DashboardTone;
         roles?: UserRole[];
     };
 
@@ -309,54 +259,39 @@ export default function Dashboard() {
         date: '2024-03-12',
     }));
 
-    const taskSummary = [
+    const taskSummary: TaskSummaryItemConfig[] = [
         {
             icon: Mail,
             label: isZh ? '新聯絡訊息' : 'New contact messages',
             count: 3,
-            surface:
-                'bg-gradient-to-br from-[#151f54]/80 via-[#1f2a6d]/65 to-[#0f153f]/70 border-[#151f54]/45 text-white/85 shadow-[0_28px_90px_-58px_rgba(21,31,84,0.52)]',
-            chip: 'bg-[#ffb401]/25 text-[#151f54]',
-            iconColor: 'text-[#ffb401]',
+            tone: 'primary',
         },
         {
             icon: Users,
             label: isZh ? '待審核使用者' : 'Pending approvals',
             count: 1,
-            surface:
-                'bg-gradient-to-br from-[#2b1a00]/80 via-[#8a6300]/65 to-[#ffb401]/58 border-[#ffb401]/45 text-white/90 shadow-[0_28px_90px_-58px_rgba(82,48,0,0.55)]',
-            chip: 'bg-[#ffb401]/25 text-[#2b1a00]',
-            iconColor: 'text-[#ffb401]',
+            tone: 'secondary',
         },
         {
             icon: ShieldCheck,
             label: isZh ? '權限調整請求' : 'Permission requests',
             count: 2,
-            surface:
-                'bg-gradient-to-br from-[#151f54]/78 via-[#3d3600]/62 to-[#fff809]/58 border-[#fff809]/35 text-white/90 shadow-[0_28px_90px_-58px_rgba(21,31,84,0.5)]',
-            chip: 'bg-[#fff809]/30 text-[#151f54]',
-            iconColor: 'text-[#fff809]',
+            tone: 'accent',
         },
     ];
 
-    const upcomingSchedule = [
+    const upcomingSchedule: ScheduleItemConfig[] = [
         {
             icon: Calendar,
             label: isZh ? '系務會議' : 'Faculty council',
             time: isZh ? '明日下午 14:00' : 'Tomorrow • 2:00 PM',
-            surface:
-                'bg-gradient-to-br from-[#151f54]/85 via-[#1f2a6d]/70 to-[#0f153f]/65 border-[#151f54]/45 text-white/90',
-            subtle: 'text-white/65',
-            iconColor: 'text-[#ffb401]',
+            tone: 'primary',
         },
         {
             icon: Clock,
             label: isZh ? '課程公告排程' : 'Course bulletin release',
             time: isZh ? '週五上午 09:00' : 'Friday • 9:00 AM',
-            surface:
-                'bg-gradient-to-br from-[#2b1a00]/80 via-[#8a6300]/60 to-[#ffb401]/55 border-[#ffb401]/40 text-white/90',
-            subtle: 'text-white/65',
-            iconColor: 'text-[#fff809]',
+            tone: 'secondary',
         },
     ];
 
@@ -370,14 +305,16 @@ export default function Dashboard() {
                         <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
                             <div className="flex flex-1 flex-col gap-6">
                                 <div className="space-y-4">
-                                    <span className="inline-flex w-fit items-center gap-2 rounded-full bg-white/15 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+                                    <span
+                                        className="inline-flex w-fit items-center gap-2 rounded-full border border-[#d5dcf8] bg-[#f4f6ff] px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-[#3d4a87]"
+                                    >
                                         NCUE CSIE
                                     </span>
                                     <div className="space-y-2">
-                                        <h1 className="text-3xl font-semibold text-white md:text-4xl">
+                                        <h1 className="text-3xl font-semibold text-[#151f54] md:text-4xl">
                                             {isZh ? '系統管理後台總覽' : 'Administrative control center'}
                                         </h1>
-                                        <p className="max-w-xl text-white/75">
+                                        <p className="max-w-xl text-slate-600">
                                             {isZh
                                                 ? '快速掌握公告、師資、實驗室與課程等核心指標，從這裡展開每日的營運管理。'
                                                 : 'Stay on top of announcements, faculty, labs, and courses—all the operational essentials in one place.'}
@@ -386,18 +323,20 @@ export default function Dashboard() {
                                 </div>
                                 <div className="grid w-full gap-3 sm:grid-cols-2 sm:gap-4 md:max-w-2xl">
                                     {kpiSummary.map((item) => (
-                                        <GlassTile
+                                        <div
                                             key={item.label}
-                                            shimmer
-                                            float="slow"
-                                            className="w-full px-5 py-4 text-sm text-white/85 backdrop-blur-sm"
+                                            className={cn(
+                                                'flex w-full flex-col gap-1 rounded-2xl px-5 py-4 shadow-sm',
+                                                brandPalette.surface,
+                                                brandPalette.border,
+                                            )}
                                         >
-                                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/60">
+                                            <p className={cn('text-xs font-semibold uppercase tracking-[0.35em]', brandPalette.textMuted)}>
                                                 {item.label}
                                             </p>
-                                            <p className="text-xl font-semibold text-white">{item.value}</p>
-                                            <span className="text-xs text-white/75">{item.trend}</span>
-                                        </GlassTile>
+                                            <p className="text-xl font-semibold text-[#151f54]">{item.value}</p>
+                                            <span className={cn('text-xs font-medium', brandPalette.textMuted)}>{item.trend}</span>
+                                        </div>
                                     ))}
                                 </div>
                             </div>
@@ -443,10 +382,10 @@ export default function Dashboard() {
                 <div className={cn(quickActionsLayout.container, 'space-y-6 w-full')}>
                     <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                         <div>
-                            <h2 className="text-xl font-semibold text-white md:text-2xl">
+                            <h2 className="text-xl font-semibold text-[#151f54] md:text-2xl">
                                 {isZh ? '快速操作' : 'Quick actions'}
                             </h2>
-                            <p className="text-sm text-white/70">
+                            <p className="text-sm text-slate-600">
                                 {isZh
                                     ? '常用管理任務整理於此，協助您迅速完成日常工作。'
                                     : 'Access the most common management tasks without digging through menus.'}
@@ -454,7 +393,7 @@ export default function Dashboard() {
                         </div>
                         <Link
                             href="/admin"
-                            className="inline-flex items-center gap-2 rounded-full border border-[#ffb401]/45 px-4 py-2 text-sm font-medium text-[#ffb401] transition hover:bg-[#ffb401]/20 hover:text-[#151f54]"
+                            className="inline-flex items-center gap-2 rounded-full border border-[#151f54]/20 bg-white px-4 py-2 text-sm font-medium text-[#151f54] transition hover:bg-[#eef1ff]"
                         >
                             {isZh ? '檢視完整控制台' : 'Open full control center'}
                             <ChevronRight className="size-4 text-current" />
@@ -478,16 +417,16 @@ export default function Dashboard() {
                     <div className={cn(activityLayout.primary)}>
                         <div className="flex items-center justify-between">
                             <div>
-                                <h3 className="text-lg font-semibold text-white md:text-xl">
+                                <h3 className="text-lg font-semibold text-[#151f54] md:text-xl">
                                     {isZh ? '最新公告摘要' : 'Recent bulletin highlights'}
                                 </h3>
-                                <p className="text-sm text-white/70">
+                                <p className="text-sm text-slate-600">
                                     {isZh ? '檢視最新置頂與近期公告' : 'Stay synced with the latest published updates.'}
                                 </p>
                             </div>
                             <Link
                                 href="/admin/posts"
-                                className="inline-flex items-center gap-2 rounded-full bg-[#ffb401]/15 px-3 py-1 text-sm font-medium text-[#ffb401] transition hover:bg-[#ffb401]/25 hover:text-[#151f54]"
+                                className="inline-flex items-center gap-2 rounded-full border border-[#151f54]/20 bg-white px-3 py-1 text-sm font-medium text-[#151f54] transition hover:bg-[#eef1ff]"
                             >
                                 {isZh ? '查看全部' : 'View all'}
                                 <ChevronRight className="size-4 text-current" />
@@ -499,11 +438,11 @@ export default function Dashboard() {
                                     <div className="flex flex-col gap-2">
                                         <Link
                                             href={`/admin/posts/${item.id}`}
-                                            className="text-base font-semibold text-white transition hover:text-[#ffb401]"
+                                            className="text-base font-semibold text-[#151f54] transition hover:text-[#8a6300]"
                                         >
                                             {item.title}
                                         </Link>
-                                        <div className="flex flex-wrap items-center gap-2 text-xs text-white/70">
+                                        <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600">
                                             <span className="inline-flex items-center gap-1">
                                                 <Clock className="size-3" />
                                                 {item.time}
@@ -525,50 +464,22 @@ export default function Dashboard() {
 
                     <aside className={cn(activityLayout.secondary)}>
                         <div className="space-y-4">
-                            <h3 className="text-lg font-semibold text-white">
+                            <h3 className="text-lg font-semibold text-[#151f54]">
                                 {isZh ? '待處理事項' : 'Pending tasks'}
                             </h3>
                             <div className="space-y-3">
                                 {taskSummary.map((task) => (
-                                    <GlassTile
-                                        key={task.label}
-                                        shimmer
-                                        className={cn(
-                                            'flex items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-white/90',
-                                            task.surface,
-                                        )}
-                                    >
-                                        <span className="flex items-center gap-2">
-                                            <task.icon className={cn('size-4', task.iconColor)} />
-                                            {task.label}
-                                        </span>
-                                        <GlassChip className={cn('px-3 py-1 text-xs font-semibold text-white', task.chip)}>
-                                            {task.count}
-                                        </GlassChip>
-                                    </GlassTile>
+                                    <TaskSummaryItem key={task.label} {...task} />
                                 ))}
                             </div>
                         </div>
                         <div className="space-y-4">
-                            <h3 className="text-lg font-semibold text-white">
+                            <h3 className="text-lg font-semibold text-[#151f54]">
                                 {isZh ? '即將到來' : 'Upcoming schedule'}
                             </h3>
                             <div className="space-y-3">
                                 {upcomingSchedule.map((item) => (
-                                    <GlassTile
-                                        key={item.label}
-                                        float="slow"
-                                        className={cn(
-                                            'flex items-center gap-3 px-4 py-3 text-sm text-white/85',
-                                            item.surface,
-                                        )}
-                                    >
-                                        <item.icon className={cn('size-4', item.iconColor)} />
-                                        <div className="flex flex-col">
-                                            <span className="font-medium text-white">{item.label}</span>
-                                            <span className={cn('text-xs', item.subtle)}>{item.time}</span>
-                                        </div>
-                                    </GlassTile>
+                                    <UpcomingScheduleItem key={item.label} {...item} />
                                 ))}
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- extract reusable dashboard stat and quick action cards with brand palette styling
- centralize dashboard tone styling helpers and apply tone-based accents for tasks and schedule
- restyle dashboard page content for white surfaces and semantic data tones

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce1fdf6e908323b1966e2e7d6f1411