### PR TITLE
feat: add role-based manage layout

### DIFF
--- a/resources/js/components/manage/admin/sidebar.tsx
+++ b/resources/js/components/manage/admin/sidebar.tsx
@@ -1,6 +1,6 @@
 import { AppSidebar } from '@/components/app-sidebar';
 
 export default function AdminSidebar() {
-	// reuse existing AppSidebar which already contains admin navigation
-	return <AppSidebar />;
+    // 直接沿用現有的 AppSidebar，維持完整的管理導覽
+    return <AppSidebar />;
 }

--- a/resources/js/components/manage/teacher/sidebar.tsx
+++ b/resources/js/components/manage/teacher/sidebar.tsx
@@ -1,6 +1,54 @@
-import { AppSidebar } from '@/components/app-sidebar';
+import AppLogo from '@/components/app-logo';
+import { NavFooter } from '@/components/nav-footer';
+import { NavMain } from '@/components/nav-main';
+import { NavUser } from '@/components/nav-user';
+import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { type NavItem, type SharedData } from '@/types';
+import { Link, usePage } from '@inertiajs/react';
+import { LayoutGrid, Megaphone, Beaker, NotebookPen, Settings, HelpCircle } from 'lucide-react';
 
 export default function TeacherSidebar() {
-    // For now reuse AppSidebar; customize later if teacher nav differs
-    return <AppSidebar />;
+    const { locale } = usePage<SharedData>().props;
+    const isZh = locale?.toLowerCase() === 'zh-tw';
+
+    const mainNavItems: NavItem[] = [
+        { title: isZh ? '教職儀表板' : 'Teaching Home', href: '/manage/dashboard', icon: LayoutGrid },
+        { title: isZh ? '公告管理' : 'Announcements', href: '/manage/teacher/posts', icon: Megaphone },
+        { title: isZh ? '研究管理' : 'Research', href: '/manage/teacher/labs', icon: Beaker },
+        { title: isZh ? '課程與活動' : 'Courses & Activities', href: '/manage/teacher/courses', icon: NotebookPen },
+        { title: isZh ? '個人設定' : 'Profile Settings', href: '/settings/profile', icon: Settings },
+    ];
+
+    const footerNavItems: NavItem[] = [
+        {
+            title: isZh ? '教學資源指南' : 'Teaching Guide',
+            href: 'https://github.com/Grasonyang/csie_web',
+            icon: HelpCircle,
+        },
+    ];
+
+    return (
+        <Sidebar collapsible="icon" variant="inset">
+            <SidebarHeader>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <SidebarMenuButton size="lg" asChild>
+                            <Link href="/manage/dashboard" prefetch>
+                                <AppLogo />
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
+            </SidebarHeader>
+
+            <SidebarContent>
+                <NavMain items={mainNavItems} label={isZh ? '教學管理' : 'Teaching'} />
+            </SidebarContent>
+
+            <SidebarFooter>
+                <NavFooter items={footerNavItems} className="mt-auto" />
+                <NavUser />
+            </SidebarFooter>
+        </Sidebar>
+    );
 }

--- a/resources/js/components/manage/user/sidebar.tsx
+++ b/resources/js/components/manage/user/sidebar.tsx
@@ -1,6 +1,53 @@
-import { AppSidebar } from '@/components/app-sidebar';
+import AppLogo from '@/components/app-logo';
+import { NavFooter } from '@/components/nav-footer';
+import { NavMain } from '@/components/nav-main';
+import { NavUser } from '@/components/nav-user';
+import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { type NavItem, type SharedData } from '@/types';
+import { Link, usePage } from '@inertiajs/react';
+import { LayoutGrid, User, Palette, ShieldCheck, LifeBuoy } from 'lucide-react';
 
 export default function UserSidebar() {
-    // For now reuse AppSidebar; customize later if user nav differs
-    return <AppSidebar />;
+    const { locale } = usePage<SharedData>().props;
+    const isZh = locale?.toLowerCase() === 'zh-tw';
+
+    const mainNavItems: NavItem[] = [
+        { title: isZh ? '會員首頁' : 'Member Home', href: '/manage/dashboard', icon: LayoutGrid },
+        { title: isZh ? '個人資料' : 'Profile', href: '/settings/profile', icon: User },
+        { title: isZh ? '外觀偏好' : 'Appearance', href: '/settings/appearance', icon: Palette },
+        { title: isZh ? '安全設定' : 'Security', href: '/settings/password', icon: ShieldCheck },
+    ];
+
+    const footerNavItems: NavItem[] = [
+        {
+            title: isZh ? '協助中心' : 'Support',
+            href: 'mailto:csie@cc.ncue.edu.tw',
+            icon: LifeBuoy,
+        },
+    ];
+
+    return (
+        <Sidebar collapsible="icon" variant="inset">
+            <SidebarHeader>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <SidebarMenuButton size="lg" asChild>
+                            <Link href="/manage/dashboard" prefetch>
+                                <AppLogo />
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
+            </SidebarHeader>
+
+            <SidebarContent>
+                <NavMain items={mainNavItems} label={isZh ? '會員專區' : 'Member Area'} />
+            </SidebarContent>
+
+            <SidebarFooter>
+                <NavFooter items={footerNavItems} className="mt-auto" />
+                <NavUser />
+            </SidebarFooter>
+        </Sidebar>
+    );
 }

--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -2,14 +2,15 @@ import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, Sideba
 import { type NavItem } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
 
-export function NavMain({ items = [] }: { items: NavItem[] }) {
+export function NavMain({ items = [], label }: { items: NavItem[]; label?: string }) {
     const page = usePage<any>();
     const { locale } = page.props;
     const isZh = locale?.toLowerCase() === 'zh-tw';
+    const groupLabel = label ?? (isZh ? '系統功能' : 'Platform');
 
     return (
         <SidebarGroup className="px-2 py-0">
-            <SidebarGroupLabel>{isZh ? "系統功能" : "Platform"}</SidebarGroupLabel>
+            <SidebarGroupLabel>{groupLabel}</SidebarGroupLabel>
             <SidebarMenu>
                 {items.map((item) => (
                     <SidebarMenuItem key={item.title}>

--- a/resources/js/layouts/manage/manage-layout.tsx
+++ b/resources/js/layouts/manage/manage-layout.tsx
@@ -5,34 +5,49 @@ import TeacherManageSidebar from '@/components/manage/teacher/sidebar';
 import UserManageSidebar from '@/components/manage/user/sidebar';
 import { AppSidebarHeader } from '@/components/app-sidebar-header';
 import AdminFooter from '@/components/admin-footer';
-import { type PropsWithChildren } from 'react';
+import { type PropsWithChildren, useMemo } from 'react';
 import { usePage } from '@inertiajs/react';
-import { type SharedData } from '@/types';
+import { type BreadcrumbItem, type SharedData } from '@/types';
 
 interface ManageLayoutProps {
     role?: 'admin' | 'teacher' | 'user';
+    breadcrumbs?: BreadcrumbItem[];
 }
 
-export default function ManageLayout({ children }: PropsWithChildren<ManageLayoutProps>) {
-    const { locale, auth } = usePage<SharedData>().props;
-    // Prefer explicit role from auth, fallback to user role
-    const role = (auth?.user?.role as 'admin' | 'teacher' | 'user') ?? 'user';
+export default function ManageLayout({
+    children,
+    breadcrumbs = [],
+    role: roleOverride,
+}: PropsWithChildren<ManageLayoutProps>) {
+    const { auth } = usePage<SharedData>().props;
+    // 依據認證資訊判斷目前角色，若有外部覆寫則以參數優先
+    const role = (roleOverride ?? auth?.user?.role ?? 'user') as 'admin' | 'teacher' | 'user';
 
-    const Sidebar = role === 'admin' ? AdminManageSidebar : role === 'teacher' ? TeacherManageSidebar : UserManageSidebar;
+    const Sidebar = useMemo(() => {
+        if (role === 'admin') {
+            return AdminManageSidebar;
+        }
+
+        if (role === 'teacher') {
+            return TeacherManageSidebar;
+        }
+
+        return UserManageSidebar;
+    }, [role]);
 
     return (
         <AppShell variant="sidebar">
             <Sidebar />
 
-            <AppContent variant="sidebar" className="relative overflow-x-hidden bg-white text-black">
-                <div className="relative flex min-h-svh flex-col gap-6 pb-10">
-                    <AppSidebarHeader />
+            <AppContent variant="sidebar" className="relative overflow-x-hidden bg-neutral-50 text-neutral-900">
+                <div className="flex min-h-svh flex-col">
+                    <AppSidebarHeader breadcrumbs={breadcrumbs} />
 
-                    <main className="flex flex-1 flex-col gap-8 px-4 pb-6 sm:px-6 md:px-8">
-                        {children}
+                    <main className="flex-1 px-4 py-8 sm:px-6 lg:px-8">
+                        <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">{children}</div>
                     </main>
 
-                    <footer className="mx-4 flex items-center justify-center gap-3 rounded-2xl bg-white/90 px-4 py-4 text-xs text-neutral-600 shadow-sm ring-1 ring-black/5 sm:mx-6 md:mx-8">
+                    <footer className="mx-4 mb-6 mt-auto flex items-center justify-center gap-3 rounded-2xl bg-white px-4 py-4 text-xs text-neutral-600 shadow-sm ring-1 ring-black/5 sm:mx-6 md:mx-8">
                         <AdminFooter />
                     </footer>
                 </div>


### PR DESCRIPTION
## Summary
- adjust manage layout to inject breadcrumbs, cleaner surface styling, and role-derived sidebar selection
- add dedicated teacher and user sidebars with localized navigation groups and footer resources
- extend NavMain to support custom section labels so each role can present tailored copy

## Testing
- ❌ `npm run types` *(fails: existing unresolved module aliases such as @/routes and admin controller action imports)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7e0cfc0c83239b8c858a77533f57