### PR TITLE
Fix dashboard redirects after authentication

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,11 @@ use App\Http\Controllers\HomeController;
 
 Route::get('/', HomeController::class)->name('home');
 
+// 已登入使用者造訪舊的 /dashboard 路徑時轉向至管理後台首頁
+Route::middleware(['auth', 'verified'])->get('/dashboard', function () {
+    return redirect()->route('manage.dashboard');
+})->name('dashboard');
+
 // Public Routes
 Route::group(['as' => 'public.'], function () {
     // Labs


### PR DESCRIPTION
## Summary
- add an authenticated /dashboard route that redirects to the manage dashboard

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cef3ba4f248323944d691ff6f33704