### PR TITLE
feat: 建立管理後台使用者管理介面

### DIFF
--- a/resources/js/components/manage/users/user-form.tsx
+++ b/resources/js/components/manage/users/user-form.tsx
@@ -1,0 +1,277 @@
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+import { useTranslator } from '@/hooks/use-translator';
+import { Link, useForm, type InertiaFormProps } from '@inertiajs/react';
+import type { FormEventHandler } from 'react';
+
+export interface SelectOption {
+    value: string;
+    label: string;
+}
+
+export interface UserFormValues {
+    name: string;
+    email: string;
+    role: string;
+    status: string;
+    locale: string;
+    password: string;
+    password_confirmation: string;
+    email_verified: boolean;
+}
+
+interface UserFormProps {
+    mode: 'create' | 'edit';
+    initialValues: UserFormValues;
+    roleOptions: SelectOption[];
+    statusOptions: SelectOption[];
+    cancelUrl: string;
+    onSubmit: (form: InertiaFormProps<UserFormValues>) => void;
+    isDeleted?: boolean;
+}
+
+export default function UserForm({
+    mode,
+    initialValues,
+    roleOptions,
+    statusOptions,
+    cancelUrl,
+    onSubmit,
+    isDeleted = false,
+}: UserFormProps) {
+    const { t, isZh } = useTranslator('manage');
+
+    // 依據模式切換送出按鈕文案
+    const submitLabel = mode === 'create'
+        ? t('users.form.actions.create', isZh ? '建立使用者' : 'Create user')
+        : t('users.form.actions.update', isZh ? '更新資料' : 'Update user');
+    const processingLabel = mode === 'create'
+        ? t('users.form.actions.creating', isZh ? '建立中…' : 'Creating…')
+        : t('users.form.actions.updating', isZh ? '更新中…' : 'Updating…');
+
+    const form = useForm<UserFormValues>({
+        name: initialValues.name,
+        email: initialValues.email,
+        role: initialValues.role,
+        status: initialValues.status,
+        locale: initialValues.locale,
+        password: initialValues.password,
+        password_confirmation: initialValues.password_confirmation,
+        email_verified: initialValues.email_verified,
+    });
+
+    const { data, setData, errors, processing } = form;
+
+    const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+        event.preventDefault();
+        onSubmit(form);
+    };
+
+    const renderOptionLabel = (option: SelectOption, type: 'role' | 'status') => {
+        if (type === 'role') {
+            return t(`users.roles.${option.value}`, option.label);
+        }
+
+        return t(`users.status.${option.value}`, option.label);
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-6">
+            {isDeleted && (
+                <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                    {t(
+                        'users.form.deleted_notice',
+                        isZh ? '此帳號已被移至回收桶，儲存變更前請先於列表還原。' : 'This account is in the recycle bin. Restore it before saving changes.',
+                    )}
+                </div>
+            )}
+
+            <Card className="border-0 bg-white shadow-sm ring-1 ring-black/5">
+                <CardHeader className="border-b border-neutral-100">
+                    <CardTitle className="text-lg font-semibold text-[#151f54]">
+                        {t('users.form.sections.profile', isZh ? '基本資料' : 'Profile')}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-6 py-6">
+                    <div className="grid gap-6 md:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="user-name" className="text-sm font-medium text-neutral-700">
+                                {t('users.form.fields.name.label', isZh ? '姓名' : 'Name')}
+                            </Label>
+                            <Input
+                                id="user-name"
+                                value={data.name}
+                                onChange={(event) => setData('name', event.target.value)}
+                                placeholder={t('users.form.fields.name.placeholder', isZh ? '請輸入姓名' : 'Enter full name')}
+                                required
+                            />
+                            <InputError message={errors.name} />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="user-email" className="text-sm font-medium text-neutral-700">
+                                {t('users.form.fields.email.label', isZh ? '電子郵件' : 'Email')}
+                            </Label>
+                            <Input
+                                id="user-email"
+                                type="email"
+                                value={data.email}
+                                onChange={(event) => setData('email', event.target.value)}
+                                placeholder={t('users.form.fields.email.placeholder', isZh ? 'name@example.com' : 'name@example.com')}
+                                required
+                            />
+                            <InputError message={errors.email} />
+                        </div>
+                    </div>
+
+                    <div className="grid gap-6 md:grid-cols-3">
+                        <div className="space-y-2">
+                            <Label htmlFor="user-role" className="text-sm font-medium text-neutral-700">
+                                {t('users.form.fields.role.label', isZh ? '系統角色' : 'Role')}
+                            </Label>
+                            <Select
+                                id="user-role"
+                                value={data.role}
+                                onChange={(event) => setData('role', event.target.value)}
+                            >
+                                {roleOptions.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {renderOptionLabel(option, 'role')}
+                                    </option>
+                                ))}
+                            </Select>
+                            <InputError message={errors.role} />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="user-status" className="text-sm font-medium text-neutral-700">
+                                {t('users.form.fields.status.label', isZh ? '帳號狀態' : 'Status')}
+                            </Label>
+                            <Select
+                                id="user-status"
+                                value={data.status}
+                                onChange={(event) => setData('status', event.target.value)}
+                            >
+                                {statusOptions.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {renderOptionLabel(option, 'status')}
+                                    </option>
+                                ))}
+                            </Select>
+                            <InputError message={errors.status} />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="user-locale" className="text-sm font-medium text-neutral-700">
+                                {t('users.form.fields.locale.label', isZh ? '介面語系' : 'Locale preference')}
+                            </Label>
+                            <Select
+                                id="user-locale"
+                                value={data.locale}
+                                onChange={(event) => setData('locale', event.target.value)}
+                            >
+                                <option value="">
+                                    {t('users.form.fields.locale.system', isZh ? '跟隨系統預設' : 'System default')}
+                                </option>
+                                <option value="zh-TW">{t('users.form.fields.locale.zh', '繁體中文')}</option>
+                                <option value="en">{t('users.form.fields.locale.en', 'English')}</option>
+                            </Select>
+                            <InputError message={errors.locale} />
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card className="border-0 bg-white shadow-sm ring-1 ring-black/5">
+                <CardHeader className="border-b border-neutral-100">
+                    <CardTitle className="text-lg font-semibold text-[#151f54]">
+                        {t('users.form.sections.security', isZh ? '安全設定' : 'Security settings')}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-6 py-6">
+                    <div className="grid gap-6 md:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="user-password" className="text-sm font-medium text-neutral-700">
+                                {t('users.form.fields.password.label', isZh ? '登入密碼' : 'Password')}
+                            </Label>
+                            <Input
+                                id="user-password"
+                                type="password"
+                                value={data.password}
+                                onChange={(event) => setData('password', event.target.value)}
+                                placeholder={t(
+                                    'users.form.fields.password.placeholder',
+                                    isZh ? '至少 8 碼，英數混合最佳' : 'Minimum 8 characters',
+                                )}
+                                autoComplete="new-password"
+                            />
+                            <InputError message={errors.password} />
+                            <p className="text-xs text-neutral-500">
+                                {mode === 'create'
+                                    ? t('users.form.fields.password.help_create', isZh ? '建立新帳號時必填。' : 'Required for new accounts.')
+                                    : t('users.form.fields.password.help_edit', isZh ? '若不需變更請留空。' : 'Leave blank to keep current password.')}
+                            </p>
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="user-password-confirm" className="text-sm font-medium text-neutral-700">
+                                {t('users.form.fields.password_confirmation.label', isZh ? '確認密碼' : 'Confirm password')}
+                            </Label>
+                            <Input
+                                id="user-password-confirm"
+                                type="password"
+                                value={data.password_confirmation}
+                                onChange={(event) => setData('password_confirmation', event.target.value)}
+                                placeholder={t(
+                                    'users.form.fields.password_confirmation.placeholder',
+                                    isZh ? '再次輸入密碼' : 'Re-enter the password',
+                                )}
+                                autoComplete="new-password"
+                            />
+                            <InputError message={errors.password_confirmation} />
+                        </div>
+                    </div>
+
+                    <div className="flex items-center gap-3 rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3">
+                        <Checkbox
+                            id="user-email-verified"
+                            checked={data.email_verified}
+                            onCheckedChange={(checked) => setData('email_verified', Boolean(checked))}
+                        />
+                        <div className="space-y-1">
+                            <Label htmlFor="user-email-verified" className="text-sm font-medium text-neutral-700">
+                                {t('users.form.fields.email_verified.label', isZh ? '標記為已驗證信箱' : 'Mark email as verified')}
+                            </Label>
+                            <p className="text-xs text-neutral-500">
+                                {t(
+                                    'users.form.fields.email_verified.help',
+                                    isZh
+                                        ? '啟用後系統將視為已完成信箱驗證。'
+                                        : 'Enable to treat this address as verified.',
+                                )}
+                            </p>
+                        </div>
+                    </div>
+                </CardContent>
+
+                <CardFooter className="flex flex-col gap-3 border-t border-neutral-100 py-6 sm:flex-row sm:justify-between">
+                    <Button asChild variant="outline" className="w-full rounded-full border-[#151f54]/30 text-[#151f54] sm:w-auto">
+                        <Link href={cancelUrl}>{t('users.form.actions.cancel', isZh ? '返回列表' : 'Back to list')}</Link>
+                    </Button>
+                    <Button
+                        type="submit"
+                        className="w-full rounded-full bg-[#151f54] px-6 text-white hover:bg-[#1f2a6d] sm:w-auto"
+                        disabled={processing}
+                    >
+                        {processing ? processingLabel : submitLabel}
+                    </Button>
+                </CardFooter>
+            </Card>
+        </form>
+    );
+}

--- a/resources/js/components/manage/users/user-table.tsx
+++ b/resources/js/components/manage/users/user-table.tsx
@@ -1,0 +1,240 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import { useInitials } from '@/hooks/use-initials';
+import { Link } from '@inertiajs/react';
+import { Edit, RotateCcw, ShieldAlert, Trash2 } from 'lucide-react';
+import { type ComponentProps } from 'react';
+
+export interface ManageUserRecord {
+    id: number;
+    name: string;
+    email: string;
+    role: 'admin' | 'teacher' | 'user';
+    status: 'active' | 'suspended';
+    locale?: string | null;
+    avatar?: string | null;
+    email_verified_at: string | null;
+    created_at: string;
+    updated_at: string;
+    deleted_at?: string | null;
+}
+
+interface UserTableProps {
+    users: ManageUserRecord[];
+    isZh: boolean;
+    localeKey: 'zh-TW' | 'en';
+    t: (key: string, fallback?: string, replacements?: Record<string, string | number>) => string;
+    onDelete: (user: ManageUserRecord) => void;
+    onRestore: (user: ManageUserRecord) => void;
+}
+
+const roleLabelFallback: Record<ManageUserRecord['role'], { zh: string; en: string }> = {
+    admin: { zh: '管理員', en: 'Admin' },
+    teacher: { zh: '教師', en: 'Teacher' },
+    user: { zh: '一般使用者', en: 'User' },
+};
+
+const statusLabelFallback: Record<ManageUserRecord['status'], { zh: string; en: string }> = {
+    active: { zh: '啟用', en: 'Active' },
+    suspended: { zh: '停用', en: 'Suspended' },
+};
+
+const statusBadgeVariant: Record<ManageUserRecord['status'], ComponentProps<typeof Badge>['variant']> = {
+    active: 'default',
+    suspended: 'secondary',
+};
+
+const formatDateTime = (value: string, locale: 'zh-TW' | 'en') =>
+    new Date(value).toLocaleString(locale === 'zh-TW' ? 'zh-TW' : 'en-US', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+
+export default function UserTable({ users, isZh, localeKey, t, onDelete, onRestore }: UserTableProps) {
+    const getInitials = useInitials();
+
+    if (users.length === 0) {
+        return (
+            <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-neutral-200 bg-white px-6 py-16 text-center">
+                <ShieldAlert className="h-10 w-10 text-[#151f54]" />
+                <div className="space-y-1">
+                    <p className="text-lg font-semibold text-[#151f54]">
+                        {t('users.index.table.empty.title', isZh ? '目前尚無使用者資料' : 'No users yet')}
+                    </p>
+                    <p className="text-sm text-neutral-600">
+                        {t(
+                            'users.index.table.empty.description',
+                            isZh ? '建立第一位使用者以開始管理系統權限。' : 'Create the first user to start managing access.',
+                        )}
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="overflow-hidden rounded-2xl border border-neutral-200 bg-white">
+            <table className="min-w-full divide-y divide-neutral-200">
+                <thead className="bg-[#151f54]/5">
+                    <tr>
+                        <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[#151f54]">
+                            {t('users.index.table.columns.user', isZh ? '使用者' : 'User')}
+                        </th>
+                        <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[#151f54]">
+                            {t('users.index.table.columns.role', isZh ? '角色' : 'Role')}
+                        </th>
+                        <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[#151f54]">
+                            {t('users.index.table.columns.status', isZh ? '狀態' : 'Status')}
+                        </th>
+                        <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[#151f54]">
+                            {t('users.index.table.columns.email', isZh ? '電子郵件' : 'Email')}
+                        </th>
+                        <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[#151f54]">
+                            {t('users.index.table.columns.created_at', isZh ? '建立時間' : 'Created at')}
+                        </th>
+                        <th className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wider text-[#151f54]">
+                            {t('users.index.table.columns.actions', isZh ? '操作' : 'Actions')}
+                        </th>
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-200 bg-white">
+                    {users.map((user) => {
+                        const roleLabel = t(
+                            `users.roles.${user.role}`,
+                            isZh ? roleLabelFallback[user.role].zh : roleLabelFallback[user.role].en,
+                        );
+                        const statusLabel = t(
+                            `users.status.${user.status}`,
+                            isZh ? statusLabelFallback[user.status].zh : statusLabelFallback[user.status].en,
+                        );
+                        const verifiedLabel = user.email_verified_at
+                            ? t('users.index.table.email_verified', isZh ? '已驗證' : 'Verified')
+                            : t('users.index.table.email_unverified', isZh ? '未驗證' : 'Unverified');
+
+                        return (
+                            <tr
+                                key={user.id}
+                                className={cn(user.deleted_at ? 'bg-rose-50/60 text-neutral-500' : 'bg-white text-neutral-700')}
+                            >
+                                <td className="px-6 py-4">
+                                    <div className="flex items-center gap-3">
+                                        <Avatar className="h-10 w-10">
+                                            <AvatarImage src={user.avatar ?? undefined} alt={user.name} />
+                                            <AvatarFallback className="bg-[#151f54]/10 text-sm font-semibold text-[#151f54]">
+                                                {getInitials(user.name)}
+                                            </AvatarFallback>
+                                        </Avatar>
+                                        <div className="flex flex-col">
+                                            <span className="text-sm font-semibold text-[#151f54]">{user.name}</span>
+                                            <span className="text-xs text-neutral-500">ID #{user.id}</span>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td className="px-6 py-4">
+                                    <Badge variant="outline" className="border-[#151f54]/30 text-[#151f54]">
+                                        {roleLabel}
+                                    </Badge>
+                                </td>
+                                <td className="px-6 py-4">
+                                    <div className="flex items-center gap-2">
+                                        <Badge variant={statusBadgeVariant[user.status]} className="capitalize">
+                                            {statusLabel}
+                                        </Badge>
+                                        <span
+                                            className={cn(
+                                                'rounded-full px-2 py-0.5 text-xs',
+                                                user.email_verified_at
+                                                    ? 'bg-emerald-100 text-emerald-700'
+                                                    : 'bg-amber-100 text-amber-700',
+                                            )}
+                                        >
+                                            {verifiedLabel}
+                                        </span>
+                                    </div>
+                                </td>
+                                <td className="px-6 py-4">
+                                    <div className="flex flex-col text-sm text-neutral-600">
+                                        <span>{user.email}</span>
+                                        {user.locale && (
+                                            <span className="text-xs text-neutral-400">
+                                                {t('users.index.table.locale', isZh ? '語系' : 'Locale')}: {user.locale}
+                                            </span>
+                                        )}
+                                    </div>
+                                </td>
+                                <td className="px-6 py-4 text-sm text-neutral-600">
+                                    {formatDateTime(user.created_at, localeKey)}
+                                </td>
+                                <td className="px-6 py-4">
+                                    <div className="flex items-center justify-end gap-2">
+                                        {!user.deleted_at && (
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <Button
+                                                        asChild
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="rounded-full text-[#151f54] hover:bg-[#151f54]/10"
+                                                    >
+                                                        <Link href={`/manage/admin/users/${user.id}/edit`}>
+                                                            <Edit className="h-4 w-4" />
+                                                        </Link>
+                                                    </Button>
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                    {t('users.index.table.actions.edit', isZh ? '編輯' : 'Edit')}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        )}
+
+                                        {user.deleted_at ? (
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <Button
+                                                        type="button"
+                                                        variant="secondary"
+                                                        size="sm"
+                                                        className="rounded-full bg-emerald-500 text-white hover:bg-emerald-600"
+                                                        onClick={() => onRestore(user)}
+                                                    >
+                                                        <RotateCcw className="h-4 w-4" />
+                                                    </Button>
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                    {t('users.index.table.actions.restore', isZh ? '還原' : 'Restore')}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        ) : (
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="rounded-full text-rose-600 hover:bg-rose-50"
+                                                        onClick={() => onDelete(user)}
+                                                    >
+                                                        <Trash2 className="h-4 w-4" />
+                                                    </Button>
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                    {t('users.index.table.actions.delete', isZh ? '刪除' : 'Delete')}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        )}
+                                    </div>
+                                </td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/resources/js/pages/manage/admin/users/create.tsx
+++ b/resources/js/pages/manage/admin/users/create.tsx
@@ -1,0 +1,92 @@
+import UserForm, { type SelectOption, type UserFormValues } from '@/components/manage/users/user-form';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { useTranslator } from '@/hooks/use-translator';
+import { Head, Link } from '@inertiajs/react';
+import type { InertiaFormProps } from '@inertiajs/react';
+
+interface CreateUserProps {
+    roleOptions?: SelectOption[];
+    statusOptions?: SelectOption[];
+}
+
+export default function CreateUser({
+    roleOptions = [
+        { value: 'admin', label: 'Admin' },
+        { value: 'teacher', label: 'Teacher' },
+        { value: 'user', label: 'User' },
+    ],
+    statusOptions = [
+        { value: 'active', label: 'Active' },
+        { value: 'suspended', label: 'Suspended' },
+    ],
+}: CreateUserProps) {
+    const { t, isZh } = useTranslator('manage');
+
+    const usersIndexUrl = '/manage/admin/users';
+
+    const breadcrumbs = [
+        { title: t('layout.breadcrumbs.dashboard', isZh ? '管理首頁' : 'Management'), href: '/manage/dashboard' },
+        { title: t('layout.breadcrumbs.users', isZh ? '使用者管理' : 'Users'), href: usersIndexUrl },
+        { title: t('layout.breadcrumbs.users_create', isZh ? '新增使用者' : 'Create user'), href: '/manage/admin/users/create' },
+    ];
+
+    const defaultRole = roleOptions[0]?.value ?? 'user';
+    const defaultStatus = statusOptions[0]?.value ?? 'active';
+
+    const initialValues: UserFormValues = {
+        name: '',
+        email: '',
+        role: defaultRole,
+        status: defaultStatus,
+        locale: '',
+        password: '',
+        password_confirmation: '',
+        email_verified: false,
+    };
+
+    const handleSubmit = (form: InertiaFormProps<UserFormValues>) => {
+        form.post(usersIndexUrl, {
+            preserveScroll: true,
+        });
+    };
+
+    return (
+        <ManageLayout role="admin" breadcrumbs={breadcrumbs}>
+            <Head title={t('users.form.header.create.title', isZh ? '建立使用者' : 'Create user')} />
+
+            <section className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-0">
+                <Card className="border-0 bg-white shadow-sm ring-1 ring-black/5">
+                    <CardContent className="flex flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="space-y-2">
+                            <h1 className="text-3xl font-semibold text-[#151f54]">
+                                {t('users.form.header.create.title', isZh ? '建立使用者' : 'Create user')}
+                            </h1>
+                            <p className="text-sm text-slate-600">
+                                {t(
+                                    'users.form.header.create.description',
+                                    isZh
+                                        ? '建立新帳號並指派角色，必要時可預先標記信箱為已驗證。'
+                                        : 'Create a new account, assign a role, and optionally mark the email as verified.',
+                                )}
+                            </p>
+                        </div>
+                        <Button asChild variant="outline" className="rounded-full border-[#151f54]/30 text-[#151f54]">
+                            <Link href={usersIndexUrl}>{t('users.form.actions.cancel', isZh ? '返回列表' : 'Back to list')}</Link>
+                        </Button>
+                    </CardContent>
+                </Card>
+
+                <UserForm
+                    mode="create"
+                    initialValues={initialValues}
+                    roleOptions={roleOptions}
+                    statusOptions={statusOptions}
+                    cancelUrl={usersIndexUrl}
+                    onSubmit={handleSubmit}
+                />
+            </section>
+        </ManageLayout>
+    );
+}

--- a/resources/js/pages/manage/admin/users/edit.tsx
+++ b/resources/js/pages/manage/admin/users/edit.tsx
@@ -1,0 +1,124 @@
+import UserForm, { type SelectOption, type UserFormValues } from '@/components/manage/users/user-form';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { useTranslator } from '@/hooks/use-translator';
+import { Head, Link, useForm } from '@inertiajs/react';
+import type { InertiaFormProps } from '@inertiajs/react';
+
+interface EditableUser {
+    id: number;
+    name: string;
+    email: string;
+    role: 'admin' | 'teacher' | 'user';
+    status: 'active' | 'suspended';
+    locale: string | null;
+    email_verified_at: string | null;
+    deleted_at: string | null;
+}
+
+interface EditUserProps {
+    user: EditableUser;
+    roleOptions?: SelectOption[];
+    statusOptions?: SelectOption[];
+}
+
+export default function EditUser({
+    user,
+    roleOptions = [
+        { value: 'admin', label: 'Admin' },
+        { value: 'teacher', label: 'Teacher' },
+        { value: 'user', label: 'User' },
+    ],
+    statusOptions = [
+        { value: 'active', label: 'Active' },
+        { value: 'suspended', label: 'Suspended' },
+    ],
+}: EditUserProps) {
+    const { t, isZh } = useTranslator('manage');
+    const { post } = useForm({});
+
+    const usersIndexUrl = '/manage/admin/users';
+    const editUrl = `/manage/admin/users/${user.id}`;
+
+    const breadcrumbs = [
+        { title: t('layout.breadcrumbs.dashboard', isZh ? '管理首頁' : 'Management'), href: '/manage/dashboard' },
+        { title: t('layout.breadcrumbs.users', isZh ? '使用者管理' : 'Users'), href: usersIndexUrl },
+        { title: t('layout.breadcrumbs.users_edit', isZh ? '編輯使用者' : 'Edit user'), href: editUrl },
+    ];
+
+    const initialValues: UserFormValues = {
+        name: user.name,
+        email: user.email,
+        role: user.role,
+        status: user.status,
+        locale: user.locale ?? '',
+        password: '',
+        password_confirmation: '',
+        email_verified: Boolean(user.email_verified_at),
+    };
+
+    const handleSubmit = (form: InertiaFormProps<UserFormValues>) => {
+        form.put(editUrl, {
+            preserveScroll: true,
+        });
+    };
+
+    const handleRestore = () => {
+        post(`${editUrl}/restore`, {
+            preserveScroll: true,
+            preserveState: true,
+        });
+    };
+
+    return (
+        <ManageLayout role="admin" breadcrumbs={breadcrumbs}>
+            <Head title={t('users.form.header.edit.title', isZh ? '編輯使用者' : 'Edit user')} />
+
+            <section className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-0">
+                <Card className="border-0 bg-white shadow-sm ring-1 ring-black/5">
+                    <CardContent className="flex flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="space-y-2">
+                            <h1 className="text-3xl font-semibold text-[#151f54]">
+                                {t('users.form.header.edit.title', isZh ? '編輯使用者' : 'Edit user')}
+                            </h1>
+                            <p className="text-sm text-slate-600">
+                                {t(
+                                    'users.form.header.edit.description',
+                                    isZh
+                                        ? '調整帳號資訊、角色與狀態；留空密碼欄位即維持現有設定。'
+                                        : 'Update account details, role, and status. Leave password fields blank to keep the current one.',
+                                )}
+                            </p>
+                        </div>
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                            {user.deleted_at && (
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    className="rounded-full bg-emerald-500 text-white hover:bg-emerald-600"
+                                    onClick={handleRestore}
+                                >
+                                    {t('users.form.actions.restore', isZh ? '還原帳號' : 'Restore user')}
+                                </Button>
+                            )}
+                            <Button asChild variant="outline" className="rounded-full border-[#151f54]/30 text-[#151f54]">
+                                <Link href={usersIndexUrl}>{t('users.form.actions.cancel', isZh ? '返回列表' : 'Back to list')}</Link>
+                            </Button>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <UserForm
+                    mode="edit"
+                    initialValues={initialValues}
+                    roleOptions={roleOptions}
+                    statusOptions={statusOptions}
+                    cancelUrl={usersIndexUrl}
+                    onSubmit={handleSubmit}
+                    isDeleted={Boolean(user.deleted_at)}
+                />
+            </section>
+        </ManageLayout>
+    );
+}

--- a/resources/js/pages/manage/admin/users/index.tsx
+++ b/resources/js/pages/manage/admin/users/index.tsx
@@ -1,0 +1,434 @@
+import UserTable, { type ManageUserRecord } from '@/components/manage/users/user-table';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { useTranslator } from '@/hooks/use-translator';
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { cn } from '@/lib/utils';
+import { type SharedData } from '@/types';
+import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
+import type { FormEvent } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+interface SelectOption {
+    value: string;
+    label: string;
+}
+
+interface PaginationMeta {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+}
+
+interface UsersIndexProps {
+    users: {
+        data: ManageUserRecord[];
+        links: Array<{ url: string | null; label: string; active: boolean }>;
+        meta?: PaginationMeta;
+        current_page?: number;
+        last_page?: number;
+        per_page?: number;
+        total?: number;
+    };
+    filters?: {
+        search?: string;
+        role?: string;
+        status?: string;
+        per_page?: number;
+    };
+    roleOptions?: SelectOption[];
+    statusOptions?: SelectOption[];
+    perPageOptions?: number[];
+}
+
+type FilterState = {
+    search: string;
+    role: string;
+    status: string;
+    per_page: string;
+};
+
+const DEFAULT_PAGINATION_META: PaginationMeta = {
+    current_page: 1,
+    last_page: 1,
+    per_page: 20,
+    total: 0,
+};
+
+const sanitizeLabel = (label: string) =>
+    label
+        .replace(/<[^>]+>/g, '')
+        .replace(/&laquo;/g, '«')
+        .replace(/&raquo;/g, '»')
+        .replace(/&nbsp;/g, ' ');
+
+const resolvePaginationLabel = (
+    label: string,
+    t: (key: string, fallback?: string) => string,
+    isZh: boolean,
+) => {
+    if (/previous/i.test(label)) {
+        const arrow = label.includes('«') ? '« ' : '';
+        return `${arrow}${t('users.index.pagination.previous', isZh ? '上一頁' : 'Previous')}`;
+    }
+
+    if (/next/i.test(label)) {
+        const arrow = label.includes('»') ? ' »' : '';
+        return `${t('users.index.pagination.next', isZh ? '下一頁' : 'Next')}${arrow}`;
+    }
+
+    return label;
+};
+
+export default function UsersIndex({
+    users,
+    filters = {},
+    roleOptions = [
+        { value: 'admin', label: 'Admin' },
+        { value: 'teacher', label: 'Teacher' },
+        { value: 'user', label: 'User' },
+    ],
+    statusOptions = [
+        { value: 'active', label: 'Active' },
+        { value: 'suspended', label: 'Suspended' },
+    ],
+    perPageOptions = [],
+}: UsersIndexProps) {
+    const { auth } = usePage<SharedData>().props;
+    const { t, isZh, localeKey } = useTranslator('manage');
+    const role = auth?.user?.role ?? 'user';
+
+    const usersIndexUrl = '/manage/admin/users';
+
+    const { delete: destroy, post } = useForm({});
+
+    const usersData = users?.data ?? [];
+    const paginationMeta: PaginationMeta = {
+        current_page: users?.meta?.current_page ?? users?.current_page ?? DEFAULT_PAGINATION_META.current_page,
+        last_page: users?.meta?.last_page ?? users?.last_page ?? DEFAULT_PAGINATION_META.last_page,
+        per_page: users?.meta?.per_page ?? users?.per_page ?? DEFAULT_PAGINATION_META.per_page,
+        total: users?.meta?.total ?? users?.total ?? DEFAULT_PAGINATION_META.total,
+    };
+    const paginationLinks = users?.links ?? [];
+    const resolvedPerPageOptions = perPageOptions.length > 0 ? perPageOptions : [10, 20, 50];
+
+    const [filterState, setFilterState] = useState<FilterState>({
+        search: filters.search ?? '',
+        role: filters.role ?? '',
+        status: filters.status ?? '',
+        per_page: String(filters.per_page ?? paginationMeta.per_page ?? DEFAULT_PAGINATION_META.per_page),
+    });
+
+    useEffect(() => {
+        setFilterState({
+            search: filters.search ?? '',
+            role: filters.role ?? '',
+            status: filters.status ?? '',
+            per_page: String(filters.per_page ?? paginationMeta.per_page ?? DEFAULT_PAGINATION_META.per_page),
+        });
+    }, [filters.search, filters.role, filters.status, filters.per_page, paginationMeta.per_page]);
+
+    const handleFilterChange = (key: keyof FilterState, value: string) => {
+        setFilterState((previous) => ({
+            ...previous,
+            [key]: value,
+        }));
+    };
+
+    const buildFilterQuery = (overrides: Record<string, string | number> = {}) => {
+        const query: Record<string, string | number> = {};
+
+        Object.entries(filterState).forEach(([key, value]) => {
+            if (value !== '') {
+                query[key] = value;
+            }
+        });
+
+        Object.entries(overrides).forEach(([key, value]) => {
+            if (value !== '' && value !== undefined && value !== null) {
+                query[key] = value;
+            }
+        });
+
+        return query;
+    };
+
+    const applyFilters = (event?: FormEvent) => {
+        event?.preventDefault();
+        router.get(usersIndexUrl, buildFilterQuery(), {
+            preserveState: true,
+            preserveScroll: true,
+            replace: true,
+        });
+    };
+
+    const resetFilters = () => {
+        const resetState: FilterState = {
+            search: '',
+            role: '',
+            status: '',
+            per_page: String(paginationMeta.per_page ?? DEFAULT_PAGINATION_META.per_page),
+        };
+        setFilterState(resetState);
+        router.get(usersIndexUrl, { per_page: resetState.per_page }, {
+            preserveState: true,
+            preserveScroll: true,
+            replace: true,
+        });
+    };
+
+    const hasActiveFilters = useMemo(() => {
+        const { search, role: roleFilter, status } = filterState;
+        return [search, roleFilter, status].some((value) => value !== '');
+    }, [filterState]);
+
+    const handleDelete = (user: ManageUserRecord) => {
+        if (
+            confirm(
+                t(
+                    'users.index.dialogs.delete_confirm',
+                    isZh ? `確定要停用並刪除「${user.name}」？` : `Delete user "${user.name}"?`,
+                    { name: user.name },
+                ),
+            )
+        ) {
+            destroy(`${usersIndexUrl}/${user.id}`, {
+                preserveScroll: true,
+                preserveState: true,
+            });
+        }
+    };
+
+    const handleRestore = (user: ManageUserRecord) => {
+        post(`${usersIndexUrl}/${user.id}/restore`, {
+            preserveScroll: true,
+            preserveState: true,
+        });
+    };
+
+    const breadcrumbs = [
+        { title: t('layout.breadcrumbs.dashboard', isZh ? '管理首頁' : 'Management'), href: '/manage/dashboard' },
+        { title: t('layout.breadcrumbs.users', isZh ? '使用者管理' : 'Users'), href: usersIndexUrl },
+    ];
+
+    return (
+        <ManageLayout role="admin" breadcrumbs={breadcrumbs}>
+            <Head title={t('users.index.title', isZh ? '使用者管理' : 'User management')} />
+
+            <section className="space-y-6 px-4 py-8 sm:px-6 lg:px-0">
+                <Card className="border-0 bg-white shadow-sm ring-1 ring-black/5">
+                    <CardContent className="flex flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="space-y-2">
+                            <h1 className="text-3xl font-semibold text-[#151f54]">
+                                {t('users.index.title', isZh ? '使用者管理' : 'User management')}
+                            </h1>
+                            <p className="text-sm text-slate-600">
+                                {t(
+                                    'users.index.description',
+                                    isZh
+                                        ? '檢視系統帳號、調整角色權限並快速回復已刪除的使用者。'
+                                        : 'Review accounts, adjust roles, and recover deleted users with ease.',
+                                )}
+                            </p>
+                        </div>
+
+                        {role === 'admin' && (
+                            <Button asChild className="rounded-full bg-[#151f54] px-6 text-white shadow-sm hover:bg-[#1f2a6d]">
+                                <Link href="/manage/admin/users/create">
+                                    {t('users.index.actions.create', isZh ? '新增使用者' : 'New user')}
+                                </Link>
+                            </Button>
+                        )}
+                    </CardContent>
+                </Card>
+
+                <Card className="border-0 bg-white shadow-sm ring-1 ring-black/5">
+                    <CardHeader className="pb-4">
+                        <CardTitle className="text-lg font-semibold text-[#151f54]">
+                            {t('users.index.filters.title', isZh ? '篩選條件' : 'Filters')}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <form
+                            onSubmit={applyFilters}
+                            className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6"
+                        >
+                            <div className="xl:col-span-2">
+                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="user-search">
+                                    {t('users.index.filters.search', isZh ? '搜尋姓名或信箱' : 'Search name or email')}
+                                </label>
+                                <Input
+                                    id="user-search"
+                                    type="search"
+                                    value={filterState.search}
+                                    onChange={(event) => handleFilterChange('search', event.target.value)}
+                                    placeholder={t('users.index.filters.search_placeholder', isZh ? '輸入關鍵字' : 'Keyword')}
+                                />
+                            </div>
+
+                            <div>
+                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="user-role-filter">
+                                    {t('users.index.filters.role', isZh ? '角色' : 'Role')}
+                                </label>
+                                <Select
+                                    id="user-role-filter"
+                                    value={filterState.role}
+                                    onChange={(event) => handleFilterChange('role', event.target.value)}
+                                >
+                                    <option value="">
+                                        {t('users.index.filters.role_all', isZh ? '全部角色' : 'All roles')}
+                                    </option>
+                                    {roleOptions.map((option) => (
+                                        <option key={option.value} value={option.value}>
+                                            {t(`users.roles.${option.value}`, option.label)}
+                                        </option>
+                                    ))}
+                                </Select>
+                            </div>
+
+                            <div>
+                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="user-status-filter">
+                                    {t('users.index.filters.status', isZh ? '狀態' : 'Status')}
+                                </label>
+                                <Select
+                                    id="user-status-filter"
+                                    value={filterState.status}
+                                    onChange={(event) => handleFilterChange('status', event.target.value)}
+                                >
+                                    <option value="">
+                                        {t('users.index.filters.status_all', isZh ? '全部狀態' : 'All statuses')}
+                                    </option>
+                                    {statusOptions.map((option) => (
+                                        <option key={option.value} value={option.value}>
+                                            {t(`users.status.${option.value}`, option.label)}
+                                        </option>
+                                    ))}
+                                </Select>
+                            </div>
+
+                            <div>
+                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="user-per-page">
+                                    {t('users.index.filters.per_page', isZh ? '每頁顯示' : 'Per page')}
+                                </label>
+                                <Select
+                                    id="user-per-page"
+                                    value={filterState.per_page}
+                                    onChange={(event) => handleFilterChange('per_page', event.target.value)}
+                                >
+                                    {resolvedPerPageOptions.map((option) => (
+                                        <option key={option} value={option}>
+                                            {option}
+                                        </option>
+                                    ))}
+                                </Select>
+                            </div>
+
+                            <div className="flex items-end gap-3 xl:col-span-2 xl:justify-end">
+                                <Button type="submit" className="rounded-full bg-[#151f54] px-6 text-white hover:bg-[#1f2a6d]">
+                                    {t('users.index.filters.apply', isZh ? '套用篩選' : 'Apply filters')}
+                                </Button>
+                                {hasActiveFilters && (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="rounded-full border-[#151f54]/20 text-[#151f54]"
+                                        onClick={resetFilters}
+                                    >
+                                        {t('users.index.filters.reset', isZh ? '清除條件' : 'Reset')}
+                                    </Button>
+                                )}
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+
+                <Card className="border-0 bg-white shadow-sm ring-1 ring-black/5">
+                    <CardHeader className="pb-4">
+                        <CardTitle className="text-lg font-semibold text-[#151f54]">
+                            {t('users.index.table.title', isZh ? '使用者列表' : 'User list')}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <UserTable
+                            users={usersData}
+                            isZh={isZh}
+                            localeKey={localeKey}
+                            t={t}
+                            onDelete={handleDelete}
+                            onRestore={handleRestore}
+                        />
+
+                        {paginationLinks.length > 0 && (
+                            <div className="flex flex-col gap-2 border-t border-neutral-100 pt-4 text-sm text-neutral-600 sm:flex-row sm:items-center sm:justify-between">
+                                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
+                                    <span>
+                                        {t(
+                                            'users.index.pagination.summary',
+                                            isZh
+                                                ? `第 ${paginationMeta.current_page} / ${paginationMeta.last_page} 頁`
+                                                : `Page ${paginationMeta.current_page} of ${paginationMeta.last_page}`,
+                                            {
+                                                current: paginationMeta.current_page,
+                                                last: paginationMeta.last_page,
+                                            },
+                                        )}
+                                    </span>
+                                    <span className="text-xs text-neutral-400 sm:text-sm">
+                                        {t(
+                                            'users.index.pagination.total',
+                                            isZh
+                                                ? `共 ${paginationMeta.total} 位使用者`
+                                                : `${paginationMeta.total} users in total`,
+                                            { total: paginationMeta.total },
+                                        )}
+                                    </span>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    {paginationLinks.map((link, index) => {
+                                        const rawLabel = sanitizeLabel(link.label);
+                                        const label = resolvePaginationLabel(rawLabel, t, isZh);
+
+                                        if (!link.url) {
+                                            return (
+                                                <span
+                                                    key={`${rawLabel}-${index}`}
+                                                    className="inline-flex h-8 min-w-8 items-center justify-center rounded-md border border-neutral-200 px-2 text-sm text-neutral-400"
+                                                >
+                                                    {label}
+                                                </span>
+                                            );
+                                        }
+
+                                        return (
+                                            <button
+                                                type="button"
+                                                key={`${rawLabel}-${index}`}
+                                                onClick={() => router.visit(link.url as string, {
+                                                    preserveState: true,
+                                                    preserveScroll: true,
+                                                    replace: true,
+                                                })}
+                                                className={cn(
+                                                    'inline-flex h-8 min-w-8 items-center justify-center rounded-md border px-2 text-sm transition',
+                                                    link.active
+                                                        ? 'border-[#151f54]/20 bg-[#151f54] text-white'
+                                                        : 'border-transparent bg-white text-neutral-600 hover:bg-[#f5f7ff]'
+                                                )}
+                                                aria-label={label}
+                                            >
+                                                {label}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+            </section>
+        </ManageLayout>
+    );
+}


### PR DESCRIPTION
## Summary
- 新增管理後台的使用者列表頁，支援搜尋、篩選、分頁以及刪除與還原操作
- 建立 UserTable 與 UserForm 元件，統一使用者資料顯示與表單驗證流程
- 新增建立與編輯頁面，整合表單並連接現有的使用者路由

## Testing
- npm run types
- npm run test *(失敗：既有 Jest 組態在 ESM 環境下無法載入)*

------
https://chatgpt.com/codex/tasks/task_e_68cf88a7bfa88323a4fbf48cf675ebab