### PR TITLE
Fix settings sidebar role visibility

### DIFF
--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -16,6 +16,10 @@ import {
     Settings,
     Folder,
     HelpCircle,
+    NotebookPen,
+    User,
+    ShieldCheck,
+    LifeBuoy,
 } from 'lucide-react';
 import ManageBrand from '@/components/manage/manage-brand';
 import { useTranslator } from '@/hooks/use-translator';
@@ -25,72 +29,105 @@ export function AppSidebar() {
     const role = auth.user.role;
     const { t } = useTranslator('manage');
 
-    type UserRole = SharedData['auth']['user']['role'];
-    type RoleAwareNavItem = NavItem & { roles?: UserRole[] };
+    const mainNavItemsByRole: Record<SharedData['auth']['user']['role'], NavItem[]> = {
+        admin: [
+            {
+                title: t('sidebar.admin.dashboard', 'Dashboard'),
+                href: '/manage/admin/dashboard',
+                icon: LayoutGrid,
+            },
+            {
+                title: t('sidebar.admin.posts', 'Announcements'),
+                href: '/manage/admin/posts',
+                icon: Megaphone,
+            },
+            {
+                title: t('sidebar.admin.staff', 'Faculty & Staff'),
+                href: '/manage/admin/staff',
+                icon: UserCheck,
+            },
+            {
+                title: t('sidebar.admin.labs', 'Laboratories'),
+                href: '/manage/admin/labs',
+                icon: Beaker,
+            },
+            {
+                title: t('sidebar.admin.academics', 'Courses & Programs'),
+                href: '/manage/admin/academics',
+                icon: GraduationCap,
+            },
+            {
+                title: t('sidebar.admin.users', 'Users'),
+                href: '/manage/admin/users',
+                icon: Users,
+            },
+            {
+                title: t('sidebar.admin.messages', 'Messages'),
+                href: '/manage/admin/contact-messages',
+                icon: Mail,
+            },
+            {
+                title: t('sidebar.admin.attachments', 'Attachments'),
+                href: '/manage/admin/attachments',
+                icon: FileText,
+            },
+        ],
+        teacher: [
+            { title: t('sidebar.teacher.dashboard', 'Teaching Home'), href: '/manage/dashboard', icon: LayoutGrid },
+            { title: t('sidebar.teacher.posts', 'Announcements'), href: '/manage/teacher/posts', icon: Megaphone },
+            { title: t('sidebar.teacher.labs', 'Research'), href: '/manage/teacher/labs', icon: Beaker },
+            { title: t('sidebar.teacher.courses', 'Courses & Activities'), href: '/manage/teacher/courses', icon: NotebookPen },
+            { title: t('sidebar.teacher.profile', 'Profile Settings'), href: '/settings/profile', icon: Settings },
+        ],
+        user: [
+            { title: t('sidebar.user.dashboard', 'Member Home'), href: '/manage/dashboard', icon: LayoutGrid },
+            { title: t('sidebar.user.profile', 'Profile'), href: '/settings/profile', icon: User },
+            { title: t('sidebar.user.security', 'Security'), href: '/settings/password', icon: ShieldCheck },
+        ],
+    };
 
-    const localizedMainNavItems: RoleAwareNavItem[] = [
-        {
-            title: t('sidebar.admin.dashboard', 'Dashboard'),
-            href: '/manage/admin/dashboard',
-            icon: LayoutGrid,
-        },
-        {
-            title: t('sidebar.admin.posts', 'Announcements'),
-            href: '/manage/admin/posts',
-            icon: Megaphone,
-        },
-        {
-            title: t('sidebar.admin.staff', 'Faculty & Staff'),
-            href: '/manage/admin/staff',
-            icon: UserCheck,
-            roles: ['admin', 'teacher'],
-        },
-        {
-            title: t('sidebar.admin.labs', 'Laboratories'),
-            href: '/manage/admin/labs',
-            icon: Beaker,
-        },
-        {
-            title: t('sidebar.admin.academics', 'Courses & Programs'),
-            href: '/manage/admin/academics',
-            icon: GraduationCap,
-        },
-        {
-            title: t('sidebar.admin.users', 'Users'),
-            href: '/manage/admin/users',
-            icon: Users,
-        },
-        {
-            title: t('sidebar.admin.messages', 'Messages'),
-            href: '/manage/admin/contact-messages',
-            icon: Mail,
-        },
-        {
-            title: t('sidebar.admin.attachments', 'Attachments'),
-            href: '/manage/admin/attachments',
-            icon: FileText,
-        },
-    ];
+    const footerNavItemsByRole: Record<SharedData['auth']['user']['role'], NavItem[]> = {
+        admin: [
+            {
+                title: t('sidebar.footer.settings', 'Settings'),
+                href: '/settings/profile',
+                icon: Settings,
+            },
+            {
+                title: t('sidebar.footer.docs', 'Documentation'),
+                href: 'https://laravel.com/docs',
+                icon: HelpCircle,
+            },
+            {
+                title: t('sidebar.footer.repo', 'Repository'),
+                href: 'https://github.com/Grasonyang/csie_web',
+                icon: Folder,
+            },
+        ],
+        teacher: [
+            {
+                title: t('sidebar.teacher.guide', 'Teaching Guide'),
+                href: 'https://github.com/Grasonyang/csie_web',
+                icon: HelpCircle,
+            },
+        ],
+        user: [
+            {
+                title: t('sidebar.user.support', 'Support'),
+                href: 'mailto:csie@cc.ncue.edu.tw',
+                icon: LifeBuoy,
+            },
+        ],
+    };
 
-    const localizedFooterNavItems: NavItem[] = [
-        {
-            title: t('sidebar.footer.settings', 'Settings'),
-            href: '/settings/profile',
-            icon: Settings,
-        },
-        {
-            title: t('sidebar.footer.docs', 'Documentation'),
-            href: 'https://laravel.com/docs',
-            icon: HelpCircle,
-        },
-        {
-            title: t('sidebar.footer.repo', 'Repository'),
-            href: 'https://github.com/Grasonyang/csie_web',
-            icon: Folder,
-        },
-    ];
+    const navLabelsByRole: Partial<Record<SharedData['auth']['user']['role'], string>> = {
+        teacher: t('sidebar.teacher.nav_label', 'Teaching'),
+        user: t('sidebar.user.nav_label', 'Member area'),
+    };
 
-    const mainNavItems = localizedMainNavItems.filter((item) => !item.roles || item.roles.includes(role));
+    const mainNavItems = mainNavItemsByRole[role] ?? mainNavItemsByRole.user;
+    const footerNavItems = footerNavItemsByRole[role] ?? footerNavItemsByRole.user;
+    const navLabel = navLabelsByRole[role];
 
     return (
         <Sidebar collapsible="icon" variant="inset">
@@ -107,11 +144,11 @@ export function AppSidebar() {
             </SidebarHeader>
 
             <SidebarContent>
-                <NavMain items={mainNavItems} />
+                <NavMain items={mainNavItems} label={navLabel} />
             </SidebarContent>
 
             <SidebarFooter>
-                <NavFooter items={localizedFooterNavItems} className="mt-auto" />
+                <NavFooter items={footerNavItems} className="mt-auto" />
                 <NavUser />
             </SidebarFooter>
         </Sidebar>


### PR DESCRIPTION
## Summary
- 調整 AppSidebar 依據使用者角色提供對應的主要與底部導覽內容，避免一般會員在設定頁面看到管理選單

## Testing
- npm run types *(已存在的模組路徑缺失問題：Cannot find module '@/routes')*


------
https://chatgpt.com/codex/tasks/task_e_68cfe2dfdc6c832381cf1ff665958b7d