### PR TITLE
Handle missing attachment size column on dashboard

### DIFF
--- a/app/Actions/Admin/BuildAdminDashboardData.php
+++ b/app/Actions/Admin/BuildAdminDashboardData.php
@@ -7,6 +7,7 @@ use App\Models\ContactMessage;
 use App\Models\Post;
 use App\Models\User;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
 
 class BuildAdminDashboardData
 {
@@ -24,7 +25,9 @@ class BuildAdminDashboardData
         $documentAttachments = (clone $attachmentsQuery)->where('type', 'document')->count();
         $linkAttachments = (clone $attachmentsQuery)->where('type', 'link')->count();
         $trashedAttachments = Attachment::onlyTrashed()->count();
-        $totalAttachmentSize = (int) Attachment::query()->sum('size');
+        $totalAttachmentSize = Schema::hasColumn($attachmentsQuery->getModel()->getTable(), 'size')
+            ? (int) Attachment::query()->sum('size')
+            : 0;
 
         $recentPosts = Post::query()
             ->with(['category:id,name,name_en'])


### PR DESCRIPTION
## Summary
- guard the attachment size aggregation against missing size column errors
- use the schema facade to verify the column before summing its values

## Testing
- php artisan test *(fails: vendor directory not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b58f50a4832389af78aada12c469