### PR TITLE
調整管理後台配色與排版

### DIFF
--- a/resources/js/components/manage/admin/dashboard/admin-dashboard.tsx
+++ b/resources/js/components/manage/admin/dashboard/admin-dashboard.tsx
@@ -80,14 +80,14 @@ function PostListItem({
     const localeKey = locale?.toLowerCase() ?? 'zh-tw';
 
     return (
-        <li className="flex flex-col gap-2 rounded-2xl bg-neutral-50/70 px-4 py-3 text-sm text-neutral-700 ring-1 ring-black/5">
+        <li className="flex flex-col gap-2 rounded-2xl border border-slate-200/70 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm">
             <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="font-medium text-neutral-900">{title}</div>
-                <Badge variant="outline" className="border-[#0f1c3f]/20 bg-[#0f1c3f]/10 text-[#0f1c3f]">
+                <div className="font-medium text-slate-900">{title}</div>
+                <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-700">
                     {badgeCopy[post.status] ?? post.status}
                 </Badge>
             </div>
-            <div className="flex flex-wrap items-center gap-3 text-xs text-neutral-500">
+            <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
                 {publishAt && (
                     <span>
                         {publishAt.locale(localeKey).format('YYYY/MM/DD HH:mm')}
@@ -117,20 +117,20 @@ function AttachmentListItem({
     const localeKey = locale?.toLowerCase() ?? 'zh-tw';
 
     return (
-        <li className="flex flex-col gap-2 rounded-2xl bg-neutral-50/70 px-4 py-3 text-sm text-neutral-700 ring-1 ring-black/5">
+        <li className="flex flex-col gap-2 rounded-2xl border border-slate-200/70 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm">
             <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="font-medium text-neutral-900">
+                <div className="font-medium text-slate-900">
                     {attachment.title ?? t('dashboard.admin.attachments.untitled', '未命名附件')}
                 </div>
-                <Badge variant="outline" className="border-neutral-200 bg-white text-neutral-600">
+                <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-700">
                     {t(`dashboard.admin.attachments.types.${attachment.type}`, attachment.type)}
                 </Badge>
             </div>
-            <div className="flex flex-wrap items-center gap-3 text-xs text-neutral-500">
+            <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
                 <span>{formatBytes(attachment.size)}</span>
                 {createdAt && <span>{createdAt.locale(localeKey).format('YYYY/MM/DD HH:mm')}</span>}
                 {attachment.attachable?.label && (
-                    <span className="truncate text-neutral-600">
+                    <span className="truncate text-slate-600">
                         {attachment.attachable.label}
                     </span>
                 )}
@@ -218,13 +218,13 @@ export default function AdminDashboard() {
             <section className="space-y-4">
                 <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                     <div className="space-y-2">
-                        <p className="text-sm font-medium uppercase tracking-wide text-[#0f1c3f]">
+                        <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
                             {t('dashboard.admin.badge', '管理儀表板')}
                         </p>
-                        <h1 className="text-3xl font-semibold text-neutral-900">
+                        <h1 className="text-3xl font-semibold text-slate-900">
                             {t('dashboard.admin.title', '系統總覽')}
                         </h1>
-                        <p className="max-w-2xl text-sm text-neutral-500">
+                        <p className="max-w-2xl text-sm text-slate-600">
                             {t(
                                 'dashboard.admin.description',
                                 '即時掌握公告、附件與聯絡訊息狀態，協助團隊快速行動。'
@@ -233,12 +233,12 @@ export default function AdminDashboard() {
                     </div>
 
                     <div className="flex flex-wrap items-center gap-3">
-                        <Button asChild className="bg-[#0f1c3f] hover:bg-[#172b63]">
+                        <Button asChild className="rounded-full px-5">
                             <Link href="/manage/posts/create">
                                 {t('dashboard.admin.actions.create_post', '快速建立公告')}
                             </Link>
                         </Button>
-                        <Button asChild variant="outline">
+                        <Button asChild variant="outline" className="rounded-full px-5">
                             <Link href="/manage/posts">
                                 {t('dashboard.admin.actions.view_posts', '檢視公告列表')}
                             </Link>
@@ -252,13 +252,13 @@ export default function AdminDashboard() {
                     {metrics.map((metric) => (
                         <Card
                             key={metric.key}
-                            className="rounded-3xl border-none bg-white shadow-sm ring-1 ring-black/5"
+                            className="rounded-2xl border border-slate-200 bg-white shadow-sm"
                         >
                             <CardHeader className="gap-1">
-                                <CardDescription className="text-sm text-neutral-500">
+                                <CardDescription className="text-sm text-slate-500">
                                     {metric.label}
                                 </CardDescription>
-                                <CardTitle className="text-3xl font-semibold text-neutral-900">
+                                <CardTitle className="text-3xl font-semibold text-slate-900">
                                     {formatNumber(metric.value)}
                                 </CardTitle>
                             </CardHeader>
@@ -270,25 +270,25 @@ export default function AdminDashboard() {
                     {attachmentMetrics.map((metric) => (
                         <Card
                             key={metric.key}
-                            className="rounded-3xl border-none bg-white shadow-sm ring-1 ring-black/5"
+                            className="rounded-2xl border border-slate-200 bg-white shadow-sm"
                         >
                             <CardHeader className="gap-1">
-                                <CardDescription className="text-sm text-neutral-500">
+                                <CardDescription className="text-sm text-slate-500">
                                     {metric.label}
                                 </CardDescription>
-                                <CardTitle className="text-3xl font-semibold text-neutral-900">
+                                <CardTitle className="text-3xl font-semibold text-slate-900">
                                     {formatNumber(metric.value)}
                                 </CardTitle>
                             </CardHeader>
                         </Card>
                     ))}
 
-                    <Card className="rounded-3xl border-none bg-white shadow-sm ring-1 ring-black/5">
+                    <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
                         <CardHeader className="gap-1">
-                            <CardDescription className="text-sm text-neutral-500">
+                            <CardDescription className="text-sm text-slate-500">
                                 {attachmentCopy.totalSize}
                             </CardDescription>
-                            <CardTitle className="text-3xl font-semibold text-neutral-900">
+                            <CardTitle className="text-3xl font-semibold text-slate-900">
                                 {formatBytes(adminDashboard.attachments.totalSize)}
                             </CardTitle>
                         </CardHeader>
@@ -297,18 +297,18 @@ export default function AdminDashboard() {
             </section>
 
             <section className="grid gap-6 lg:grid-cols-2">
-                <Card className="h-full rounded-3xl border-none bg-white shadow-sm ring-1 ring-black/5">
+                <Card className="h-full rounded-2xl border border-slate-200 bg-white shadow-sm">
                     <CardHeader>
-                        <CardTitle className="text-lg font-semibold text-neutral-900">
+                        <CardTitle className="text-lg font-semibold text-slate-900">
                             {t('dashboard.admin.posts.title', '最新公告')}
                         </CardTitle>
-                        <CardDescription className="text-sm text-neutral-500">
+                        <CardDescription className="text-sm text-slate-500">
                             {t('dashboard.admin.posts.description', '追蹤最近發佈或更新的公告')}
                         </CardDescription>
                     </CardHeader>
                     <CardContent className="space-y-4">
                         {adminDashboard.recentPosts.length === 0 ? (
-                            <p className="text-sm text-neutral-500">
+                            <p className="text-sm text-slate-500">
                                 {t('dashboard.admin.posts.empty', '目前沒有公告記錄。')}
                             </p>
                         ) : (
@@ -326,18 +326,18 @@ export default function AdminDashboard() {
                     </CardContent>
                 </Card>
 
-                <Card className="h-full rounded-3xl border-none bg-white shadow-sm ring-1 ring-black/5">
+                <Card className="h-full rounded-2xl border border-slate-200 bg-white shadow-sm">
                     <CardHeader>
-                        <CardTitle className="text-lg font-semibold text-neutral-900">
+                        <CardTitle className="text-lg font-semibold text-slate-900">
                             {t('dashboard.admin.attachments.recent_title', '最新附件')}
                         </CardTitle>
-                        <CardDescription className="text-sm text-neutral-500">
+                        <CardDescription className="text-sm text-slate-500">
                             {t('dashboard.admin.attachments.recent_description', '檢視最近上傳或建立的附件資源')}
                         </CardDescription>
                     </CardHeader>
                     <CardContent className="space-y-4">
                         {adminDashboard.recentAttachments.length === 0 ? (
-                            <p className="text-sm text-neutral-500">
+                            <p className="text-sm text-slate-500">
                                 {t('dashboard.admin.attachments.empty', '目前沒有附件記錄。')}
                             </p>
                         ) : (
@@ -357,12 +357,12 @@ export default function AdminDashboard() {
             </section>
 
             <section>
-                <Card className="rounded-3xl border-none bg-white shadow-sm ring-1 ring-black/5">
+                <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
                     <CardHeader>
-                        <CardTitle className="text-lg font-semibold text-neutral-900">
+                        <CardTitle className="text-lg font-semibold text-slate-900">
                             {t('dashboard.admin.contact.title', '聯絡訊息狀態')}
                         </CardTitle>
-                        <CardDescription className="text-sm text-neutral-500">
+                        <CardDescription className="text-sm text-slate-500">
                             {t('dashboard.admin.contact.description', '即時掌握聯絡表單處理進度')}
                         </CardDescription>
                     </CardHeader>
@@ -371,12 +371,12 @@ export default function AdminDashboard() {
                             {(['new', 'in_progress', 'resolved', 'spam'] as const).map((key) => (
                                 <div
                                     key={key}
-                                    className="flex flex-col gap-1 rounded-2xl bg-neutral-50/70 px-4 py-3 text-sm text-neutral-600 ring-1 ring-black/5"
+                                    className="flex flex-col gap-1 rounded-2xl border border-slate-200/70 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm"
                                 >
-                                    <span className="text-xs uppercase tracking-wide text-neutral-500">
+                                    <span className="text-xs uppercase tracking-wide text-slate-500">
                                         {t(`dashboard.admin.contact.status.${key}`, key)}
                                     </span>
-                                    <span className="text-2xl font-semibold text-neutral-900">
+                                    <span className="text-2xl font-semibold text-slate-900">
                                         {formatNumber(adminDashboard.contactMessages[key])}
                                     </span>
                                 </div>

--- a/resources/js/pages/manage/attachments/index.tsx
+++ b/resources/js/pages/manage/attachments/index.tsx
@@ -432,11 +432,11 @@ export default function AttachmentsIndex({
         <ManageLayout breadcrumbs={breadcrumbs}>
             <Head title={t('attachments.index.title', isZh ? '附件管理' : 'Attachment management')} />
 
-            <section className="space-y-6 px-4 py-8 sm:px-6 lg:px-0">
-                <Card className="border-0 bg-white shadow-sm ring-1 ring-black/5">
+            <section className="space-y-6">
+                <Card className="border border-slate-200 bg-white shadow-sm">
                     <CardContent className="flex flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
                         <div className="space-y-2">
-                            <h1 className="text-3xl font-semibold text-[#151f54]">
+                            <h1 className="text-3xl font-semibold text-slate-900">
                                 {t('attachments.index.title', isZh ? '附件管理' : 'Attachment management')}
                             </h1>
                             <p className="text-sm text-slate-600">
@@ -451,8 +451,8 @@ export default function AttachmentsIndex({
                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                             <Button
                                 type="button"
-                                variant="secondary"
-                                className="w-full rounded-full border-[#151f54]/20 text-[#151f54] hover:bg-[#eef1ff] sm:w-auto"
+                                variant="outline"
+                                className="w-full rounded-full sm:w-auto"
                                 disabled={!hasSelection || bulkForm.processing}
                                 onClick={() => handleBulk('delete')}
                             >
@@ -461,15 +461,15 @@ export default function AttachmentsIndex({
                             </Button>
                             <Button
                                 type="button"
-                                variant="outline"
-                                className="w-full rounded-full border-rose-200 text-rose-600 hover:bg-rose-50 sm:w-auto"
+                                variant="destructive"
+                                className="w-full rounded-full sm:w-auto"
                                 disabled={!hasSelection || bulkForm.processing}
                                 onClick={() => handleBulk('force')}
                             >
                                 <Trash2 className="mr-2 h-4 w-4" />
                                 {t('attachments.index.actions.bulk_force', isZh ? '批次永久刪除' : 'Bulk permanently delete')}
                             </Button>
-                            <Button asChild variant="outline" className="w-full rounded-full border-[#151f54]/30 sm:w-auto">
+                            <Button asChild variant="outline" className="w-full rounded-full sm:w-auto">
                                 <Link href="/manage/posts">
                                     {t('attachments.index.back_to_posts', isZh ? '回公告列表' : 'Back to posts')}
                                 </Link>
@@ -478,9 +478,9 @@ export default function AttachmentsIndex({
                     </CardContent>
                 </Card>
 
-                <Card className="border-0 bg-white shadow-sm ring-1 ring-black/5">
+                <Card className="border border-slate-200 bg-white shadow-sm">
                     <CardHeader className="pb-4">
-                        <CardTitle className="text-lg font-semibold text-[#151f54]">
+                        <CardTitle className="text-lg font-semibold text-slate-900">
                             {t('attachments.index.filters_title', isZh ? '篩選條件' : 'Filters')}
                         </CardTitle>
                     </CardHeader>
@@ -490,7 +490,7 @@ export default function AttachmentsIndex({
                             className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6"
                         >
                             <div className="xl:col-span-2">
-                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="attachment-search">
+                                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="attachment-search">
                                     {t('attachments.index.filters.search', isZh ? '搜尋附件' : 'Search attachments')}
                                 </label>
                                 <Input
@@ -506,7 +506,7 @@ export default function AttachmentsIndex({
                             </div>
 
                             <div>
-                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="attachment-type">
+                                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="attachment-type">
                                     {t('attachments.index.filters.type', isZh ? '附件類型' : 'Type')}
                                 </label>
                                 <Select
@@ -524,7 +524,7 @@ export default function AttachmentsIndex({
                             </div>
 
                             <div>
-                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="attachment-source-type">
+                                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="attachment-source-type">
                                     {t('attachments.index.filters.attachable', isZh ? '資料來源' : 'Attachable')}
                                 </label>
                                 <Select
@@ -542,7 +542,7 @@ export default function AttachmentsIndex({
                             </div>
 
                             <div>
-                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="attachment-source-id">
+                                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="attachment-source-id">
                                     {t('attachments.index.filters.source_id', isZh ? '來源 ID' : 'Source ID')}
                                 </label>
                                 <Input
@@ -559,7 +559,7 @@ export default function AttachmentsIndex({
                             </div>
 
                             <div>
-                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="attachment-visibility">
+                                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="attachment-visibility">
                                     {t('attachments.index.filters.visibility', isZh ? '可見範圍' : 'Visibility')}
                                 </label>
                                 <Select
@@ -577,7 +577,7 @@ export default function AttachmentsIndex({
                             </div>
 
                             <div>
-                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="attachment-trashed">
+                                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="attachment-trashed">
                                     {t('attachments.index.filters.trashed', isZh ? '刪除範圍' : 'Trashed filter')}
                                 </label>
                                 <Select
@@ -592,7 +592,7 @@ export default function AttachmentsIndex({
                             </div>
 
                             <div>
-                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="attachment-sort">
+                                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="attachment-sort">
                                     {t('attachments.index.filters.sort', isZh ? '排序' : 'Sort')}
                                 </label>
                                 <Select
@@ -620,7 +620,7 @@ export default function AttachmentsIndex({
                             </div>
 
                             <div>
-                                <label className="mb-1 block text-sm font-medium text-neutral-700" htmlFor="attachment-per-page">
+                                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="attachment-per-page">
                                     {t('attachments.index.filters.per_page', isZh ? '每頁數量' : 'Per page')}
                                 </label>
                                 <Select
@@ -690,9 +690,9 @@ export default function AttachmentsIndex({
                         )}
                     </CardHeader>
                     <CardContent className="space-y-4">
-                        <div className="overflow-hidden rounded-2xl border border-neutral-200/70">
-                            <table className="min-w-full divide-y divide-neutral-200 bg-white text-sm">
-                                <thead className="bg-neutral-50 text-left text-xs uppercase tracking-wide text-neutral-500">
+                        <div className="overflow-hidden rounded-2xl border border-slate-200/80">
+                            <table className="min-w-full divide-y divide-slate-200 bg-white text-sm">
+                                <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
                                     <tr>
                                         <th className="w-12 px-4 py-3">
                                             <Checkbox
@@ -724,10 +724,10 @@ export default function AttachmentsIndex({
                                         </th>
                                     </tr>
                                 </thead>
-                                <tbody className="divide-y divide-neutral-200">
+                                <tbody className="divide-y divide-slate-200">
                                     {attachmentsData.length === 0 && (
                                         <tr>
-                                            <td colSpan={6} className="px-6 py-8 text-center text-sm text-neutral-500">
+                                            <td colSpan={6} className="px-6 py-8 text-center text-sm text-slate-500">
                                                 {t('attachments.index.table.empty', isZh ? '目前沒有符合條件的附件' : 'No attachments found for the current filters.')}
                                             </td>
                                         </tr>
@@ -738,7 +738,7 @@ export default function AttachmentsIndex({
                                         const displayName = attachment.title ?? attachment.filename ?? attachment.external_url ?? `#${attachment.id}`;
 
                                         return (
-                                            <tr key={attachment.id} className={attachment.deleted_at ? 'bg-neutral-50/60 text-neutral-500' : ''}>
+                                            <tr key={attachment.id} className={attachment.deleted_at ? 'bg-slate-50 text-slate-500' : ''}>
                                                 <td className="px-4 py-4">
                                                     <Checkbox
                                                         aria-label={t('attachments.index.table.columns.select_row', isZh ? '選取附件' : 'Select attachment')}
@@ -748,15 +748,15 @@ export default function AttachmentsIndex({
                                                 </td>
                                                 <td className="px-4 py-4">
                                                     <div className="flex items-start gap-3">
-                                                        <span className={cn('flex h-10 w-10 items-center justify-center rounded-full bg-[#f2f4ff] text-[#151f54]', attachment.deleted_at && 'opacity-70')}>
+                                                        <span className={cn('flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-slate-700', attachment.deleted_at && 'opacity-70')}>
                                                             <Icon className="h-5 w-5" />
                                                         </span>
                                                         <div className="space-y-1">
-                                                            <p className="font-medium text-neutral-800 line-clamp-2">{displayName}</p>
-                                                            <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+                                                            <p className="font-medium text-slate-800 line-clamp-2">{displayName}</p>
+                                                            <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
                                                                 <span>{attachment.mime_type ?? '-'}</span>
                                                                 <span>·</span>
-                                                                <Badge variant={visibilityMeta?.variant ?? 'secondary'} className="text-[11px]">
+                                                                <Badge variant={visibilityMeta?.variant ?? 'secondary'} className="text-[11px] text-slate-700">
                                                                     {formatVisibility(attachment.visibility)}
                                                                 </Badge>
                                                             </div>
@@ -773,11 +773,11 @@ export default function AttachmentsIndex({
                                                         </div>
                                                     </div>
                                                 </td>
-                                                <td className="px-4 py-4 text-sm text-neutral-600">
+                                                <td className="px-4 py-4 text-sm text-slate-600">
                                                     <div className="space-y-1">
                                                         <div>{formatAttachableLabel(attachment)}</div>
                                                         {attachment.uploader && (
-                                                            <div className="text-xs text-neutral-500">
+                                                            <div className="text-xs text-slate-500">
                                                                 {t('attachments.index.table.uploader', isZh ? `上傳者：${attachment.uploader.name}` : `Uploaded by ${attachment.uploader.name}`, {
                                                                     name: attachment.uploader.name,
                                                                 })}
@@ -785,8 +785,8 @@ export default function AttachmentsIndex({
                                                         )}
                                                     </div>
                                                 </td>
-                                                <td className="px-4 py-4 text-sm text-neutral-600">{formatBytes(attachment.size)}</td>
-                                                <td className="px-4 py-4 text-sm text-neutral-600">
+                                                <td className="px-4 py-4 text-sm text-slate-600">{formatBytes(attachment.size)}</td>
+                                                <td className="px-4 py-4 text-sm text-slate-600">
                                                     <div className="space-y-1">
                                                         <div>{formatDateTime(attachment.updated_at)}</div>
                                                         {attachment.deleted_at && (
@@ -872,7 +872,7 @@ export default function AttachmentsIndex({
                         </div>
 
                         {paginationLinks.length > 0 && (
-                            <div className="flex flex-col gap-2 pt-2 text-sm text-neutral-500 sm:flex-row sm:items-center sm:justify-between">
+                            <div className="flex flex-col gap-2 pt-2 text-sm text-slate-500 sm:flex-row sm:items-center sm:justify-between">
                                 <div>
                                     {t(
                                         'attachments.index.pagination.summary',
@@ -894,7 +894,7 @@ export default function AttachmentsIndex({
                                             return (
                                                 <span
                                                     key={`${rawLabel}-${index}`}
-                                                    className="inline-flex h-8 min-w-8 items-center justify-center rounded-md border border-neutral-200 px-2 text-sm text-neutral-400"
+                                                    className="inline-flex h-8 min-w-8 items-center justify-center rounded-md border border-slate-200 px-2 text-sm text-slate-400"
                                                 >
                                                     {label}
                                                 </span>
@@ -915,8 +915,8 @@ export default function AttachmentsIndex({
                                                 className={cn(
                                                     'inline-flex h-8 min-w-8 items-center justify-center rounded-md border px-2 text-sm transition',
                                                     link.active
-                                                        ? 'border-[#151f54]/20 bg-[#151f54] text-white'
-                                                        : 'border-transparent bg-white text-neutral-600 hover:bg-[#f5f7ff]'
+                                                        ? 'border-slate-900/30 bg-slate-900 text-white'
+                                                        : 'border-transparent bg-white text-slate-600 hover:bg-slate-50'
                                                 )}
                                                 aria-label={label}
                                             >

--- a/resources/js/pages/manage/dashboard.tsx
+++ b/resources/js/pages/manage/dashboard.tsx
@@ -98,22 +98,22 @@ export default function Dashboard() {
                 <div className="rounded-3xl bg-white px-6 py-8 shadow-sm ring-1 ring-black/5">
                     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                         <div className="space-y-2">
-                            <span className="inline-flex items-center gap-2 rounded-full bg-[#151f54]/10 px-3 py-1 text-xs font-semibold text-[#151f54]">
+                            <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
                                 <LayoutGrid className="h-4 w-4" />
                                 {t('dashboard.common.manage_center')}
                             </span>
-                            <h1 className="text-3xl font-semibold text-[#151f54]">{title}</h1>
+                            <h1 className="text-3xl font-semibold text-slate-900">{title}</h1>
                             <p className="max-w-2xl text-sm text-slate-600">{description}</p>
                         </div>
-                        <Button asChild className="rounded-full bg-[#151f54] px-6 text-white shadow-sm hover:bg-[#1f2a6d]">
+                        <Button asChild className="rounded-full px-6">
                             <Link href="/manage/dashboard">{t('dashboard.common.back_to_overview')}</Link>
                         </Button>
                     </div>
                 </div>
 
-                <Card className="border-0 bg-white shadow-sm ring-1 ring-black/5">
+                <Card className="border border-slate-200 bg-white shadow-sm">
                     <CardHeader>
-                        <CardTitle className="text-lg font-semibold text-[#151f54]">
+                        <CardTitle className="text-lg font-semibold text-slate-900">
                             {t('dashboard.common.quick_actions')}
                         </CardTitle>
                     </CardHeader>
@@ -122,10 +122,10 @@ export default function Dashboard() {
                             <Link
                                 key={href}
                                 href={href}
-                                className="group flex flex-col gap-3 rounded-2xl border border-transparent bg-[#f7f8fc] px-5 py-4 text-left shadow-sm transition hover:border-[#151f54]/20 hover:bg-white"
+                                className="group flex flex-col gap-3 rounded-2xl border border-transparent bg-slate-50 px-5 py-4 text-left shadow-sm transition hover:border-slate-200 hover:bg-white"
                             >
-                                <span className="inline-flex items-center gap-2 text-sm font-medium text-[#151f54]">
-                                    <span className="inline-flex size-8 items-center justify-center rounded-xl bg-white text-[#151f54] shadow-sm">
+                                <span className="inline-flex items-center gap-2 text-sm font-medium text-slate-700">
+                                    <span className="inline-flex size-8 items-center justify-center rounded-xl bg-white text-slate-700 shadow-sm">
                                         <Icon className="h-4 w-4" />
                                     </span>
                                     {label}

--- a/resources/js/pages/manage/posts/index.tsx
+++ b/resources/js/pages/manage/posts/index.tsx
@@ -262,28 +262,28 @@ export default function PostsIndex({ posts, categories, authors, filters, status
             <Head title="公告管理" />
 
             <section className="space-y-6">
-                <Card className="border-0 bg-gradient-to-br from-white via-white to-[#eef1ff] shadow-sm ring-1 ring-black/5">
+                <Card className="border border-slate-200 bg-white shadow-sm">
                     <CardContent className="flex flex-col gap-4 p-6 md:flex-row md:items-center md:justify-between">
                         <div className="space-y-2">
-                            <span className="inline-flex items-center gap-2 rounded-full bg-[#151f54]/10 px-3 py-1 text-xs font-semibold text-[#151f54]">
+                            <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
                                 <Filter className="h-4 w-4" /> 公告總覽
                             </span>
-                            <h1 className="text-3xl font-semibold text-[#151f54]">公告管理</h1>
+                            <h1 className="text-3xl font-semibold text-slate-900">公告管理</h1>
                             <p className="text-sm text-slate-600">
                                 管理公告分類、排程發布及附件檔案，確保資訊即時且一致。
                             </p>
                         </div>
                         {can.create && (
-                            <Button asChild className="rounded-full bg-[#151f54] px-6 text-white shadow-sm hover:bg-[#1f2a6d]">
+                            <Button asChild className="rounded-full px-6">
                                 <Link href="/manage/posts/create">新增公告</Link>
                             </Button>
                         )}
                     </CardContent>
                 </Card>
 
-                <Card className="border-0 shadow-sm ring-1 ring-black/5">
+                <Card className="border border-slate-200 shadow-sm">
                     <CardHeader className="border-b border-slate-100 pb-4">
-                        <CardTitle className="flex items-center gap-2 text-lg font-semibold text-[#151f54]">
+                        <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
                             <Filter className="h-5 w-5" /> 篩選條件
                         </CardTitle>
                     </CardHeader>
@@ -400,14 +400,14 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                             </div>
 
                             <div className="flex items-end gap-2">
-                                <Button type="submit" className="w-full bg-[#151f54] text-white hover:bg-[#1f2a6d]">
+                                <Button type="submit" className="w-full rounded-full">
                                     套用
                                 </Button>
                                 <Button
                                     type="button"
                                     variant="secondary"
                                     disabled={!hasActiveFilters}
-                                    className="w-full"
+                                    className="w-full rounded-full"
                                     onClick={resetFilters}
                                 >
                                     重設
@@ -417,11 +417,11 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                     </CardContent>
                 </Card>
 
-                <Card className="border-0 shadow-sm ring-1 ring-black/5">
+                <Card className="border border-slate-200 shadow-sm">
                     <CardHeader className="flex flex-col gap-4 border-b border-slate-100 pb-4 lg:flex-row lg:items-center lg:justify-between">
                         <div>
-                            <CardTitle className="text-lg font-semibold text-[#151f54]">公告列表</CardTitle>
-                            <p className="text-sm text-slate-500">共 {pagination.total} 筆資料</p>
+                            <CardTitle className="text-lg font-semibold text-slate-900">公告列表</CardTitle>
+                            <p className="text-sm text-slate-600">共 {pagination.total} 筆資料</p>
                         </div>
                         {can.bulk && (
                             <div className="flex flex-wrap items-center gap-2">
@@ -488,7 +488,7 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                                         const isSelected = selected.includes(post.id);
 
                                         return (
-                                            <tr key={post.id} className="bg-white hover:bg-[#f7f8fc]">
+                                            <tr key={post.id} className="bg-white hover:bg-slate-50">
                                                 {can.bulk && (
                                                     <td className="px-4 py-3">
                                                         <Checkbox
@@ -501,7 +501,7 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                                                     <div className="flex flex-col gap-1">
                                                         <Link
                                                             href={`/manage/posts/${post.id}`}
-                                                            className="font-semibold text-[#151f54] hover:text-[#8a6300]"
+                                                            className="font-semibold text-slate-800 hover:text-slate-900"
                                                         >
                                                             {post.title}
                                                         </Link>
@@ -526,7 +526,7 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                                                             <TooltipTrigger asChild>
                                                                 <Link
                                                                     href={`/manage/posts/${post.id}`}
-                                                                    className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white p-2 text-slate-600 hover:border-[#151f54]/40 hover:text-[#151f54]"
+                                                                    className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white p-2 text-slate-600 hover:border-slate-300 hover:text-slate-900"
                                                                 >
                                                                     <Eye className="h-4 w-4" />
                                                                 </Link>
@@ -537,7 +537,7 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                                                             <TooltipTrigger asChild>
                                                                 <Link
                                                                     href={`/manage/posts/${post.id}/edit`}
-                                                                    className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white p-2 text-slate-600 hover:border-[#151f54]/40 hover:text-[#151f54]"
+                                                                    className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white p-2 text-slate-600 hover:border-slate-300 hover:text-slate-900"
                                                                 >
                                                                     <Pen className="h-4 w-4" />
                                                                 </Link>
@@ -565,7 +565,7 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                                             'inline-flex h-8 w-8 items-center justify-center rounded-md border text-sm transition',
                                             pagination.current_page <= 1
                                                 ? 'cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400'
-                                                : 'border-transparent bg-[#151f54] text-white hover:bg-[#1f2a6d]'
+                                                : 'border-transparent bg-slate-900 text-white hover:bg-slate-800'
                                         )}
                                         onClick={() => changePage(pagination.current_page - 1)}
                                         disabled={pagination.current_page <= 1}
@@ -589,8 +589,8 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                                                 className={cn(
                                                     'inline-flex h-8 min-w-8 items-center justify-center rounded-md border px-2 text-sm transition',
                                                     link.active
-                                                        ? 'border-[#151f54]/30 bg-[#151f54] text-white'
-                                                        : 'border-transparent bg-white text-slate-600 hover:bg-[#f5f7ff]'
+                                                        ? 'border-slate-900/30 bg-slate-900 text-white'
+                                                        : 'border-transparent bg-white text-slate-600 hover:bg-slate-50'
                                                 )}
                                                 onClick={() => changePage(pageNumber)}
                                             >
@@ -604,7 +604,7 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                                             'inline-flex h-8 w-8 items-center justify-center rounded-md border text-sm transition',
                                             pagination.current_page >= pagination.last_page
                                                 ? 'cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400'
-                                                : 'border-transparent bg-[#151f54] text-white hover:bg-[#1f2a6d]'
+                                                : 'border-transparent bg-slate-900 text-white hover:bg-slate-800'
                                         )}
                                         onClick={() => changePage(pagination.current_page + 1)}
                                         disabled={pagination.current_page >= pagination.last_page}


### PR DESCRIPTION
## Summary
- 提升管理儀表板的卡片樣式與清單閱讀性，統一白底與淺色描邊並更新按鈕樣式
- 套用全新配色於管理首頁快捷操作區，改善色彩對比與文字可讀性
- 重構公告與附件管理頁面外觀，調整篩選、表格與分頁按鈕配色以避免爆版並維持高對比

## Testing
- npm run types

------
https://chatgpt.com/codex/tasks/task_e_68d0d6587d48832382ef4f6c9cc57aae