### PR TITLE
移除協同管理角色並調整權限

### DIFF
--- a/app/Http/Controllers/Manage/DashboardController.php
+++ b/app/Http/Controllers/Manage/DashboardController.php
@@ -15,7 +15,7 @@ class DashboardController extends Controller
         $user = $request->user();
 
         $dashboard = null;
-        if ($user && in_array($user->role, ['admin', 'manager'], true)) {
+        if ($user && $user->role === 'admin') {
             $dashboard = $buildDashboardData();
         }
 

--- a/app/Http/Controllers/Manage/UserController.php
+++ b/app/Http/Controllers/Manage/UserController.php
@@ -61,7 +61,7 @@ class UserController extends Controller
             'perPageOptions' => $this->perPageOptions,
             'can' => [
                 'create' => $request->user()->can('create', User::class),
-                'manage' => in_array($request->user()->role, ['admin', 'manager'], true),
+                'manage' => $request->user()->role === 'admin',
             ],
             'authUserId' => $request->user()->id,
         ]);
@@ -196,7 +196,7 @@ class UserController extends Controller
         if ($data['action'] === 'delete') {
             $authUser = $request->user();
 
-            $privilegedRoles = ['admin', 'manager'];
+            $privilegedRoles = ['admin'];
 
             $activeAdminsCount = User::query()
                 ->whereIn('role', $privilegedRoles)
@@ -301,7 +301,7 @@ class UserController extends Controller
         }
 
         $role = $request->input('role');
-        if (in_array($role, ['admin', 'manager', 'teacher', 'user'], true)) {
+        if (in_array($role, ['admin', 'teacher', 'user'], true)) {
             $query->where('role', $role);
         } else {
             $role = '';
@@ -391,7 +391,6 @@ class UserController extends Controller
     {
         return [
             ['value' => 'admin', 'label' => '管理員'],
-            ['value' => 'manager', 'label' => '協同管理'],
             ['value' => 'teacher', 'label' => '教師'],
             ['value' => 'user', 'label' => '一般會員'],
         ];
@@ -425,14 +424,12 @@ class UserController extends Controller
 
     private function isLastActiveAdmin(User $user): bool
     {
-        if (! in_array($user->role, ['admin', 'manager'], true)) {
+        if ($user->role !== 'admin') {
             return false;
         }
 
-        $privilegedRoles = ['admin', 'manager'];
-
         $activeAdmins = User::query()
-            ->whereIn('role', $privilegedRoles)
+            ->where('role', 'admin')
             ->whereNull('deleted_at')
             ->count();
 

--- a/app/Http/Requests/Manage/User/StoreUserRequest.php
+++ b/app/Http/Requests/Manage/User/StoreUserRequest.php
@@ -26,7 +26,7 @@ class StoreUserRequest extends FormRequest
                 'max:255',
                 Rule::unique('users', 'email')->withoutTrashed(),
             ],
-            'role' => ['required', Rule::in(['admin', 'manager', 'teacher', 'user'])],
+            'role' => ['required', Rule::in(['admin', 'teacher', 'user'])],
             'status' => ['required', Rule::in(['active', 'suspended'])],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
             'password_confirmation' => ['required_with:password'],

--- a/app/Http/Requests/Manage/User/UpdateUserRequest.php
+++ b/app/Http/Requests/Manage/User/UpdateUserRequest.php
@@ -35,7 +35,7 @@ class UpdateUserRequest extends FormRequest
                 'max:255',
                 Rule::unique('users', 'email')->ignore($target->id)->withoutTrashed(),
             ],
-            'role' => ['required', Rule::in(['admin', 'manager', 'teacher', 'user'])],
+            'role' => ['required', Rule::in(['admin', 'teacher', 'user'])],
             'status' => ['required', Rule::in(['active', 'suspended'])],
             'password' => ['nullable', 'string', 'min:8', 'confirmed'],
             'password_confirmation' => ['nullable'],

--- a/app/Models/Settings.php
+++ b/app/Models/Settings.php
@@ -56,15 +56,15 @@ class Settings extends Model
     }
 
     /**
-     * Scope: Get settings accessible by user (considering role hierarchy)
+     * 範圍：依角色層級取得使用者可存取的設定
      */
     public function scopeAccessibleBy($query, $user)
     {
-        if (in_array($user->role, ['admin', 'manager'], true)) {
-            // 管理角色可以檢視所有設定
+        if ($user->role === 'admin') {
+            // 管理員可以檢視所有設定
             return $query;
         } elseif ($user->role === 'teacher') {
-            // Teacher can access own settings and public user settings only
+            // 教師僅能檢視自己的設定與一般會員公開設定
             return $query->where(function ($q) use ($user) {
                 $q->where('user_id', $user->id)
                   ->orWhere(function ($subQ) use ($user) {
@@ -75,7 +75,7 @@ class Settings extends Model
                   });
             });
         } else {
-            // Regular user can only access own settings and other public user settings
+            // 一般會員僅能檢視自己的設定與其他會員公開資訊
             return $query->where(function ($q) use ($user) {
                 $q->where('user_id', $user->id)
                   ->orWhere(function ($subQ) use ($user) {

--- a/app/Policies/AttachmentPolicy.php
+++ b/app/Policies/AttachmentPolicy.php
@@ -9,7 +9,7 @@ class AttachmentPolicy
 {
     public function viewAny(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     public function view(?User $user, Attachment $attachment): bool
@@ -22,7 +22,7 @@ class AttachmentPolicy
             return false;
         }
 
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        if ($user->role === 'admin') {
             return true;
         }
 
@@ -31,16 +31,16 @@ class AttachmentPolicy
 
     public function delete(User $user, Attachment $attachment): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     public function restore(User $user, Attachment $attachment): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     public function forceDelete(User $user, Attachment $attachment): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 }

--- a/app/Policies/LabPolicy.php
+++ b/app/Policies/LabPolicy.php
@@ -15,7 +15,7 @@ class LabPolicy
      */
     public function before(User $user): bool|null
     {
-        // Admin has access to most actions, but we'll handle specific restrictions per method
+        // 管理員大多數情境皆可操作，細部限制由各方法處理
         return null;
     }
 
@@ -40,7 +40,7 @@ class LabPolicy
      */
     public function create(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -48,12 +48,12 @@ class LabPolicy
      */
     public function update(User $user, Lab $lab): bool
     {
-        // 管理角色可更新任何實驗室
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可更新任何實驗室
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // Teacher can update lab if they are a member of the lab
+        // 教師若為該實驗室成員即可更新資料
         if ($user->role === 'teacher') {
             return $this->isLabMember($user, $lab);
         }
@@ -66,7 +66,7 @@ class LabPolicy
      */
     public function delete(User $user, Lab $lab): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -74,7 +74,7 @@ class LabPolicy
      */
     public function restore(User $user, Lab $lab): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -82,7 +82,7 @@ class LabPolicy
      */
     public function forceDelete(User $user, Lab $lab): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -90,12 +90,12 @@ class LabPolicy
      */
     public function manageMembers(User $user, Lab $lab): bool
     {
-        // 管理角色可管理任何實驗室成員
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可管理任何實驗室成員
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // Teacher can manage members if they are a member of the lab
+        // 教師若為實驗室成員即可調整成員資訊
         if ($user->role === 'teacher') {
             return $this->isLabMember($user, $lab);
         }
@@ -108,12 +108,12 @@ class LabPolicy
      */
     public function viewAnalytics(User $user, Lab $lab): bool
     {
-        // 管理角色可檢視所有實驗室統計
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可檢視所有實驗室統計
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // Teacher can view analytics if they are a member of the lab
+        // 教師若為實驗室成員即可檢視統計資訊
         if ($user->role === 'teacher') {
             return $this->isLabMember($user, $lab);
         }
@@ -126,12 +126,12 @@ class LabPolicy
      */
     public function managePosts(User $user, Lab $lab): bool
     {
-        // 管理角色可管理任何實驗室相關貼文
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可管理任何實驗室相關貼文
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // Teacher can manage posts if they are a member of the lab
+        // 教師若為實驗室成員即可管理貼文
         if ($user->role === 'teacher') {
             return $this->isLabMember($user, $lab);
         }
@@ -144,13 +144,13 @@ class LabPolicy
      */
     public function isLabMember(User $user, Lab $lab): bool
     {
-        // Only teachers can be lab members
+        // 僅教師具備加入實驗室的資格
         if ($user->role !== 'teacher') {
             return false;
         }
 
-        // Check if user has a teacher profile and is assigned to this lab
-        if (!$user->teacher) {
+        // 確認使用者具備教師資料並與該實驗室綁定
+        if (! $user->teacher) {
             return false;
         }
 

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -32,17 +32,17 @@ class PostPolicy
      */
     public function view(User $user, Post $post): bool
     {
-        // 管理角色可檢視所有公告
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可檢視所有公告
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // 教師可以檢視所有公告以利協作管理
+        // 教師可檢視所有公告以利協作管理
         if ($user->role === 'teacher') {
             return true;
         }
 
-        // Regular user can only view published posts
+        // 一般會員僅能檢視已發布的公告
         return $post->status === 'published';
     }
 
@@ -51,7 +51,7 @@ class PostPolicy
      */
     public function create(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager', 'teacher']);
+        return in_array($user->role, ['admin', 'teacher'], true);
     }
 
     /**
@@ -59,8 +59,8 @@ class PostPolicy
      */
     public function update(User $user, Post $post): bool
     {
-        // 管理角色可編輯所有公告
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可編輯所有公告
+        if ($user->role === 'admin') {
             return true;
         }
 
@@ -69,7 +69,7 @@ class PostPolicy
             return true;
         }
 
-        // Regular users cannot update posts
+        // 一般會員不可編輯公告
         return false;
     }
 
@@ -78,17 +78,17 @@ class PostPolicy
      */
     public function delete(User $user, Post $post): bool
     {
-        // 管理角色可刪除任何公告
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可刪除任何公告
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // Teacher can only delete their own posts
+        // 教師僅能刪除自己建立的公告
         if ($user->role === 'teacher') {
             return $post->created_by === $user->id;
         }
 
-        // Regular users cannot delete posts
+        // 一般會員不可刪除公告
         return false;
     }
 
@@ -97,17 +97,17 @@ class PostPolicy
      */
     public function restore(User $user, Post $post): bool
     {
-        // 管理角色可復原任何公告
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可復原任何公告
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // Teacher can only restore their own posts
+        // 教師僅能復原自己建立的公告
         if ($user->role === 'teacher') {
             return $post->created_by === $user->id;
         }
 
-        // Regular users cannot restore posts
+        // 一般會員不可復原公告
         return false;
     }
 
@@ -116,8 +116,8 @@ class PostPolicy
      */
     public function forceDelete(User $user, Post $post): bool
     {
-        // 只有管理角色可以永久刪除公告
-        return in_array($user->role, ['admin', 'manager'], true);
+        // 只有管理員可以永久刪除公告
+        return $user->role === 'admin';
     }
 
     /**
@@ -125,7 +125,7 @@ class PostPolicy
      */
     public function publish(User $user, Post $post): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -133,7 +133,7 @@ class PostPolicy
      */
     public function unpublish(User $user, Post $post): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -141,7 +141,7 @@ class PostPolicy
      */
     public function manageCategories(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -149,7 +149,7 @@ class PostPolicy
      */
     public function bulkOperations(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -157,7 +157,7 @@ class PostPolicy
      */
     public function viewAnalytics(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager', 'teacher']);
+        return in_array($user->role, ['admin', 'teacher'], true);
     }
 
     /**
@@ -165,7 +165,7 @@ class PostPolicy
      */
     public function schedulePost(User $user, Post $post): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -173,6 +173,6 @@ class PostPolicy
      */
     public function moderateComments(User $user, Post $post): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 }

--- a/app/Policies/PublicationPolicy.php
+++ b/app/Policies/PublicationPolicy.php
@@ -12,41 +12,41 @@ class PublicationPolicy
 
     public function before(User $user): bool|null
     {
-        return in_array($user->role, ['admin', 'manager'], true) ? true : null;
+        return $user->role === 'admin' ? true : null;
     }
 
     public function viewAny(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager', 'teacher']);
+        return in_array($user->role, ['admin', 'teacher'], true);
     }
 
     public function view(User $user, Publication $publication): bool
     {
-        return in_array($user->role, ['admin', 'manager', 'teacher']);
+        return in_array($user->role, ['admin', 'teacher'], true);
     }
 
     public function create(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager', 'teacher']);
+        return in_array($user->role, ['admin', 'teacher'], true);
     }
 
     public function update(User $user, Publication $publication): bool
     {
-        return in_array($user->role, ['admin', 'manager', 'teacher']);
+        return in_array($user->role, ['admin', 'teacher'], true);
     }
 
     public function delete(User $user, Publication $publication): bool
     {
-        return in_array($user->role, ['admin', 'manager', 'teacher']);
+        return in_array($user->role, ['admin', 'teacher'], true);
     }
 
     public function restore(User $user, Publication $publication): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     public function forceDelete(User $user, Publication $publication): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 }

--- a/app/Policies/StaffPolicy.php
+++ b/app/Policies/StaffPolicy.php
@@ -13,26 +13,26 @@ class StaffPolicy
     // 判斷使用者是否可檢視列表
     public function viewAny(User $user): bool
     {
-        // 教師需能檢視師資模組，但仍保留管理權限給管理員
-        return in_array($user->role, ['admin', 'manager', 'teacher'], true);
+        // 教師需能檢視師資模組，但仍保留完整管理權限給管理員
+        return in_array($user->role, ['admin', 'teacher'], true);
     }
 
     // 判斷使用者是否可檢視單筆資料
     public function view(User $user, Staff $staff): bool
     {
-        return in_array($user->role, ['admin', 'manager', 'teacher'], true);
+        return in_array($user->role, ['admin', 'teacher'], true);
     }
 
     // 判斷使用者是否可新增
     public function create(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     // 判斷使用者是否可更新
     public function update(User $user, Staff $staff): bool
     {
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        if ($user->role === 'admin') {
             return true;
         }
 
@@ -47,16 +47,16 @@ class StaffPolicy
     // 判斷使用者是否可刪除
     public function delete(User $user, Staff $staff): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     public function restore(User $user, Staff $staff): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     public function forceDelete(User $user, Staff $staff): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -24,7 +24,7 @@ class UserPolicy
      */
     public function viewAny(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager']);
+        return $user->role === 'admin';
     }
 
     /**
@@ -32,12 +32,12 @@ class UserPolicy
      */
     public function view(User $user, User $model): bool
     {
-        // Admin can view all users
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可檢視所有使用者
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // User can only view themselves
+        // 其他角色僅能檢視自身資料
         return $user->id === $model->id;
     }
 
@@ -46,7 +46,7 @@ class UserPolicy
      */
     public function create(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -55,11 +55,11 @@ class UserPolicy
     public function update(User $user, User $model): bool
     {
         // 管理員可管理所有帳號
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // User can only update themselves
+        // 其他角色僅能更新自身帳號
         return $user->id === $model->id;
     }
 
@@ -68,7 +68,7 @@ class UserPolicy
      */
     public function delete(User $user, User $model): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true) && $user->id !== $model->id;
+        return $user->role === 'admin' && $user->id !== $model->id;
     }
 
     /**
@@ -76,7 +76,7 @@ class UserPolicy
      */
     public function restore(User $user, User $model): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -84,8 +84,8 @@ class UserPolicy
      */
     public function forceDelete(User $user, User $model): bool
     {
-        // Admin can force delete users, but not themselves
-        return in_array($user->role, ['admin', 'manager'], true) && $user->id !== $model->id;
+        // 管理員可以永久刪除其他帳號，但不得刪除自己
+        return $user->role === 'admin' && $user->id !== $model->id;
     }
 
     /**
@@ -94,7 +94,7 @@ class UserPolicy
     public function assignRole(User $user, User $model): bool
     {
         // 只有管理員可以調整角色
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -102,7 +102,7 @@ class UserPolicy
      */
     public function manageTeacherAssignments(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -110,12 +110,12 @@ class UserPolicy
      */
     public function viewSettings(User $user, User $model): bool
     {
-        // Admin can view all settings
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可檢視所有設定
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // Users can only view their own settings
+        // 其他角色僅能檢視自己的設定
         return $user->id === $model->id;
     }
 
@@ -124,12 +124,12 @@ class UserPolicy
      */
     public function updateSettings(User $user, User $model): bool
     {
-        // Admin can update all settings
-        if (in_array($user->role, ['admin', 'manager'], true)) {
+        // 管理員可更新所有設定
+        if ($user->role === 'admin') {
             return true;
         }
 
-        // Users can only update their own settings
+        // 其他角色僅能更新自己的設定
         return $user->id === $model->id;
     }
 
@@ -138,7 +138,7 @@ class UserPolicy
      */
     public function accessAdminDashboard(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager'], true);
+        return $user->role === 'admin';
     }
 
     /**
@@ -146,6 +146,6 @@ class UserPolicy
      */
     public function accessManageDashboard(User $user): bool
     {
-        return in_array($user->role, ['admin', 'manager']);
+        return in_array($user->role, ['admin', 'teacher'], true);
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,7 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
-            'role' => 'user', // Default role
+            'role' => 'user', // 預設角色
             'locale' => 'en',
             'status' => 'active',
         ];
@@ -52,16 +52,6 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'role' => 'admin',
-        ]);
-    }
-
-    /**
-     * Create a manager user.
-     */
-    public function manager(): static
-    {
-        return $this->state(fn (array $attributes) => [
-            'role' => 'manager',
         ]);
     }
 

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('email')->unique();
-            $table->enum('role', ['admin','manager','teacher','user'])->default('user')->index();
+            $table->enum('role', ['admin','teacher','user'])->default('user')->index();
             $table->string('locale')->nullable();
             $table->enum('status', ['active','suspended'])->default('active');
             $table->timestamp('email_verified_at')->nullable();

--- a/lang/en/manage.php
+++ b/lang/en/manage.php
@@ -23,10 +23,6 @@ return [
                 'primary' => 'CSIE Admin',
                 'secondary' => 'Management Console',
             ],
-            'manager' => [
-                'primary' => 'CSIE Manager',
-                'secondary' => 'Collaborative Console',
-            ],
             'teacher' => [
                 'primary' => 'CSIE Teacher',
                 'secondary' => 'Teaching Console',

--- a/lang/zh-TW/manage.php
+++ b/lang/zh-TW/manage.php
@@ -23,10 +23,6 @@ return [
                 'primary' => 'CSIE 後台',
                 'secondary' => '系統管理中心',
             ],
-            'manager' => [
-                'primary' => 'CSIE 管理',
-                'secondary' => '協同管理中心',
-            ],
             'teacher' => [
                 'primary' => 'CSIE 教師',
                 'secondary' => '教學管理後台',

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -74,7 +74,6 @@ export function AppSidebar() {
 
     const mainNavItemsByRole: Record<SharedData['auth']['user']['role'], NavItem[]> = {
         admin: adminNavItems,
-        manager: adminNavItems,
         teacher: [
             { title: t('sidebar.teacher.dashboard'), href: '/manage/dashboard', icon: LayoutGrid },
             { title: t('sidebar.teacher.posts'), href: '/manage/posts', icon: Megaphone },
@@ -109,7 +108,6 @@ export function AppSidebar() {
 
     const footerNavItemsByRole: Record<SharedData['auth']['user']['role'], NavItem[]> = {
         admin: adminFooterItems,
-        manager: adminFooterItems,
         teacher: [
             {
                 title: t('sidebar.teacher.guide'),

--- a/resources/js/components/manage/manage-brand.tsx
+++ b/resources/js/components/manage/manage-brand.tsx
@@ -3,7 +3,7 @@ import { type SharedData } from '@/types';
 import { usePage } from '@inertiajs/react';
 import { useTranslator } from '@/hooks/use-translator';
 
-export type ManageRole = 'admin' | 'manager' | 'teacher' | 'user';
+export type ManageRole = 'admin' | 'teacher' | 'user';
 
 interface ManageBrandProps {
     role?: ManageRole;

--- a/resources/js/components/manage/users/UserForm.tsx
+++ b/resources/js/components/manage/users/UserForm.tsx
@@ -16,7 +16,7 @@ interface UserPayload {
     id?: number;
     name: string;
     email: string;
-    role: 'admin' | 'manager' | 'teacher' | 'user';
+    role: 'admin' | 'teacher' | 'user';
     status: 'active' | 'suspended';
     email_verified_at?: string | null;
 }

--- a/resources/js/components/manage/users/UserTable.tsx
+++ b/resources/js/components/manage/users/UserTable.tsx
@@ -12,7 +12,7 @@ export interface UserRow {
     id: number;
     name: string;
     email: string;
-    role: 'admin' | 'manager' | 'teacher' | 'user';
+    role: 'admin' | 'teacher' | 'user';
     status: 'active' | 'suspended';
     avatar?: string | null;
     email_verified_at?: string | null;
@@ -51,7 +51,6 @@ interface UserTableProps {
 
 const roleLabels: Record<UserRow['role'], string> = {
     admin: '管理員',
-    manager: '協同管理',
     teacher: '教師',
     user: '一般會員',
 };

--- a/resources/js/layouts/manage/manage-layout.tsx
+++ b/resources/js/layouts/manage/manage-layout.tsx
@@ -10,7 +10,7 @@ import { type BreadcrumbItem, type SharedData } from '@/types';
 import ManageHeader from '@/components/manage/manage-header';
 
 interface ManageLayoutProps {
-    role?: 'admin' | 'manager' | 'teacher' | 'user';
+    role?: 'admin' | 'teacher' | 'user';
     breadcrumbs?: BreadcrumbItem[];
 }
 
@@ -21,10 +21,10 @@ export default function ManageLayout({
 }: PropsWithChildren<ManageLayoutProps>) {
     const { auth } = usePage<SharedData>().props;
     // 依據認證資訊判斷目前角色，若有外部覆寫則以參數優先
-    const role = (roleOverride ?? auth?.user?.role ?? 'user') as 'admin' | 'manager' | 'teacher' | 'user';
+    const role = (roleOverride ?? auth?.user?.role ?? 'user') as 'admin' | 'teacher' | 'user';
 
     const Sidebar = useMemo(() => {
-        if (role === 'admin' || role === 'manager') {
+        if (role === 'admin') {
             return AdminManageSidebar;
         }
 

--- a/resources/js/pages/manage/dashboard.tsx
+++ b/resources/js/pages/manage/dashboard.tsx
@@ -8,7 +8,7 @@ import { BookOpen, LayoutGrid, Megaphone, NotebookPen, Settings, ShieldCheck, Us
 import { type ComponentType } from 'react';
 import { useTranslator } from '@/hooks/use-translator';
 
-type ManageRole = 'admin' | 'manager' | 'teacher' | 'user';
+type ManageRole = 'admin' | 'teacher' | 'user';
 
 interface QuickAction {
     href: string;
@@ -22,7 +22,7 @@ export default function Dashboard() {
     const role = (auth?.user?.role ?? 'user') as ManageRole;
     const { t } = useTranslator('manage');
 
-    if (role === 'admin' || role === 'manager') {
+    if (role === 'admin') {
         const adminTitle = t('dashboard.admin.title', '系統總覽');
         const breadcrumbs = [
             { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },

--- a/resources/js/pages/manage/posts/create.tsx
+++ b/resources/js/pages/manage/posts/create.tsx
@@ -21,14 +21,8 @@ interface CreatePostProps {
 export default function CreatePost({ categories, statusOptions }: CreatePostProps) {
     const { auth } = usePage<SharedData>().props;
     const userRole = auth?.user?.role ?? 'user';
-    const layoutRole: 'admin' | 'manager' | 'teacher' | 'user' =
-        userRole === 'admin'
-            ? 'admin'
-            : userRole === 'manager'
-              ? 'manager'
-              : userRole === 'teacher'
-                ? 'teacher'
-                : 'user';
+    const layoutRole: 'admin' | 'teacher' | 'user' =
+        userRole === 'admin' ? 'admin' : userRole === 'teacher' ? 'teacher' : 'user';
 
     const breadcrumbs: BreadcrumbItem[] = [
         { title: '管理首頁', href: '/manage/dashboard' },

--- a/resources/js/pages/manage/posts/edit.tsx
+++ b/resources/js/pages/manage/posts/edit.tsx
@@ -22,14 +22,8 @@ interface EditPostProps {
 export default function EditPost({ post, categories, statusOptions }: EditPostProps) {
     const { auth } = usePage<SharedData>().props;
     const userRole = auth?.user?.role ?? 'user';
-    const layoutRole: 'admin' | 'manager' | 'teacher' | 'user' =
-        userRole === 'admin'
-            ? 'admin'
-            : userRole === 'manager'
-              ? 'manager'
-              : userRole === 'teacher'
-                ? 'teacher'
-                : 'user';
+    const layoutRole: 'admin' | 'teacher' | 'user' =
+        userRole === 'admin' ? 'admin' : userRole === 'teacher' ? 'teacher' : 'user';
 
     const breadcrumbs: BreadcrumbItem[] = [
         { title: '管理首頁', href: '/manage/dashboard' },

--- a/resources/js/pages/manage/posts/index.tsx
+++ b/resources/js/pages/manage/posts/index.tsx
@@ -95,14 +95,8 @@ const formatDateTime = (value: string | null) => {
 export default function PostsIndex({ posts, categories, authors, filters, statusOptions, perPageOptions, can }: PostsIndexProps) {
     const { auth } = usePage<SharedData>().props;
     const userRole = auth?.user?.role ?? 'user';
-    const layoutRole: 'admin' | 'manager' | 'teacher' | 'user' =
-        userRole === 'admin'
-            ? 'admin'
-            : userRole === 'manager'
-              ? 'manager'
-              : userRole === 'teacher'
-                ? 'teacher'
-                : 'user';
+    const layoutRole: 'admin' | 'teacher' | 'user' =
+        userRole === 'admin' ? 'admin' : userRole === 'teacher' ? 'teacher' : 'user';
     const [selected, setSelected] = useState<number[]>([]);
     const defaultPerPage = perPageOptions[0] ?? 20;
 

--- a/resources/js/pages/manage/posts/show.tsx
+++ b/resources/js/pages/manage/posts/show.tsx
@@ -59,14 +59,8 @@ const formatDateTime = (value: string | null) => {
 export default function ShowPost({ post }: ShowPostProps) {
     const { auth } = usePage<SharedData>().props;
     const userRole = auth?.user?.role ?? 'user';
-    const layoutRole: 'admin' | 'manager' | 'teacher' | 'user' =
-        userRole === 'admin'
-            ? 'admin'
-            : userRole === 'manager'
-              ? 'manager'
-              : userRole === 'teacher'
-                ? 'teacher'
-                : 'user';
+    const layoutRole: 'admin' | 'teacher' | 'user' =
+        userRole === 'admin' ? 'admin' : userRole === 'teacher' ? 'teacher' : 'user';
 
     const breadcrumbs: BreadcrumbItem[] = [
         { title: '管理首頁', href: '/manage/dashboard' },

--- a/resources/js/pages/manage/users/edit.tsx
+++ b/resources/js/pages/manage/users/edit.tsx
@@ -13,7 +13,7 @@ interface UserPayload {
     id: number;
     name: string;
     email: string;
-    role: 'admin' | 'manager' | 'teacher' | 'user';
+    role: 'admin' | 'teacher' | 'user';
     status: 'active' | 'suspended';
     email_verified_at?: string | null;
 }

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -100,7 +100,7 @@ export interface User {
     id: number;
     name: string;
     email: string;
-    role: 'admin' | 'manager' | 'teacher' | 'user';
+    role: 'admin' | 'teacher' | 'user';
     status?: 'active' | 'suspended';
     locale?: string | null;
     avatar?: string;

--- a/routes/manage.php
+++ b/routes/manage.php
@@ -18,7 +18,7 @@ use App\Http\Controllers\Manage\Admin\PublicationController as AdminPublicationC
 use App\Http\Controllers\Manage\Admin\ContactMessageController as AdminContactMessageController;
 use App\Http\Controllers\Manage\Admin\AttachmentController as AdminAttachmentController;
 
-Route::middleware(['auth', 'role:admin|manager'])
+Route::middleware(['auth', 'role:admin|teacher'])
     ->prefix('manage')->name('manage.')
     ->group(function () {
         Route::get('/', function () {


### PR DESCRIPTION
## Summary
- 移除 manager 角色並調整路由、資料結構與後端權限判斷
- 更新政策、設定與使用者管理流程以支援 admin、teacher、user 三種角色
- 調整前端型別、側邊欄與翻譯內容，使介面與功能一致

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d0d93efc388323a18db12ea6cc63ca