### PR TITLE
fix: avoid missing logout route export

### DIFF
--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -1,11 +1,13 @@
 import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
 import { UserInfo } from '@/components/user-info';
 import { useMobileNavigation } from '@/hooks/use-mobile-navigation';
-import { logout } from '@/routes';
 import { type User } from '@/types';
 import { Link, router } from '@inertiajs/react';
 import { LogOut, Settings } from 'lucide-react';
 import { useTranslator } from '@/hooks/use-translator';
+
+// 登出路徑常數，避免 Wayfinder 尚未生成時導致匯入錯誤
+const LOGOUT_ROUTE = '/logout';
 
 interface UserMenuContentProps {
     user: User;
@@ -39,7 +41,14 @@ export function UserMenuContent({ user }: UserMenuContentProps) {
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>
-                <Link className="block w-full" href={logout()} as="button" onClick={handleLogout} data-test="logout-button">
+                <Link
+                    className="block w-full"
+                    href={LOGOUT_ROUTE}
+                    method="post"
+                    as="button"
+                    onClick={handleLogout}
+                    data-test="logout-button"
+                >
                     <LogOut className="mr-2" />
                     {tAuth('actions.logout')}
                 </Link>

--- a/resources/js/pages/auth/verify-email.tsx
+++ b/resources/js/pages/auth/verify-email.tsx
@@ -2,11 +2,13 @@ import EmailVerificationNotificationController from '@/actions/App/Http/Controll
 import TextLink from '@/components/text-link';
 import { Button } from '@/components/ui/button';
 import AuthLayout from '@/layouts/auth-layout';
-import { logout } from '@/routes';
 import { Form, Head } from '@inertiajs/react';
 import { LoaderCircle } from 'lucide-react';
 import { useTranslator } from '@/hooks/use-translator';
 import { formButtonClass, formLinkClass, formStatusClass } from './styles';
+
+// 使用常數避免 Wayfinder 尚未生成時造成匯入錯誤
+const LOGOUT_ROUTE = '/logout';
 
 export default function VerifyEmail({ status }: { status?: string }) {
     const { t } = useTranslator('auth');
@@ -32,7 +34,12 @@ export default function VerifyEmail({ status }: { status?: string }) {
                             {copy.submit}
                         </Button>
 
-                        <TextLink href={logout()} className={`${formLinkClass} text-sm font-semibold`}>
+                        <TextLink
+                            href={LOGOUT_ROUTE}
+                            method="post"
+                            as="button"
+                            className={`${formLinkClass} text-sm font-semibold`}
+                        >
                             {copy.logout}
                         </TextLink>
                     </>


### PR DESCRIPTION
## Summary
- 避免依賴 Wayfinder 匯出的 logout 函式，改用常數路徑與 POST 方法送出登出請求
- 在驗證信頁面使用相同的登出常數，確保不會因為缺少動態模組而報錯

## Testing
- npm run types

------
https://chatgpt.com/codex/tasks/task_e_68d0dcaeab2c8323aeabfd774974196b