### PR TITLE
Fix manage user pagination links fallback

### DIFF
--- a/resources/js/components/manage/users/UserTable.tsx
+++ b/resources/js/components/manage/users/UserTable.tsx
@@ -28,6 +28,7 @@ export interface PaginationMeta {
     total: number;
     from?: number | null;
     to?: number | null;
+    links?: PaginationLink[];
 }
 
 export interface PaginationLink {
@@ -39,7 +40,7 @@ export interface PaginationLink {
 interface UserTableProps {
     data: UserRow[];
     meta: PaginationMeta;
-    links: PaginationLink[];
+    links?: PaginationLink[] | Record<string, unknown> | null;
     selected: number[];
     onSelect: (userId: number, checked: boolean) => void;
     onSelectAll: (checked: boolean) => void;
@@ -102,6 +103,13 @@ export default function UserTable({
     authUserId,
 }: UserTableProps) {
     const allIds = useMemo(() => data.map((user) => user.id), [data]);
+
+    // 為了避免 API 回傳的連結格式不一致，預先轉換為陣列以供下方渲染使用
+    const paginationLinks = Array.isArray(links)
+        ? links
+        : Array.isArray(meta.links)
+            ? meta.links
+            : [];
 
     const isAllSelected = allIds.length > 0 && allIds.every((id) => selected.includes(id));
     const isIndeterminate = selected.length > 0 && !isAllSelected;
@@ -300,7 +308,7 @@ export default function UserTable({
                     共 <span className="font-semibold text-neutral-900">{meta.total}</span> 筆資料
                 </div>
                 <div className="flex items-center gap-2">
-                    {links.map((link, index) => {
+                    {paginationLinks.map((link, index) => {
                         const label = link.label.replace('&laquo;', '«').replace('&raquo;', '»');
                         const isDisabled = !link.url;
                         return (

--- a/resources/js/pages/manage/users/index.tsx
+++ b/resources/js/pages/manage/users/index.tsx
@@ -17,7 +17,7 @@ interface UsersIndexProps {
     users: {
         data: UserRow[];
         meta: PaginationMeta;
-        links: PaginationLink[];
+        links?: PaginationLink[] | Record<string, unknown> | null;
     };
     filters: Partial<Record<'q' | 'role' | 'status' | 'created_from' | 'created_to' | 'sort' | 'per_page', string>>;
     roleOptions: OptionItem[];
@@ -59,6 +59,12 @@ export default function UsersIndex({
 }: UsersIndexProps) {
     const defaultSort = sortOptions[0]?.value ?? '-created_at';
     const defaultPerPage = String(perPageOptions[0] ?? 15);
+
+    const paginationLinks = Array.isArray(users.links)
+        ? users.links
+        : Array.isArray(users.meta.links)
+            ? users.meta.links
+            : [];
 
     const [filterState, setFilterState] = useState<FilterState>({
         q: filters.q ?? '',
@@ -415,7 +421,7 @@ export default function UsersIndex({
             <UserTable
                 data={users.data}
                 meta={users.meta}
-                links={users.links}
+                links={paginationLinks}
                 selected={selected}
                 onSelect={handleSelect}
                 onSelectAll={handleSelectAll}


### PR DESCRIPTION
## Summary
- 處理使用者管理頁面分頁連結可能為物件或陣列的情況，統一轉換為陣列再渲染
- 更新頁面組件的型別與傳遞參數，確保分頁連結來源一致且安全

## Testing
- npm run build *(fails: [@laravel/vite-plugin-wayfinder] Error generating types: Command failed: php artisan wayfinder:generate --with-form)*

------
https://chatgpt.com/codex/tasks/task_e_68d34845212083238f58b80d163f053a