### PR TITLE
Handle missing tags table gracefully

### DIFF
--- a/app/Http/Controllers/Manage/PostController.php
+++ b/app/Http/Controllers/Manage/PostController.php
@@ -142,18 +142,7 @@ class PostController extends Controller
                 ->orderBy('name')
                 ->get(),
             'statusOptions' => $statusOptions,
-            'availableTags' => Tag::forContext('posts')
-                ->orderBy('sort_order')
-                ->orderBy('name')
-                ->get()
-                ->map(fn (Tag $tag) => [[
-                    'id' => $tag->id,
-                    'name' => $tag->name,
-                    'slug' => $tag->slug,
-                    'description' => $tag->description,
-                ]])
-                ->values()
-                ->all(),
+            'availableTags' => $this->availableTagsForPosts(),
         ]);
     }
 
@@ -285,19 +274,31 @@ class PostController extends Controller
                 ->orderBy('name')
                 ->get(),
             'statusOptions' => $statusOptions,
-            'availableTags' => Tag::forContext('posts')
-                ->orderBy('sort_order')
-                ->orderBy('name')
-                ->get()
-                ->map(fn (Tag $tag) => [[
-                    'id' => $tag->id,
-                    'name' => $tag->name,
-                    'slug' => $tag->slug,
-                    'description' => $tag->description,
-                ]])
-                ->values()
-                ->all(),
+            'availableTags' => $this->availableTagsForPosts(),
         ]);
+    }
+
+    /**
+     * 取得公告表單可用的標籤列表，若資料表不存在則回傳空陣列。
+     */
+    private function availableTagsForPosts(): array
+    {
+        if (! Tag::tableExists()) {
+            return [];
+        }
+
+        return Tag::forContext('posts')
+            ->orderBy('sort_order')
+            ->orderBy('name')
+            ->get()
+            ->map(fn (Tag $tag) => [[
+                'id' => $tag->id,
+                'name' => $tag->name,
+                'slug' => $tag->slug,
+                'description' => $tag->description,
+            ]])
+            ->values()
+            ->all();
     }
 
     public function update(Request $request, Post $post)

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
 
 class Tag extends Model
 {
@@ -32,6 +33,14 @@ class Tag extends Model
     protected $casts = [
         'sort_order' => 'integer',
     ];
+
+    /**
+     * 判斷標籤資料表是否已建立。
+     */
+    public static function tableExists(): bool
+    {
+        return Schema::hasTable((new static())->getTable());
+    }
 
     public function scopeForContext($query, string $context)
     {

--- a/resources/js/pages/manage/admin/tags/create.tsx
+++ b/resources/js/pages/manage/admin/tags/create.tsx
@@ -1,17 +1,19 @@
 import { Head, Link } from '@inertiajs/react';
 import ManageLayout from '@/layouts/manage/manage-layout';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, AlertTriangle } from 'lucide-react';
 import TagForm, { TagContextOption, TagFormSubmitHandler } from '@/components/manage/tags/tag-form';
 import type { BreadcrumbItem } from '@/types';
 import { useTranslator } from '@/hooks/use-translator';
 
 interface TagCreateProps {
     contextOptions: TagContextOption[];
+    tableReady: boolean;
 }
 
-export default function CreateTag({ contextOptions }: TagCreateProps) {
+export default function CreateTag({ contextOptions, tableReady }: TagCreateProps) {
     const { t } = useTranslator('manage');
 
     const breadcrumbs: BreadcrumbItem[] = [
@@ -23,6 +25,10 @@ export default function CreateTag({ contextOptions }: TagCreateProps) {
     const pageTitle = t('tags.create.header.title', '新增標籤');
     const pageDescription = t('tags.create.header.description', '建立可供公告與其他模組使用的標籤。');
     const backToIndex = t('tags.create.actions.back', '返回標籤列表');
+    const migrationHint = t(
+        'tags.create.alert.missing_table',
+        '標籤資料表尚未建立，請執行資料庫遷移（php artisan migrate）後再試一次。'
+    );
 
     const handleSubmit: TagFormSubmitHandler = (form) => {
         form.post('/manage/tags', { preserveScroll: true });
@@ -48,12 +54,23 @@ export default function CreateTag({ contextOptions }: TagCreateProps) {
                     </CardContent>
                 </Card>
 
-                <TagForm
-                    contextOptions={contextOptions}
-                    submitLabel={t('tags.form.actions.create', '建立標籤')}
-                    cancelUrl="/manage/tags"
-                    onSubmit={handleSubmit}
-                />
+                {tableReady ? (
+                    <TagForm
+                        contextOptions={contextOptions}
+                        submitLabel={t('tags.form.actions.create', '建立標籤')}
+                        cancelUrl="/manage/tags"
+                        onSubmit={handleSubmit}
+                    />
+                ) : (
+                    <Card className="border border-amber-200 bg-amber-50 text-amber-900 shadow-sm">
+                        <CardContent className="p-6">
+                            <Alert className="border-amber-200 bg-transparent p-0 text-inherit">
+                                <AlertTriangle className="h-5 w-5 text-amber-600" />
+                                <AlertDescription>{migrationHint}</AlertDescription>
+                            </Alert>
+                        </CardContent>
+                    </Card>
+                )}
             </section>
         </ManageLayout>
     );

--- a/tests/Feature/Manage/PostManagementTest.php
+++ b/tests/Feature/Manage/PostManagementTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
@@ -188,5 +189,20 @@ class PostManagementTest extends TestCase
         $this->assertNotNull($post);
         $this->assertNotNull($post->cover_image_url);
         $this->assertTrue(Storage::disk('public')->exists(str_replace('/storage/', '', $post->cover_image_url)));
+    }
+
+    public function test_post_create_page_handles_missing_tag_table(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        Schema::dropIfExists('tags');
+
+        $response = $this->actingAs($admin)->get(route('manage.posts.create'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (\Inertia\Testing\AssertableInertia $page) =>
+            $page->component('manage/posts/create')
+                ->where('availableTags', [])
+        );
     }
 }

--- a/tests/Feature/Manage/TagManagementTest.php
+++ b/tests/Feature/Manage/TagManagementTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Manage;
 use App\Models\Tag;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
@@ -24,6 +25,23 @@ class TagManagementTest extends TestCase
             $page->component('manage/admin/tags/index')
                 ->has('tags', 2)
                 ->has('contextOptions')
+                ->where('tableReady', true)
+        );
+    }
+
+    public function test_tag_index_handles_missing_table_gracefully(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        Schema::dropIfExists('tags');
+
+        $response = $this->actingAs($admin)->get(route('manage.tags.index'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (AssertableInertia $page) =>
+            $page->component('manage/admin/tags/index')
+                ->where('tableReady', false)
+                ->where('tags', [])
         );
     }
 


### PR DESCRIPTION
## Summary
- avoid querying the tags table when it has not been migrated yet and surface a migration hint in the admin UI
- reuse a helper in the post controller so tag lookups fall back to an empty list when the table is missing
- add feature coverage ensuring the tags index and post creation screens work even without the tags table

## Testing
- php artisan test --filter=TagManagementTest

------
https://chatgpt.com/codex/tasks/task_e_68d354e277d48323bdf89532b8a1a560