### PR TITLE
refactor: reorganize manage dashboard with modular components

### DIFF
--- a/resources/js/components/manage/dashboard/dashboard-hero-card.tsx
+++ b/resources/js/components/manage/dashboard/dashboard-hero-card.tsx
@@ -1,0 +1,34 @@
+import { type ReactNode } from 'react';
+
+// 儀表板標題區塊，統一管理徽章、標題、描述與操作按鈕的排版樣式。
+interface DashboardHeroCardProps {
+    badge?: {
+        icon?: ReactNode;
+        label: string;
+    };
+    title: string;
+    description: string;
+    action?: ReactNode;
+}
+
+export function DashboardHeroCard({ badge, title, description, action }: DashboardHeroCardProps) {
+    return (
+        <div className="rounded-3xl bg-white px-6 py-8 shadow-sm ring-1 ring-black/5">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="space-y-2">
+                    {badge && (
+                        <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                            {badge.icon}
+                            {badge.label}
+                        </span>
+                    )}
+                    <h1 className="text-3xl font-semibold text-slate-900">{title}</h1>
+                    <p className="max-w-2xl text-sm text-slate-600">{description}</p>
+                </div>
+                {action && <div className="flex-shrink-0">{action}</div>}
+            </div>
+        </div>
+    );
+}
+
+export default DashboardHeroCard;

--- a/resources/js/components/manage/dashboard/dashboard-quick-actions-card.tsx
+++ b/resources/js/components/manage/dashboard/dashboard-quick-actions-card.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Link } from '@inertiajs/react';
+import { type ComponentType } from 'react';
+
+// 快速操作區塊，集中管理各角色的快捷連結樣式與互動行為。
+export interface DashboardQuickAction {
+    href: string;
+    label: string;
+    description: string;
+    icon: ComponentType<{ className?: string }>;
+}
+
+interface DashboardQuickActionsCardProps {
+    title: string;
+    actions: DashboardQuickAction[];
+}
+
+export function DashboardQuickActionsCard({ title, actions }: DashboardQuickActionsCardProps) {
+    if (actions.length === 0) {
+        return null;
+    }
+
+    return (
+        <Card className="border border-slate-200 bg-white shadow-sm">
+            <CardHeader>
+                <CardTitle className="text-lg font-semibold text-slate-900">{title}</CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-4 sm:grid-cols-2">
+                {actions.map(({ href, label, description, icon: Icon }) => (
+                    <Link
+                        key={href}
+                        href={href}
+                        className="group flex flex-col gap-3 rounded-2xl border border-transparent bg-slate-50 px-5 py-4 text-left shadow-sm transition hover:border-slate-200 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/60"
+                    >
+                        <span className="inline-flex items-center gap-2 text-sm font-medium text-slate-700">
+                            <span className="inline-flex size-8 items-center justify-center rounded-xl bg-white text-slate-700 shadow-sm">
+                                <Icon className="h-4 w-4" />
+                            </span>
+                            {label}
+                        </span>
+                        <span className="text-sm text-slate-600">{description}</span>
+                    </Link>
+                ))}
+            </CardContent>
+        </Card>
+    );
+}
+
+export default DashboardQuickActionsCard;

--- a/resources/js/components/manage/dashboard/dashboard-toast.tsx
+++ b/resources/js/components/manage/dashboard/dashboard-toast.tsx
@@ -1,0 +1,120 @@
+import { cn } from '@/lib/utils';
+import { AlertCircle, CheckCircle2, Info, X } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+// 儀表板 Toast 管理器，統一管理成功、錯誤與資訊提示，並提供自動關閉機制。
+export type DashboardToastType = 'success' | 'error' | 'info';
+
+export interface DashboardToastMessage {
+    id: string;
+    type: DashboardToastType;
+    title: string;
+    description?: string;
+}
+
+const createToastId = () =>
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : Math.random().toString(36).slice(2);
+
+export function useDashboardToast(initialToasts: DashboardToastMessage[] = []) {
+    const [toasts, setToasts] = useState<DashboardToastMessage[]>(initialToasts);
+
+    // 顯示 Toast 時建立唯一識別碼，避免同時存在多筆訊息時產生衝突。
+    const showToast = useCallback(
+        (toast: Omit<DashboardToastMessage, 'id'> & { id?: string }) => {
+            const id = toast.id ?? createToastId();
+            setToasts((previous) => [...previous, { ...toast, id }]);
+            return id;
+        },
+        [],
+    );
+
+    // 提供主動關閉 Toast 的方法，讓使用者可快速清除提示。
+    const dismissToast = useCallback((id: string) => {
+        setToasts((previous) => previous.filter((toast) => toast.id !== id));
+    }, []);
+
+    // 在特定情境需一次移除所有提示時使用，例如切換頁面或重新載入資料。
+    const clearToasts = useCallback(() => {
+        setToasts([]);
+    }, []);
+
+    return { toasts, showToast, dismissToast, clearToasts };
+}
+
+interface DashboardToastContainerProps {
+    toasts: DashboardToastMessage[];
+    onDismiss: (id: string) => void;
+    duration?: number;
+}
+
+export function DashboardToastContainer({ toasts, onDismiss, duration = 5000 }: DashboardToastContainerProps) {
+    useEffect(() => {
+        if (toasts.length === 0) {
+            return;
+        }
+
+        const timers = toasts.map((toast) =>
+            window.setTimeout(() => {
+                onDismiss(toast.id);
+            }, duration),
+        );
+
+        return () => {
+            timers.forEach((timer) => window.clearTimeout(timer));
+        };
+    }, [toasts, onDismiss, duration]);
+
+    if (toasts.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="fixed bottom-6 right-6 z-50 flex w-full max-w-xs flex-col gap-3 sm:max-w-sm">
+            {toasts.map((toast) => {
+                const variantStyles = {
+                    success: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+                    error: 'border-red-200 bg-red-50 text-red-800',
+                    info: 'border-blue-200 bg-blue-50 text-blue-800',
+                } as const;
+
+                const iconMap = {
+                    success: <CheckCircle2 className="h-5 w-5" />,
+                    error: <AlertCircle className="h-5 w-5" />,
+                    info: <Info className="h-5 w-5" />,
+                } as const;
+
+                return (
+                    <div
+                        key={toast.id}
+                        className={cn(
+                            'flex flex-col gap-3 rounded-2xl border p-4 shadow-lg shadow-black/5',
+                            variantStyles[toast.type],
+                        )}
+                    >
+                        <div className="flex items-start gap-3">
+                            <span className="mt-0.5">{iconMap[toast.type]}</span>
+                            <div className="flex-1 space-y-1 text-sm">
+                                <p className="font-semibold leading-none">{toast.title}</p>
+                                {toast.description && (
+                                    <p className="text-sm leading-snug text-current/80">{toast.description}</p>
+                                )}
+                            </div>
+                            <button
+                                type="button"
+                                onClick={() => onDismiss(toast.id)}
+                                className="rounded-full p-1 text-current/70 transition-colors hover:bg-white/50 hover:text-current"
+                                aria-label="關閉提示"
+                            >
+                                <X className="h-4 w-4" />
+                            </button>
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+export default DashboardToastContainer;

--- a/resources/js/pages/manage/dashboard.tsx
+++ b/resources/js/pages/manage/dashboard.tsx
@@ -1,26 +1,175 @@
 import AdminDashboard from '@/components/manage/admin/dashboard/admin-dashboard';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import DashboardHeroCard from '@/components/manage/dashboard/dashboard-hero-card';
+import {
+    DashboardQuickAction,
+    DashboardQuickActionsCard,
+} from '@/components/manage/dashboard/dashboard-quick-actions-card';
+import {
+    DashboardToastContainer,
+    useDashboardToast,
+} from '@/components/manage/dashboard/dashboard-toast';
 import { Button } from '@/components/ui/button';
 import ManageLayout from '@/layouts/manage/manage-layout';
+import { useTranslator } from '@/hooks/use-translator';
 import { type SharedData } from '@/types';
 import { Head, Link, usePage } from '@inertiajs/react';
 import { BookOpen, LayoutGrid, Megaphone, NotebookPen, Settings, ShieldCheck, User } from 'lucide-react';
-import { type ComponentType } from 'react';
-import { useTranslator } from '@/hooks/use-translator';
+import { useEffect, useMemo, useRef } from 'react';
 
 type ManageRole = 'admin' | 'teacher' | 'user';
 
-interface QuickAction {
-    href: string;
-    label: string;
-    description: string;
-    icon: ComponentType<{ className?: string }>;
+interface DashboardFlashMessages {
+    success?: string;
+    error?: string;
+    warnings?: string[];
+    importErrors?: string[];
+}
+
+interface AdminStatusTracker {
+    status: 'loaded' | 'missing' | null;
+    generatedAt: string | null;
+}
+
+// 嘗試以使用者語系格式化時間字串，若格式化失敗則回傳 undefined 以避免顯示錯誤資訊。
+function formatGeneratedAt(value: string | null | undefined, locale: string | undefined) {
+    if (!value) {
+        return undefined;
+    }
+
+    try {
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return undefined;
+        }
+
+        return new Intl.DateTimeFormat(locale ?? 'zh-TW', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+        }).format(date);
+    } catch {
+        return undefined;
+    }
 }
 
 export default function Dashboard() {
-    const { auth } = usePage<SharedData>().props;
+    const page = usePage<SharedData & { flash?: DashboardFlashMessages }>();
+    const { auth, adminDashboard, locale } = page.props;
+    const flashMessages: DashboardFlashMessages = page.props.flash ?? {};
     const role = (auth?.user?.role ?? 'user') as ManageRole;
     const { t } = useTranslator('manage');
+    const { toasts, showToast, dismissToast } = useDashboardToast();
+    const previousFlashRef = useRef<DashboardFlashMessages>({});
+    const adminStatusRef = useRef<AdminStatusTracker>({ status: null, generatedAt: null });
+    const roleToastRef = useRef<ManageRole | null>(null);
+
+    // 監聽後端 flash 訊息，確保操作成功或失敗時使用者能透過 Toast 立即得知結果。
+    useEffect(() => {
+        const successMessage = flashMessages.success;
+        const errorMessage = flashMessages.error;
+        const warningMessages = flashMessages.warnings ?? [];
+        const importErrorMessages = flashMessages.importErrors ?? [];
+
+        if (successMessage && successMessage !== previousFlashRef.current.success) {
+            showToast({
+                type: 'success',
+                title: t('dashboard.common.toast.success_title', '操作成功'),
+                description: successMessage,
+            });
+        }
+
+        if (errorMessage && errorMessage !== previousFlashRef.current.error) {
+            showToast({
+                type: 'error',
+                title: t('dashboard.common.toast.error_title', '操作失敗'),
+                description: errorMessage,
+            });
+        }
+
+        warningMessages
+            .filter((message) => !(previousFlashRef.current.warnings ?? []).includes(message))
+            .forEach((message) => {
+                showToast({
+                    type: 'info',
+                    title: t('dashboard.common.toast.info_title', '提醒'),
+                    description: message,
+                });
+            });
+
+        importErrorMessages
+            .filter((message) => !(previousFlashRef.current.importErrors ?? []).includes(message))
+            .forEach((message) => {
+                showToast({
+                    type: 'error',
+                    title: t('dashboard.common.toast.import_error_title', '批次匯入失敗'),
+                    description: message,
+                });
+            });
+
+        previousFlashRef.current = {
+            success: successMessage,
+            error: errorMessage,
+            warnings: [...warningMessages],
+            importErrors: [...importErrorMessages],
+        };
+    }, [flashMessages, showToast, t]);
+
+    // 當管理員儀表板資料載入或更新時顯示成功提示，若後端未提供資料則跳出錯誤提醒。
+    useEffect(() => {
+        if (role !== 'admin') {
+            adminStatusRef.current = { status: null, generatedAt: null };
+            return;
+        }
+
+        if (adminDashboard) {
+            const generatedAt = adminDashboard.generatedAt ?? null;
+            const statusChanged = adminStatusRef.current.status !== 'loaded';
+            const timestampChanged = adminStatusRef.current.generatedAt !== generatedAt;
+
+            if (statusChanged || timestampChanged) {
+                const formatted = formatGeneratedAt(generatedAt, locale);
+                showToast({
+                    type: 'success',
+                    title: t('dashboard.admin.toast.data_loaded_title', '儀表板資料載入成功'),
+                    description:
+                        formatted ?? t('dashboard.admin.toast.data_loaded_description', '統計資料已更新。'),
+                });
+            }
+
+            adminStatusRef.current = { status: 'loaded', generatedAt };
+        } else if (adminStatusRef.current.status !== 'missing') {
+            showToast({
+                type: 'error',
+                title: t('dashboard.admin.toast.data_missing_title', '無法載入儀表板資料'),
+                description: t(
+                    'dashboard.admin.toast.data_missing_description',
+                    '目前暫時無法取得統計資訊，請稍後再試。',
+                ),
+            });
+            adminStatusRef.current = { status: 'missing', generatedAt: null };
+        }
+    }, [role, adminDashboard, locale, showToast, t]);
+
+    // 非管理員角色進入儀表板時，提供載入完成的提示，避免使用者不確定頁面是否可操作。
+    useEffect(() => {
+        if (role === 'admin') {
+            roleToastRef.current = null;
+            return;
+        }
+
+        if (roleToastRef.current === role) {
+            return;
+        }
+
+        showToast({
+            type: 'success',
+            title: t('dashboard.common.toast.ready_title', '儀表板載入完成'),
+            description: t('dashboard.common.toast.ready_description', '所有快捷操作已為您準備就緒。'),
+        });
+        roleToastRef.current = role;
+    }, [role, showToast, t]);
 
     if (role === 'admin') {
         const adminTitle = t('dashboard.admin.title', '系統總覽');
@@ -32,109 +181,93 @@ export default function Dashboard() {
         return (
             <ManageLayout role={role} breadcrumbs={breadcrumbs}>
                 <Head title={adminTitle} />
+                <DashboardToastContainer toasts={toasts} onDismiss={dismissToast} />
                 <AdminDashboard />
             </ManageLayout>
         );
     }
 
-    const { title, description, actions }: { title: string; description: string; actions: QuickAction[] } =
-        role === 'teacher'
-            ? {
-                  title: t('dashboard.teacher.title'),
-                  description: t('dashboard.teacher.description'),
-                  actions: [
-                      {
-                          href: '/manage/teacher/posts',
-                          label: t('dashboard.teacher.actions.posts.label'),
-                          description: t('dashboard.teacher.actions.posts.description'),
-                          icon: Megaphone,
-                      },
-                      {
-                          href: '/manage/teacher/labs',
-                          label: t('dashboard.teacher.actions.labs.label'),
-                          description: t('dashboard.teacher.actions.labs.description'),
-                          icon: NotebookPen,
-                      },
-                      {
-                          href: '/manage/teacher/courses',
-                          label: t('dashboard.teacher.actions.courses.label'),
-                          description: t('dashboard.teacher.actions.courses.description'),
-                          icon: BookOpen,
-                      },
-                      {
-                          href: '/manage/settings/profile',
-                          label: t('dashboard.teacher.actions.profile.label'),
-                          description: t('dashboard.teacher.actions.profile.description'),
-                          icon: Settings,
-                      },
-                  ],
-              }
-            : {
-                  title: t('dashboard.user.title'),
-                  description: t('dashboard.user.description'),
-                  actions: [
-                      {
-                          href: '/manage/settings/profile',
-                          label: t('dashboard.user.actions.profile.label'),
-                          description: t('dashboard.user.actions.profile.description'),
-                          icon: User,
-                      },
-                      {
-                          href: '/manage/settings/password',
-                          label: t('dashboard.user.actions.security.label'),
-                          description: t('dashboard.user.actions.security.description'),
-                          icon: ShieldCheck,
-                      },
-                  ],
-              };
+    const { title, description, actions } = useMemo(() => {
+        if (role === 'teacher') {
+            const teacherActions: DashboardQuickAction[] = [
+                {
+                    href: '/manage/teacher/posts',
+                    label: t('dashboard.teacher.actions.posts.label'),
+                    description: t('dashboard.teacher.actions.posts.description'),
+                    icon: Megaphone,
+                },
+                {
+                    href: '/manage/teacher/labs',
+                    label: t('dashboard.teacher.actions.labs.label'),
+                    description: t('dashboard.teacher.actions.labs.description'),
+                    icon: NotebookPen,
+                },
+                {
+                    href: '/manage/teacher/courses',
+                    label: t('dashboard.teacher.actions.courses.label'),
+                    description: t('dashboard.teacher.actions.courses.description'),
+                    icon: BookOpen,
+                },
+                {
+                    href: '/manage/settings/profile',
+                    label: t('dashboard.teacher.actions.profile.label'),
+                    description: t('dashboard.teacher.actions.profile.description'),
+                    icon: Settings,
+                },
+            ];
+
+            return {
+                title: t('dashboard.teacher.title'),
+                description: t('dashboard.teacher.description'),
+                actions: teacherActions,
+            };
+        }
+
+        const userActions: DashboardQuickAction[] = [
+            {
+                href: '/manage/settings/profile',
+                label: t('dashboard.user.actions.profile.label'),
+                description: t('dashboard.user.actions.profile.description'),
+                icon: User,
+            },
+            {
+                href: '/manage/settings/password',
+                label: t('dashboard.user.actions.security.label'),
+                description: t('dashboard.user.actions.security.description'),
+                icon: ShieldCheck,
+            },
+        ];
+
+        return {
+            title: t('dashboard.user.title'),
+            description: t('dashboard.user.description'),
+            actions: userActions,
+        };
+    }, [role, t]);
 
     const breadcrumbs = [{ title: t('layout.breadcrumbs.dashboard'), href: '/manage/dashboard' }];
 
     return (
         <ManageLayout role={role} breadcrumbs={breadcrumbs}>
             <Head title={title} />
+            <DashboardToastContainer toasts={toasts} onDismiss={dismissToast} />
 
             <section className="space-y-6">
-                <div className="rounded-3xl bg-white px-6 py-8 shadow-sm ring-1 ring-black/5">
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                        <div className="space-y-2">
-                            <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
-                                <LayoutGrid className="h-4 w-4" />
-                                {t('dashboard.common.manage_center')}
-                            </span>
-                            <h1 className="text-3xl font-semibold text-slate-900">{title}</h1>
-                            <p className="max-w-2xl text-sm text-slate-600">{description}</p>
-                        </div>
+                <DashboardHeroCard
+                    badge={{ icon: <LayoutGrid className="h-4 w-4" />, label: t('dashboard.common.manage_center') }}
+                    title={title}
+                    description={description}
+                    action={
                         <Button asChild className="rounded-full px-6">
                             <Link href="/manage/dashboard">{t('dashboard.common.back_to_overview')}</Link>
                         </Button>
-                    </div>
-                </div>
+                    }
+                />
 
-                <Card className="border border-slate-200 bg-white shadow-sm">
-                    <CardHeader>
-                        <CardTitle className="text-lg font-semibold text-slate-900">
-                            {t('dashboard.common.quick_actions')}
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent className="grid gap-4 sm:grid-cols-2">
-                        {actions.map(({ href, label, description, icon: Icon }) => (
-                            <Link
-                                key={href}
-                                href={href}
-                                className="group flex flex-col gap-3 rounded-2xl border border-transparent bg-slate-50 px-5 py-4 text-left shadow-sm transition hover:border-slate-200 hover:bg-white"
-                            >
-                                <span className="inline-flex items-center gap-2 text-sm font-medium text-slate-700">
-                                    <span className="inline-flex size-8 items-center justify-center rounded-xl bg-white text-slate-700 shadow-sm">
-                                        <Icon className="h-4 w-4" />
-                                    </span>
-                                    {label}
-                                </span>
-                                <span className="text-sm text-slate-600">{description}</span>
-                            </Link>
-                        ))}
-                    </CardContent>
-                </Card>
+                <DashboardQuickActionsCard
+                    title={t('dashboard.common.quick_actions')}
+                    actions={actions}
+                />
             </section>
         </ManageLayout>
     );


### PR DESCRIPTION
## Summary
- modularize the manage dashboard page into reusable hero and quick action components
- introduce a dashboard-specific toast manager to surface flash messages and batch import issues
- add defensive handling for admin dashboard payloads, including locale-aware timestamps and error notifications

## Testing
- npm run build *(fails: php artisan wayfinder:generate --with-form)*

------
https://chatgpt.com/codex/tasks/task_e_68d41909d2648323a3e6c381bdc4de87