### PR TITLE
修正後台公告列表頁面邏輯

### DIFF
--- a/resources/js/components/manage/post/post-import-uploader.tsx
+++ b/resources/js/components/manage/post/post-import-uploader.tsx
@@ -4,7 +4,11 @@ import type { TranslatorFunction } from './post-types';
 
 // 將批次匯入流程抽象為單一按鈕與隱藏的檔案輸入框，避免出現干擾視覺的對話框。
 interface PostImportUploaderProps {
-    trigger: ReactElement<{ onClick?: (event: MouseEvent<any>) => void; disabled?: boolean }>;
+    trigger: ReactElement<{
+        onClick?: (event: MouseEvent<any>) => void;
+        disabled?: boolean;
+        'data-import-processing'?: string;
+    }>;
     t: TranslatorFunction;
     fallbackLanguage: 'zh' | 'en';
     onStart?: (message: string) => void;

--- a/resources/js/hooks/useTranslation.ts
+++ b/resources/js/hooks/useTranslation.ts
@@ -1,0 +1,16 @@
+import { useTranslator } from './use-translator';
+
+/**
+ * 提供符合舊版程式使用方式的翻譯 Hook，統一返回 t 與 locale 兩個欄位。
+ * 由於部分頁面（例如教職員管理）仍引用 useTranslation，此處包裝 useTranslator 以維持相容性。
+ */
+export function useTranslation(namespace: string = 'manage') {
+    const { t, localeKey } = useTranslator(namespace);
+
+    return {
+        t,
+        locale: localeKey,
+    };
+}
+
+export type UseTranslationReturn = ReturnType<typeof useTranslation>;

--- a/resources/js/pages/manage/admin/staff/index.tsx
+++ b/resources/js/pages/manage/admin/staff/index.tsx
@@ -1,0 +1,269 @@
+import { Head, router } from '@inertiajs/react';
+import { useMemo, useState } from 'react';
+
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import { StaffTable } from '@/components/manage/staff/StaffTable';
+import { TeacherTable } from '@/components/manage/staff/TeacherTable';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { BreadcrumbItem } from '@/types';
+import type { Staff, Teacher } from '@/types/staff';
+
+/**
+ * 分頁資訊定義，僅保留頁面所需欄位，避免額外的 props 汙染。
+ */
+type PaginationMeta = {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+};
+
+interface StaffCollection {
+    active: Staff[];
+    trashed: Staff[];
+    meta?: PaginationMeta;
+}
+
+interface TeacherCollection {
+    data: Teacher[];
+    meta?: PaginationMeta;
+}
+
+interface StaffIndexPageProps {
+    initialTab?: 'staff' | 'teachers';
+    staff: StaffCollection;
+    teachers: TeacherCollection;
+    perPage?: number;
+    perPageOptions?: number[];
+}
+
+/**
+ * 後台教職員首頁，整合職員與教師兩個分頁，並提供建立、編輯與刪除操作。
+ */
+export default function StaffIndex({
+    initialTab = 'staff',
+    staff,
+    teachers,
+}: StaffIndexPageProps) {
+    const { t, locale } = useTranslation('staff');
+
+    // 以 state 紀錄使用者目前所在的分頁，確保 UI 與按鈕顯示一致。
+    const [activeTab, setActiveTab] = useState<'staff' | 'teachers'>(initialTab);
+
+    const staffActive = staff?.active ?? [];
+    const staffTrashed = staff?.trashed ?? [];
+    const teacherList = teachers?.data ?? [];
+    const teacherMeta: PaginationMeta = teachers?.meta ?? {
+        current_page: 1,
+        last_page: 1,
+        per_page: teacherList.length,
+        total: teacherList.length,
+    };
+
+    const pageTitle = t?.('staff.index.title', '師資與職員管理') ?? '師資與職員管理';
+    const pageDescription =
+        t?.(
+            'staff.index.description',
+            '管理系所教師與職員資料，維護個人檔案與聯絡資訊。',
+        ) ?? '管理系所教師與職員資料，維護個人檔案與聯絡資訊。';
+
+    const breadcrumbs = useMemo<BreadcrumbItem[]>(
+        () => [
+            {
+                title: t?.('layout.breadcrumbs.dashboard', '管理首頁') ?? '管理首頁',
+                href: '/manage/dashboard',
+            },
+            {
+                title: t?.('layout.breadcrumbs.staff', '教職員管理') ?? '教職員管理',
+                href: '/manage/staff',
+            },
+        ],
+        [t],
+    );
+
+    const createStaffLabel = t?.('staff.actions.create_staff', '新增職員') ?? '新增職員';
+    const createTeacherLabel = t?.('staff.actions.create_teacher', '新增教師') ?? '新增教師';
+
+    const handleCreateStaff = () => {
+        router.visit('/manage/staff/create');
+    };
+
+    const handleCreateTeacher = () => {
+        router.visit('/manage/teachers/create');
+    };
+
+    const handleStaffEdit = (staffMember: Staff) => {
+        router.visit(`/manage/staff/${staffMember.id}/edit`);
+    };
+
+    const handleStaffDelete = (staffMember: Staff) => {
+        router.delete(`/manage/staff/${staffMember.id}`);
+    };
+
+    const handleTeacherEdit = (teacher: Teacher) => {
+        router.visit(`/manage/teachers/${teacher.id}/edit`);
+    };
+
+    const handleTeacherDelete = (teacher: Teacher) => {
+        router.delete(`/manage/teachers/${teacher.id}`);
+    };
+
+    const handleTabChange = (value: string) => {
+        setActiveTab((value as 'staff' | 'teachers') ?? 'staff');
+    };
+
+    return (
+        <ManageLayout role="admin" breadcrumbs={breadcrumbs}>
+            <Head title={pageTitle} />
+
+            <section className="container mx-auto flex flex-col gap-6">
+                <ManagePageHeader
+                    title={pageTitle}
+                    description={pageDescription}
+                    actions={
+                        <div className="flex flex-col gap-2 sm:flex-row">
+                            <Button
+                                role="button"
+                                variant={activeTab === 'staff' ? 'default' : 'outline'}
+                                onClick={handleCreateStaff}
+                            >
+                                {createStaffLabel}
+                            </Button>
+                            <Button
+                                role="button"
+                                variant={activeTab === 'teachers' ? 'default' : 'outline'}
+                                onClick={handleCreateTeacher}
+                            >
+                                {createTeacherLabel}
+                            </Button>
+                        </div>
+                    }
+                />
+
+                <Tabs
+                    value={activeTab}
+                    onValueChange={handleTabChange}
+                    data-testid="tabs"
+                    className="space-y-4"
+                >
+                    <TabsList className="w-full sm:w-auto">
+                        <TabsTrigger value="teachers" data-testid="tab-teachers">
+                            {t?.('staff.tabs.teachers', '教師管理') ?? '教師管理'}
+                        </TabsTrigger>
+                        <TabsTrigger value="staff" data-testid="tab-staff">
+                            {t?.('staff.tabs.staff', '職員管理') ?? '職員管理'}
+                        </TabsTrigger>
+                    </TabsList>
+
+                    <TabsContent value="teachers" data-testid="tab-content-teachers">
+                        <Card className="border border-slate-200">
+                            <CardHeader>
+                                <CardTitle>{t?.('staff.teachers.title', '教師管理') ?? '教師管理'}</CardTitle>
+                                <CardDescription>
+                                    {t?.(
+                                        'staff.teachers.description',
+                                        '檢視教師聯絡資訊、所屬實驗室與帳號連結。',
+                                    ) ?? '檢視教師聯絡資訊、所屬實驗室與帳號連結。'}
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                <TeacherTable
+                                    teachers={teacherList}
+                                    onEdit={handleTeacherEdit}
+                                    onDelete={handleTeacherDelete}
+                                    locale={(locale as 'zh-TW' | 'en') ?? 'zh-TW'}
+                                />
+
+                                <div className="text-sm text-slate-600">
+                                    {`第 ${teacherMeta.current_page} 頁 / 共 ${teacherMeta.last_page} 頁，`}
+                                    {`每頁 ${teacherMeta.per_page} 筆，共 ${teacherMeta.total} 位教師`}
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </TabsContent>
+
+                    <TabsContent value="staff" data-testid="tab-content-staff">
+                        <Card className="border border-slate-200">
+                            <CardHeader>
+                                <CardTitle>{t?.('staff.staff.title', '職員管理') ?? '職員管理'}</CardTitle>
+                                <CardDescription>
+                                    {t?.(
+                                        'staff.staff.description',
+                                        '整理系辦職員的聯絡方式、職稱與排序設定。',
+                                    ) ?? '整理系辦職員的聯絡方式、職稱與排序設定。'}
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                {staffActive.length > 0 ? (
+                                    <>
+                                        <StaffTable
+                                            staff={staffActive}
+                                            onEdit={handleStaffEdit}
+                                            onDelete={handleStaffDelete}
+                                            locale={(locale as 'zh-TW' | 'en') ?? 'zh-TW'}
+                                        />
+
+                                        <div className="grid gap-2 text-sm text-slate-600">
+                                            {staffActive.map((member) => (
+                                                <div
+                                                    key={`staff-summary-${member.id}`}
+                                                    className="flex flex-wrap items-center gap-2"
+                                                >
+                                                    <span className="font-medium">{member.name_en}</span>
+                                                    {member.position_en && (
+                                                        <span className="text-slate-500">{member.position_en}</span>
+                                                    )}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </>
+                                ) : (
+                                    <div className="rounded-lg border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">
+                                        {t?.('staff.staff.empty', '目前沒有職員資料，請先新增職員。') ?? '目前沒有職員資料，請先新增職員。'}
+                                    </div>
+                                )}
+
+                                {staffTrashed.length > 0 && (
+                                    <Card className="border border-slate-200 bg-slate-50">
+                                        <CardHeader>
+                                            <CardTitle className="text-base font-medium text-slate-700">
+                                                {t?.('staff.staff.trashed', '已刪除職員') ?? '已刪除職員'}
+                                            </CardTitle>
+                                            <CardDescription>
+                                                {t?.(
+                                                    'staff.staff.trashed_description',
+                                                    '以下職員已被移除，可在後端還原或永久刪除。',
+                                                ) ?? '以下職員已被移除，可在後端還原或永久刪除。'}
+                                            </CardDescription>
+                                        </CardHeader>
+                                        <CardContent className="space-y-2">
+                                            {staffTrashed.map((member) => (
+                                                <div
+                                                    key={`trashed-${member.id}`}
+                                                    className="flex flex-col gap-1 rounded-lg bg-white px-4 py-3 text-sm shadow-sm ring-1 ring-slate-200 sm:flex-row sm:items-center sm:justify-between"
+                                                >
+                                                    <div className="font-medium text-slate-700">{member.name}</div>
+                                                    <div className="text-xs text-slate-500">
+                                                        {member.deleted_at
+                                                            ? `${t?.('staff.staff.deleted_at', '刪除於') ?? '刪除於'} ${new Date(
+                                                                  member.deleted_at,
+                                                              ).toLocaleString('zh-TW')}`
+                                                            : t?.('staff.staff.deleted', '刪除紀錄') ?? '刪除紀錄'}
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </CardContent>
+                                    </Card>
+                                )}
+                            </CardContent>
+                        </Card>
+                    </TabsContent>
+                </Tabs>
+            </section>
+        </ManageLayout>
+    );
+}

--- a/resources/js/pages/manage/posts/index.tsx
+++ b/resources/js/pages/manage/posts/index.tsx
@@ -1,938 +1,34 @@
-import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-
-import { Head, Link, router, useForm, usePage } from '@inertiajs/react';import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
-
-import ManageLayout from '@/layouts/manage/manage-layout';import ManageLayout from '@/layouts/manage/manage-layout';
-
-import { Button } from '@/components/ui/button';import { Button } from '@/components/ui/button';
-
-import { ManagePageHeader } from '@/components/manage/manage-page-header';import { ManagePageHeader } from '@/components/manage/manage-page-header';
-
-import { Filter, Upload } from 'lucide-react';import { Filter, Upload } from 'lucide-react';
-
-import type { BreadcrumbItem, SharedData } from '@/types';import type { BreadcrumbItem, SharedData } from '@/types';
-
-import { useTranslator } from '@/hooks/use-translator';import { useTranslator } from '@/hooks/use-translator';
-
-import {import {
-
-    type AuthorOption,    type AuthorOption,
-
-    type CategoryOption,    type CategoryOption,
-
-    type FilterState,    type FilterState,
-
-    type PaginationLink,    type PaginationLink,
-
-    type PaginationMeta,    type PaginationMeta,
-
-    type PostFlashMessages,    type PostFlashMessages,
-
-    type PostItem,    type PostItem,
-
-    type PostStatus,    type PostStatus,
-
-} from '@/components/manage/post/post-types';} from '@/components/manage/post/post-types';
-
-import { PostFilterForm } from '@/components/manage/post/post-filter-form';import { PostFilterForm } from '@/components/manage/post/post-filter-form';
-
-import { PostTable } from '@/components/manage/post/post-table';import { PostTable } from '@/components/manage/post/post-table';
-
-import BulkImportDialog from '@/components/manage/post/bulk-import-dialog';import BulkImportDialog from '@/components/manage/post/bulk-import-dialog';
-
-import { PostFlashAlerts } from '@/components/manage/post/post-flash-alerts';import { PostFlashAlerts } from '@/components/manage/post/post-flash-alerts';
-
-import { useToast } from '@/hooks/use-toast';import { useToast } from '@/hooks/use-toast';
-
-import ToastContainer from '@/components/ui/toast-container';import ToastContainer from '@/components/ui/toast-container';
-
-
-
-/**/**
-
- * 公告管理主頁面 * 公告管理主頁面
-
- * *
-
- * 功能特色： * 功能特色：
-
- * - 公告列表展示與篩選 * - 公告列表展示與篩選
-
- * - 批次操作（發布、取消發布、刪除） * - 批次操作（發布、取消發布、刪除）
-
- * - CSV 批次匯入功能 * - CSV 批次匯入功能
-
- * - 完整的錯誤處理和使用者回饋 * - 完整的錯誤處理和使用者回饋
-
- * - 響應式設計 * - 響應式設計
-
- */ */
-
-
-
-interface PostsIndexProps {interface PostsIndexProps {
-
-    posts: {    posts: {
-
-        data: PostItem[];        data: PostItem[];
-
-        current_page: number;        current_page: number;
-
-        last_page: number;        last_page: number;
-
-        per_page: number;        per_page: number;
-
-        total: number;        total: number;
-
-        from: number | null;        from: number | null;
-
-        to: number | null;        to: number | null;
-
-        links: PaginationLink[];        links: PaginationLink[];
-
-    };    };
-
-    categories: CategoryOption[];    categories: CategoryOption[];
-
-    authors: AuthorOption[];    authors: AuthorOption[];
-
-    filters: Partial<FilterState>;    filters: Partial<FilterState>;
-
-    statusOptions: PostStatus[];    statusOptions: PostStatus[];
-
-    perPageOptions: number[];    perPageOptions: number[];
-
-    can: {    can: {
-
-        create: boolean;        create: boolean;
-
-        bulk: boolean;        bulk: boolean;
-
-        import: boolean;        import: boolean;
-
-    };    };
-
-}}
-
-
-
-/**/**
-
- * 建立初始篩選狀態 * 建立初始篩選狀態
-
- */ */
-
-const createInitialFilterState = (const createInitialFilterState = (
-
-    filters: PostsIndexProps['filters'],    filters: PostsIndexProps['filters'],
-
-    defaultPerPage: number,    defaultPerPage: number,
-
-): FilterState => ({): FilterState => ({
-
-    search: filters.search ?? '',    search: filters.search ?? '',
-
-    category: filters.category ?? '',    category: filters.category ?? '',
-
-    status: filters.status ?? '',    status: filters.status ?? '',
-
-    author: filters.author ?? '',    author: filters.author ?? '',
-
-    date_from: filters.date_from ?? '',    date_from: filters.date_from ?? '',
-
-    date_to: filters.date_to ?? '',    date_to: filters.date_to ?? '',
-
-    per_page: filters.per_page ?? String(defaultPerPage),    per_page: filters.per_page ?? String(defaultPerPage),
-
-});});
-
-
-
-export default function PostsIndex({ posts, categories, authors, filters, statusOptions, perPageOptions, can }: PostsIndexProps) {export default function PostsIndex({ posts, categories, authors, filters, statusOptions, perPageOptions, can }: PostsIndexProps) {
-
-    // 基本設定    // 基本設定
-
-    const page = usePage<SharedData & { flash?: PostFlashMessages }>();    const page = usePage<SharedData & { flash?: PostFlashMessages }>();
-
-    const { locale } = page.props;    const { locale } = page.props;
-
-    const flashMessages: PostFlashMessages = page.props.flash ?? {};    const flashMessages: PostFlashMessages = page.props.flash ?? {};
-
-    const { t } = useTranslator('manage');    const { t } = useTranslator('manage');
-
-
-
-    // 語言設定    // 語言設定
-
-    const fallbackLanguage = locale?.toLowerCase() === 'zh-tw' ? 'zh' : 'en';    const fallbackLanguage = locale?.toLowerCase() === 'zh-tw' ? 'zh' : 'en';
-
-    const localeForDate = locale?.toLowerCase() === 'zh-tw' ? 'zh-TW' : 'en';    const localeForDate = locale?.toLowerCase() === 'zh-tw' ? 'zh-TW' : 'en';
-
-
-
-    // 分頁與篩選狀態    // 分頁與篩選狀態
-
-    const pagination: PaginationMeta = {    const pagination: PaginationMeta = {
-
-        current_page: posts.current_page,        current_page: posts.current_page,
-
-        last_page: posts.last_page,        last_page: posts.last_page,
-
-        per_page: posts.per_page,        per_page: posts.per_page,
-
-        total: posts.total,        total: posts.total,
-
-        from: posts.from,        from: posts.from,
-
-        to: posts.to,        to: posts.to,
-
-    };    };
-
-    const paginationLinks = posts.links;    const paginationLinks = posts.links;
-
-    const defaultPerPage = perPageOptions[0] || 15;    const defaultPerPage = perPageOptions[0] || 15;
-
-
-
-    // 狀態管理    // 狀態管理
-
-    const [filterState, setFilterState] = useState<FilterState>(    const [filterState, setFilterState] = useState<FilterState>(
-
-        createInitialFilterState(filters, defaultPerPage)        createInitialFilterState(filters, defaultPerPage)
-
-    );    );
-
-    const [selected, setSelected] = useState<number[]>([]);    const [selected, setSelected] = useState<number[]>([]);
-
-
-
-    // Toast 管理    // Toast 管理
-
-    const {    const {
-
-        toasts,        toasts,
-
-        showSuccess,        showSuccess,
-
-        showError,        showError,
-
-        showInfo,        showInfo,
-
-        showBatchErrors,        showWarning,
-
-        dismissToast        showBatchErrors,
-
-    } = useToast();        dismissToast
-
-    } = useToast();
-
-    // 批次操作表單
-
-    const bulkForm = useForm<{    // 批次操作表單
-
-        action: 'publish' | 'unpublish' | 'delete';    const bulkForm = useForm<{
-
-        ids: number[];        action: 'publish' | 'unpublish' | 'delete';
-
-    }>({        ids: number[];
-
-        action: 'publish',    }>({
-
-        ids: [],        action: 'publish',
-
-    });        ids: [],
-
-    });
-
-    // 參考和快取
-
-    const skipFlashToastRef = useRef(false);    // 參考和快取
-
-    const previousFlashRef = useRef<PostFlashMessages>({});    const skipFlashToastRef = useRef(false);
-
-    const previousFlashRef = useRef<PostFlashMessages>({});
-
-    // 計算屬性
-
-    const iconActionClass = useMemo(() => 'h-4 w-4', []);    // 計算屬性
-
-    const hasFlashAlerts = useMemo(() =>    const iconActionClass = useMemo(() => 'h-4 w-4', []);
-
-        Boolean(flashMessages.success || flashMessages.error ||    const hasFlashAlerts = useMemo(() =>
-
-               (flashMessages.importErrors && flashMessages.importErrors.length > 0)),        Boolean(flashMessages.success || flashMessages.error || flashMessages.warning ||
-
-        [flashMessages]               (flashMessages.importErrors && flashMessages.importErrors.length > 0)),
-
-    );        [flashMessages]
-
-    const hasActiveFilters = useMemo(() =>    );
-
-        filterState.search !== '' ||    const hasActiveFilters = useMemo(() =>
-
-        filterState.category !== '' ||        filterState.search !== '' ||
-
-        filterState.status !== '' ||        filterState.category !== '' ||
-
-        filterState.author !== '' ||        filterState.status !== '' ||
-
-        filterState.date_from !== '' ||        filterState.author !== '' ||
-
-        filterState.date_to !== '',        filterState.date_from !== '' ||
-
-        [filterState],        filterState.date_to !== '',
-
-    );        [filterState],
-
-    );
-
-    // 麵包屑導航
-
-    const breadcrumbs: BreadcrumbItem[] = [    // 麵包屑導航
-
-        { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },    const breadcrumbs: BreadcrumbItem[] = [
-
-        { title: t('layout.breadcrumbs.posts', '公告管理'), href: '/manage/posts' },        { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
-
-    ];        { title: t('layout.breadcrumbs.posts', '公告管理'), href: '/manage/posts' },
-
-    ];
-
-    /**
-
-     * 處理篩選條件變更    /**
-
-     */     * 處理篩選條件變更
-
-    const handleFilterChange = useCallback(     */
-
-        (key: keyof FilterState, value: string) => {    const handleFilterChange = useCallback(
-
-            setFilterState((previous) => ({ ...previous, [key]: value }));        (key: keyof FilterState, value: string) => {
-
-        },            setFilterState((previous) => ({ ...previous, [key]: value }));
-
-        [],        },
-
-    );        [],
-
-    );
-
-    /**
-
-     * 套用篩選條件    /**
-
-     */     * 套用篩選條件
-
-    const applyFilters = useCallback((event?: FormEvent<HTMLFormElement>) => {     */
-
-        event?.preventDefault();    const applyFilters = useCallback((event?: FormEvent<HTMLFormElement>) => {
-
-        router.get(        event?.preventDefault();
-
-            '/manage/posts',        router.get(
-
-            {            '/manage/posts',
-
-                ...Object.fromEntries(            {
-
-                    Object.entries(filterState).filter(([, value]) => value !== ''),                ...Object.fromEntries(
-
-                ),                    Object.entries(filterState).filter(([, value]) => value !== ''),
-
-            },                ),
-
-            { preserveState: true, preserveScroll: true }            },
-
-        );            { preserveState: true, preserveScroll: true }
-
-    }, [filterState]);        );
-
-    }, [filterState]);
-
-    /**
-
-     * 重置篩選條件    /**
-
-     */     * 重置篩選條件
-
-    const resetFilters = useCallback(() => {     */
-
-        const initialState = createInitialFilterState({}, defaultPerPage);    const resetFilters = useCallback(() => {
-
-        setFilterState(initialState);        const initialState = createInitialFilterState({}, defaultPerPage);
-
-        router.get('/manage/posts', {}, { preserveState: true, preserveScroll: true });        setFilterState(initialState);
-
-    }, [defaultPerPage]);        router.get('/manage/posts', {}, { preserveState: true, preserveScroll: true });
-
-    }, [defaultPerPage]);
-
-    /**
-
-     * 切換頁面    /**
-
-     */     * 切換頁面
-
-    const changePage = useCallback((page: number) => {     */
-
-        if (page === pagination.current_page || page < 1 || page > pagination.last_page) {    const changePage = useCallback((page: number) => {
-
-            return;        if (page === pagination.current_page || page < 1 || page > pagination.last_page) {
-
-        }            return;
-
-        }
-
-        const params = {
-
-            ...Object.fromEntries(        const params = {
-
-                Object.entries(filterState).filter(([, value]) => value !== '')            ...Object.fromEntries(
-
-            ),                Object.entries(filterState).filter(([, value]) => value !== '')
-
-            page: page.toString(),            ),
-
-        };            page: page.toString(),
-
-        };
-
-        router.get('/manage/posts', params, {
-
-            preserveState: true,        router.get('/manage/posts', params, {
-
-            preserveScroll: true,            preserveState: true,
-
-        });            preserveScroll: true,
-
-    }, [pagination, filterState]);        });
-
-    }, [pagination, filterState]);
-
-    /**
-
-     * 選擇/取消選擇所有項目    /**
-
-     */     * 選擇/取消選擇所有項目
-
-    const handleToggleSelectAll = useCallback((checked: boolean) => {     */
-
-        setSelected(checked ? posts.data.map(post => post.id) : []);    const handleToggleSelectAll = useCallback((checked: boolean) => {
-
-    }, [posts.data]);        setSelected(checked ? posts.data.map(post => post.id) : []);
-
-    }, [posts.data]);
-
-    /**
-
-     * 選擇/取消選擇單一項目    /**
-
-     */     * 選擇/取消選擇單一項目
-
-    const handleToggleSelection = useCallback((postId: number) => {     */
-
-        setSelected(prev => {    const handleToggleSelection = useCallback((postId: number) => {
-
-            if (prev.includes(postId)) {        setSelected(prev => {
-
-                return prev.filter(id => id !== postId);            if (prev.includes(postId)) {
-
-            } else {                return prev.filter(id => id !== postId);
-
-                return [...prev, postId];            } else {
-
-            }                return [...prev, postId];
-
-        });            }
-
-    }, []);        });
-
-    }, []);
-
-    /**
-
-     * 執行批次操作    /**
-
-     */     * 執行批次操作
-
-    const performBulkAction = useCallback((action: 'publish' | 'unpublish' | 'delete') => {     */
-
-        if (selected.length === 0 || bulkForm.processing) return;    const performBulkAction = useCallback((action: 'publish' | 'unpublish' | 'delete') => {
-
-        if (selected.length === 0 || bulkForm.processing) return;
-
-        // 確認刪除操作
-
-        if (action === 'delete') {        // 確認刪除操作
-
-            const confirmed = window.confirm(        if (action === 'delete') {
-
-                t('posts.index.bulk.delete_confirm',            const confirmed = window.confirm(
-
-                  `確定要刪除選取的 ${selected.length} 筆公告嗎？此操作無法復原。`)                t('posts.index.bulk.delete_confirm',
-
-            );                  `確定要刪除選取的 ${selected.length} 筆公告嗎？此操作無法復原。`)
-
-            if (!confirmed) return;            );
-
-        }            if (!confirmed) return;
-
-        }
-
-        bulkForm.transform(() => ({
-
-            action,        bulkForm.transform(() => ({
-
-            ids: selected,            action,
-
-        }));            ids: selected,
-
-        }));
-
-        bulkForm.post('/manage/posts/bulk', {
-
-            preserveScroll: true,        bulkForm.post('/manage/posts/bulk', {
-
-            onSuccess: () => {            preserveScroll: true,
-
-                setSelected([]);            onSuccess: () => {
-
-                bulkForm.reset();                setSelected([]);
-
-                skipFlashToastRef.current = true;                bulkForm.reset();
-
-                skipFlashToastRef.current = true;
-
-                const messages = {
-
-                    publish: t('posts.index.bulk.publish_success', '已發布選取的公告'),                const messages = {
-
-                    unpublish: t('posts.index.bulk.unpublish_success', '已取消發布選取的公告'),                    publish: t('posts.index.bulk.publish_success', '已發布選取的公告'),
-
-                    delete: t('posts.index.bulk.delete_success', '已刪除選取的公告'),                    unpublish: t('posts.index.bulk.unpublish_success', '已取消發布選取的公告'),
-
-                };                    delete: t('posts.index.bulk.delete_success', '已刪除選取的公告'),
-
-                };
-
-                showSuccess(
-
-                    t('posts.index.flash.success_title', '操作成功'),                showSuccess(
-
-                    messages[action]                    t('posts.index.flash.success_title', '操作成功'),
-
-                );                    messages[action]
-
-            },                );
-
-            onError: (errors) => {            },
-
-                skipFlashToastRef.current = true;            onError: (errors) => {
-
-                const errorMessages = Object.values(errors)                skipFlashToastRef.current = true;
-
-                    .flat()                const errorMessages = Object.values(errors)
-
-                    .map((value) => String(value))                    .flat()
-
-                    .filter((value) => value.length > 0);                    .map((value) => String(value))
-
-                    .filter((value) => value.length > 0);
-
-                showBatchErrors(
-
-                    errorMessages.length > 0 ? errorMessages : [                showBatchErrors(
-
-                        t('posts.index.bulk.error_fallback', '批次操作失敗，請重新嘗試')                    errorMessages.length > 0 ? errorMessages : [
-
-                    ],                        t('posts.index.bulk.error_fallback', '批次操作失敗，請重新嘗試')
-
-                    t('posts.index.flash.error_title', '操作失敗')                    ],
-
-                );                    t('posts.index.flash.error_title', '操作失敗')
-
-            },                );
-
-        });            },
-
-    }, [selected, bulkForm, t, showSuccess, showBatchErrors]);        });
-
-    }, [selected, bulkForm, t, showSuccess, showBatchErrors]);
-
-    // 批次匯入處理函數
-
-    const handleImportStart = useCallback((message: string) => {    // 批次匯入處理函數
-
-        showInfo(    const handleImportStart = useCallback((message: string) => {
-
-            t('posts.index.import.start_title', fallbackLanguage === 'zh' ? '開始匯入' : 'Import started'),        showInfo(
-
-            message            t('posts.index.import.start_title', fallbackLanguage === 'zh' ? '開始匯入' : 'Import started'),
-
-        );            message
-
-    }, [showInfo, t, fallbackLanguage]);        );
-
-    }, [showInfo, t, fallbackLanguage]);
-
-    const handleImportSuccess = useCallback((message: string) => {
-
-        skipFlashToastRef.current = true;    const handleImportSuccess = useCallback((message: string) => {
-
-        showSuccess(        skipFlashToastRef.current = true;
-
-            t('posts.index.flash.success_title', '操作成功'),        showSuccess(
-
-            message            t('posts.index.flash.success_title', '操作成功'),
-
-        );            message
-
-        );
-
-        // 重新載入頁面資料
-
-        router.reload({ only: ['posts'] });        // 重新載入頁面資料
-
-    }, [showSuccess, t]);        router.reload({ only: ['posts'] });
-
-    }, [showSuccess, t]);
-
-    const handleImportError = useCallback((messages: string[]) => {
-
-        skipFlashToastRef.current = true;    const handleImportError = useCallback((messages: string[]) => {
-
-        showBatchErrors(        skipFlashToastRef.current = true;
-
-            messages,        showBatchErrors(
-
-            t('posts.index.import.error_title', fallbackLanguage === 'zh' ? '匯入失敗' : 'Import failed')            messages,
-
-        );            t('posts.index.import.error_title', fallbackLanguage === 'zh' ? '匯入失敗' : 'Import failed')
-
-    }, [showBatchErrors, t, fallbackLanguage]);        );
-
-    }, [showBatchErrors, t, fallbackLanguage]);
-
-    const handleImportClientError = useCallback((message: string) => {
-
-        showError(    const handleImportClientError = useCallback((message: string) => {
-
-            t('posts.index.import.error_title', fallbackLanguage === 'zh' ? '匯入失敗' : 'Import failed'),        showError(
-
-            message            t('posts.index.import.error_title', fallbackLanguage === 'zh' ? '匯入失敗' : 'Import failed'),
-
-        );            message
-
-    }, [showError, t, fallbackLanguage]);        );
-
-    }, [showError, t, fallbackLanguage]);
-
-    // 副作用處理
-
-    useEffect(() => {    // 副作用處理
-
-        setFilterState(createInitialFilterState(filters, defaultPerPage));    useEffect(() => {
-
-    }, [filters, defaultPerPage]);        setFilterState(createInitialFilterState(filters, defaultPerPage));
-
-    }, [filters, defaultPerPage]);
-
-    useEffect(() => {
-
-        setSelected([]);    useEffect(() => {
-
-    }, [pagination.current_page, pagination.total]);        setSelected([]);
-
-    }, [pagination.current_page, pagination.total]);
-
-    /**
-
-     * 處理後端 flash 訊息    /**
-
-     */     * 處理後端 flash 訊息
-
-    useEffect(() => {     */
-
-        if (skipFlashToastRef.current) {    useEffect(() => {
-
-            previousFlashRef.current = flashMessages;        if (skipFlashToastRef.current) {
-
-            skipFlashToastRef.current = false;            previousFlashRef.current = flashMessages;
-
-            return;            skipFlashToastRef.current = false;
-
-        }            return;
-
-        }
-
-        // 成功訊息
-
-        if (flashMessages.success && flashMessages.success !== previousFlashRef.current.success) {        // 成功訊息
-
-            showSuccess(        if (flashMessages.success && flashMessages.success !== previousFlashRef.current.success) {
-
-                t('posts.index.flash.success_title', '操作成功'),            showSuccess(
-
-                flashMessages.success                t('posts.index.flash.success_title', '操作成功'),
-
-            );                flashMessages.success
-
-        }            );
-
-        }
-
-        // 錯誤訊息
-
-        if (flashMessages.error && flashMessages.error !== previousFlashRef.current.error) {        // 錯誤訊息
-
-            showError(        if (flashMessages.error && flashMessages.error !== previousFlashRef.current.error) {
-
-                t('posts.index.flash.error_title', '操作失敗'),            showError(
-
-                flashMessages.error                t('posts.index.flash.error_title', '操作失敗'),
-
-            );                flashMessages.error
-
-        }            );
-
-        }
-
-        // 匯入錯誤訊息
-
-        const importErrors = flashMessages.importErrors || [];        // 警告訊息
-
-        const previousImportErrors = previousFlashRef.current.importErrors || [];        if (flashMessages.warning && flashMessages.warning !== previousFlashRef.current.warning) {
-
-            showWarning(
-
-        const newImportErrors = importErrors.filter(error =>                t('posts.index.flash.warning_title', '注意'),
-
-            !previousImportErrors.includes(error)                flashMessages.warning
-
-        );            );
-
-        }
-
-        if (newImportErrors.length > 0) {
-
-            showBatchErrors(        // 匯入錯誤訊息
-
-                newImportErrors,        const importErrors = flashMessages.importErrors || [];
-
-                t('posts.index.import.error_title', fallbackLanguage === 'zh' ? '匯入錯誤' : 'Import errors')        const previousImportErrors = previousFlashRef.current.importErrors || [];
-
-            );
-
-        }        const newImportErrors = importErrors.filter(error =>
-
-            !previousImportErrors.includes(error)
-
-        previousFlashRef.current = flashMessages;        );
-
-    }, [flashMessages, showSuccess, showError, showBatchErrors, t, fallbackLanguage]);
-
-        if (newImportErrors.length > 0) {
-
-    return (            showBatchErrors(
-
-        <ManageLayout breadcrumbs={breadcrumbs}>                newImportErrors,
-
-            <Head title={t('posts.index.title', '公告管理')} />                t('posts.index.import.error_title', fallbackLanguage === 'zh' ? '匯入錯誤' : 'Import errors')
-
-            );
-
-            {/* Toast 容器 */}        }
-
-            <ToastContainer
-
-                toasts={toasts}        previousFlashRef.current = flashMessages;
-
-                onDismiss={dismissToast}    }, [flashMessages, showSuccess, showError, showWarning, showBatchErrors, t, fallbackLanguage]);
-
-                position="bottom-right"
-
-            />    return (
-
-        <ManageLayout breadcrumbs={breadcrumbs}>
-
-            <section className="space-y-6">            <Head title={t('posts.index.title', '公告管理')} />
-
-                {/* Flash 提示訊息 */}
-
-                {hasFlashAlerts && <PostFlashAlerts messages={flashMessages} t={t} />}            {/* Toast 容器 */}
-
-            <ToastContainer
-
-                {/* 頁面標頭 */}                toasts={toasts}
-
-                <ManagePageHeader                onDismiss={dismissToast}
-
-                    badge={{                position="bottom-right"
-
-                        icon: <Filter className="h-4 w-4" />,            />
-
-                        label: t('posts.index.badge', '公告總覽')
-
-                    }}            <section className="space-y-6">
-
-                    title={t('posts.index.title', '公告管理')}                {/* Flash 提示訊息 */}
-
-                    description={t(                {hasFlashAlerts && <PostFlashAlerts messages={flashMessages} t={t} />}
-
-                        'posts.index.description',
-
-                        '管理公告分類、排程發布及附件檔案，確保資訊即時且一致。',                {/* 頁面標頭 */}
-
-                    )}                <ManagePageHeader
-
-                    actions={                    badge={{
-
-                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">                        icon: <Filter className="h-4 w-4" />,
-
-                            {/* 批次匯入按鈕 */}                        label: t('posts.index.badge', '公告總覽')
-
-                            {(can.bulk && can.import) && (                    }}
-
-                                <BulkImportDialog                    title={t('posts.index.title', '公告管理')}
-
-                                    t={t}                    description={t(
-
-                                    fallbackLanguage={fallbackLanguage}                        'posts.index.description',
-
-                                    trigger={                        '管理公告分類、排程發布及附件檔案，確保資訊即時且一致。',
-
-                                        <Button variant="outline" className="rounded-full px-6">                    )}
-
-                                            <Upload className="mr-2 h-4 w-4" />                    actions={
-
-                                            {t('posts.index.actions.import_csv',                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-
-                                              fallbackLanguage === 'zh' ? '批次匯入' : 'Bulk Import')}                            {/* 批次匯入按鈕 */}
-
-                                        </Button>                            {(can.bulk && can.import) && (
-
-                                    }                                <BulkImportDialog
-
-                                    onStart={handleImportStart}                                    t={t}
-
-                                    onSuccess={handleImportSuccess}                                    fallbackLanguage={fallbackLanguage}
-
-                                    onError={handleImportError}                                    trigger={
-
-                                    onClientError={handleImportClientError}                                        <Button variant="outline" className="rounded-full px-6">
-
-                                />                                            <Upload className="mr-2 h-4 w-4" />
-
-                            )}                                            {t('posts.index.actions.import_csv',
-
-                                              fallbackLanguage === 'zh' ? '批次匯入' : 'Bulk Import')}
-
-                            {/* 新增公告按鈕 */}                                        </Button>
-
-                            {can.create && (                                    }
-
-                                <Button asChild className="rounded-full px-6">                                    onStart={handleImportStart}
-
-                                    <Link href="/manage/posts/create">                                    onSuccess={handleImportSuccess}
-
-                                        {t('posts.index.create', '新增公告')}                                    onError={handleImportError}
-
-                                    </Link>                                    onClientError={handleImportClientError}
-
-                                </Button>                                />
-
-                            )}                            )}
-
-                        </div>
-
-                    }                            {/* 新增公告按鈕 */}
-
-                />                            {can.create && (
-
-                                <Button asChild className="rounded-full px-6">
-
-                {/* 篩選表單 */}                                    <Link href="/manage/posts/create">
-
-                <PostFilterForm                                        {t('posts.index.create', '新增公告')}
-
-                    filterState={filterState}                                    </Link>
-
-                    categories={categories}                                </Button>
-
-                    authors={authors}                            )}
-
-                    statusOptions={statusOptions}                        </div>
-
-                    perPageOptions={perPageOptions}                    }
-
-                    hasActiveFilters={hasActiveFilters}                />
-
-                    onChange={handleFilterChange}
-
-                    onSubmit={applyFilters}                {/* 篩選表單 */}
-
-                    onReset={resetFilters}                <PostFilterForm
-
-                    t={t}                    filterState={filterState}
-
-                    fallbackLanguage={fallbackLanguage}                    categories={categories}
-
-                />                    authors={authors}
-
-                    statusOptions={statusOptions}
-
-                {/* 公告列表 */}                    perPageOptions={perPageOptions}
-
-                <PostTable                    hasActiveFilters={hasActiveFilters}
-
-                    posts={posts.data}                    onChange={handleFilterChange}
-
-                    selectedIds={selected}                    onSubmit={applyFilters}
-
-                    canBulk={can.bulk}                    onReset={resetFilters}
-
-                    onToggleSelectAll={handleToggleSelectAll}                    t={t}
-
-                    onToggleSelection={handleToggleSelection}                    fallbackLanguage={fallbackLanguage}
-
-                    onBulkAction={performBulkAction}                />
-
-                    bulkFormProcessing={bulkForm.processing}
-
-                    pagination={pagination}                {/* 公告列表 */}
-
-                    paginationLinks={paginationLinks}                <PostTable
-
-                    changePage={changePage}                    posts={posts.data}
-
-                    iconActionClass={iconActionClass}                    selectedIds={selected}
-
-                    t={t}                    canBulk={can.bulk}
-
-                    fallbackLanguage={fallbackLanguage}                    onToggleSelectAll={handleToggleSelectAll}
-
-                    localeForDate={localeForDate}                    onToggleSelection={handleToggleSelection}
-
-                />                    onBulkAction={performBulkAction}
-
-            </section>                    bulkFormProcessing={bulkForm.processing}
-
-        </ManageLayout>                    pagination={pagination}
-
-    );                    paginationLinks={paginationLinks}
-
-}                    changePage={changePage}
-                    iconActionClass={iconActionClass}
-                    t={t}
-                    fallbackLanguage={fallbackLanguage}
-                    localeForDate={localeForDate}
-                />
-            </section>
-        </ManageLayout>
-    );
-}
-
+import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
+import { Filter, Upload } from 'lucide-react';
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import { Button } from '@/components/ui/button';
+import ToastContainer from '@/components/ui/toast-container';
+import ManageLayout from '@/layouts/manage/manage-layout';
+
+import { useToast } from '@/hooks/use-toast';
+import { useTranslator } from '@/hooks/use-translator';
+
+import BulkImportDialog from '@/components/manage/post/bulk-import-dialog';
+import { PostFilterForm } from '@/components/manage/post/post-filter-form';
+import { PostFlashAlerts } from '@/components/manage/post/post-flash-alerts';
+import { PostTable } from '@/components/manage/post/post-table';
+import type {
+    AuthorOption,
+    CategoryOption,
+    FilterState,
+    PaginationLink,
+    PaginationMeta,
+    PostFlashMessages,
+    PostItem,
+    PostStatus,
+} from '@/components/manage/post/post-types';
+import type { BreadcrumbItem, SharedData } from '@/types';
+
+/**
+ * 公告列表頁面屬性定義
+ */
 interface PostsIndexProps {
     posts: {
         data: PostItem[];
@@ -941,8 +37,8 @@ interface PostsIndexProps {
     };
     categories: CategoryOption[];
     authors: AuthorOption[];
-    filters: Partial<Record<'search' | 'category' | 'status' | 'author' | 'date_from' | 'date_to' | 'per_page', string>>;
-    statusOptions: Array<PostStatus>;
+    filters: Partial<FilterState>;
+    statusOptions: PostStatus[];
     perPageOptions: number[];
     can: {
         create: boolean;
@@ -950,10 +46,10 @@ interface PostsIndexProps {
     };
 }
 
-const createInitialFilterState = (
-    filters: PostsIndexProps['filters'],
-    defaultPerPage: number,
-): FilterState => ({
+/**
+ * 建立初始篩選狀態，確保重新整理或重新載入後狀態一致
+ */
+const createInitialFilterState = (filters: PostsIndexProps['filters'], defaultPerPage: number): FilterState => ({
     search: filters.search ?? '',
     category: filters.category ?? '',
     status: filters.status ?? '',
@@ -964,162 +60,63 @@ const createInitialFilterState = (
 });
 
 export default function PostsIndex({ posts, categories, authors, filters, statusOptions, perPageOptions, can }: PostsIndexProps) {
-    const { auth, flash } = usePage<SharedData & { flash?: PostFlashMessages }>().props;
-    const userRole = auth?.user?.role ?? 'user';
-    const layoutRole: 'admin' | 'teacher' | 'user' =
-        userRole === 'admin' ? 'admin' : userRole === 'teacher' ? 'teacher' : 'user';
-    const { t, localeKey } = useTranslator('manage');
-    const fallbackLanguage: 'zh' | 'en' = localeKey === 'zh-TW' ? 'zh' : 'en';
-    const localeForDate: 'zh-TW' | 'en' = localeKey === 'zh-TW' ? 'zh-TW' : 'en';
-    const iconActionClass = cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-9 w-9 p-0');
-    const defaultPerPage = perPageOptions[0] ?? 20;
+    const page = usePage<SharedData & { flash?: PostFlashMessages }>();
+    const flashMessages: PostFlashMessages = page.props.flash ?? {};
+    const locale = page.props.locale ?? 'zh-TW';
 
-    const flashMessages: PostFlashMessages = flash ?? {};
-    const hasFlashAlerts = Boolean(
-        flashMessages.success ||
-            flashMessages.error ||
-            (flashMessages.importErrors && flashMessages.importErrors.length > 0),
-    );
+    const { t } = useTranslator('manage');
+    const fallbackLanguage: 'zh' | 'en' = locale.toLowerCase() === 'zh-tw' ? 'zh' : 'en';
+    const localeForDate: 'zh-TW' | 'en' = locale.toLowerCase() === 'zh-tw' ? 'zh-TW' : 'en';
 
-    const [selected, setSelected] = useState<number[]>([]);
-    const [filterState, setFilterState] = useState<FilterState>(
-        createInitialFilterState(filters, defaultPerPage),
-    );
-    const resolvedPerPage = Number(filterState.per_page || defaultPerPage);
-
+    const defaultPerPage = perPageOptions[0] ?? 15;
     const postData = posts?.data ?? [];
-    const pagination: PaginationMeta = posts?.meta ?? {
+    const paginationMeta = posts?.meta ?? {
         current_page: 1,
         last_page: 1,
-        per_page: resolvedPerPage,
+        per_page: defaultPerPage,
         total: postData.length,
+        from: postData.length > 0 ? 1 : 0,
+        to: postData.length,
+    };
+    const pagination: PaginationMeta = {
+        current_page: paginationMeta.current_page,
+        last_page: paginationMeta.last_page,
+        per_page: paginationMeta.per_page,
+        total: paginationMeta.total,
+        from: paginationMeta.from,
+        to: paginationMeta.to,
     };
     const paginationLinks = posts?.links ?? [];
 
-    const bulkForm = useForm({
-        action: '',
-        ids: [] as number[],
-    });
+    // Toast 管理，確保各種操作都有即時提示
+    const { toasts, showSuccess, showError, showInfo, showBatchErrors, dismissToast } = useToast();
 
-    const { toasts, showToast, dismissToast } = usePostToast();
+    // 頁面狀態管理
+    const [filterState, setFilterState] = useState<FilterState>(createInitialFilterState(filters, defaultPerPage));
+    const [selected, setSelected] = useState<number[]>([]);
+
+    // 由於批次操作與匯入可能會回傳 flash 訊息，此旗標用來避免重複顯示 toast
     const skipFlashToastRef = useRef(false);
     const previousFlashRef = useRef<PostFlashMessages>({});
 
-    const breadcrumbs: BreadcrumbItem[] = [
-        { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
-        { title: t('layout.breadcrumbs.posts', '公告管理'), href: '/manage/posts' },
-    ];
-
-    const handleFilterChange = useCallback(
-        (key: keyof FilterState, value: string) => {
-            setFilterState((previous) => ({ ...previous, [key]: value }));
-        },
+    const iconActionClass = useMemo(
+        () =>
+            'inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500/60',
         [],
     );
 
-    const applyFilters = (event?: FormEvent<HTMLFormElement>) => {
-        event?.preventDefault();
-        router.get(
-            '/manage/posts',
-            {
-                ...Object.fromEntries(
-                    Object.entries(filterState).filter(([, value]) => value !== ''),
-                ),
-            },
-            {
-                preserveState: true,
-                preserveScroll: true,
-            },
-        );
-    };
+    const breadcrumbs: BreadcrumbItem[] = useMemo(
+        () => [
+            { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+            { title: t('layout.breadcrumbs.posts', '公告管理'), href: '/manage/posts' },
+        ],
+        [t],
+    );
 
-    const resetFilters = () => {
-        const resetState = createInitialFilterState({}, defaultPerPage);
-        setFilterState(resetState);
-        router.get(
-            '/manage/posts',
-            { per_page: defaultPerPage },
-            {
-                preserveState: true,
-                preserveScroll: true,
-            },
-        );
-    };
-
-    const toggleSelectAll = (checked: boolean) => {
-        if (checked) {
-            setSelected(postData.map((post) => post.id));
-        } else {
-            setSelected([]);
-        }
-    };
-
-    const toggleSelection = (postId: number) => {
-        setSelected((prev) =>
-            prev.includes(postId)
-                ? prev.filter((id) => id !== postId)
-                : [...prev, postId],
-        );
-    };
-
-    const performBulkAction = (action: 'publish' | 'unpublish' | 'delete') => {
-        if (selected.length === 0 || bulkForm.processing) return;
-
-        bulkForm.transform(() => ({
-            action,
-            ids: selected,
-        }));
-
-        bulkForm.post('/manage/posts/bulk', {
-            preserveScroll: true,
-            onSuccess: () => {
-                setSelected([]);
-                bulkForm.reset();
-                skipFlashToastRef.current = true;
-                showToast({
-                    type: 'success',
-                    title: t('posts.index.flash.success_title', '操作成功'),
-                    description: t('posts.index.bulk.success', '批次操作已完成。'),
-                });
-            },
-            onError: (errors) => {
-                skipFlashToastRef.current = true;
-                const messages = Object.values(errors)
-                    .flat()
-                    .map((value) => String(value))
-                    .filter((value) => value.length > 0);
-                showToast({
-                    type: 'error',
-                    title: t('posts.index.flash.error_title', '操作失敗'),
-                    description:
-                        messages[0] ?? t('posts.index.bulk.error', '批次操作失敗，請稍後再試。'),
-                });
-            },
-            onFinish: () => {
-                bulkForm.setData('action', '');
-            },
-        });
-    };
-
-    const changePage = (page: number) => {
-        if (page <= 0 || page > pagination.last_page || page === pagination.current_page) {
-            return;
-        }
-
-        router.get(
-            '/manage/posts',
-            {
-                ...Object.fromEntries(
-                    Object.entries(filterState).filter(([, value]) => value !== ''),
-                ),
-                page,
-            },
-            {
-                preserveState: true,
-                preserveScroll: true,
-            },
-        );
-    };
+    const hasFlashAlerts = useMemo(
+        () => Boolean(flashMessages.success || flashMessages.error || (flashMessages.importErrors && flashMessages.importErrors.length > 0)),
+        [flashMessages],
+    );
 
     const hasActiveFilters = useMemo(
         () =>
@@ -1132,62 +129,205 @@ export default function PostsIndex({ posts, categories, authors, filters, status
         [filterState],
     );
 
+    /**
+     * 監聽篩選器輸入，並更新狀態
+     */
+    const handleFilterChange = useCallback((key: keyof FilterState, value: string) => {
+        setFilterState((previous) => ({ ...previous, [key]: value }));
+    }, []);
+
+    /**
+     * 提交篩選條件給後端
+     */
+    const applyFilters = useCallback(
+        (event?: FormEvent<HTMLFormElement>) => {
+            event?.preventDefault();
+
+            const params = Object.fromEntries(Object.entries(filterState).filter(([, value]) => value !== ''));
+
+            router.get('/manage/posts', params, {
+                preserveState: true,
+                preserveScroll: true,
+            });
+        },
+        [filterState],
+    );
+
+    /**
+     * 重設篩選條件並回到預設每頁筆數
+     */
+    const resetFilters = useCallback(() => {
+        const initialState = createInitialFilterState({}, defaultPerPage);
+        setFilterState(initialState);
+        router.get(
+            '/manage/posts',
+            { per_page: defaultPerPage },
+            {
+                preserveState: true,
+                preserveScroll: true,
+            },
+        );
+    }, [defaultPerPage]);
+
+    /**
+     * 切換分頁
+     */
+    const changePage = useCallback(
+        (pageNumber: number) => {
+            if (pageNumber <= 0 || pageNumber > pagination.last_page || pageNumber === pagination.current_page) {
+                return;
+            }
+
+            const params = Object.fromEntries(Object.entries(filterState).filter(([, value]) => value !== ''));
+
+            params.page = pageNumber.toString();
+
+            router.get('/manage/posts', params, {
+                preserveState: true,
+                preserveScroll: true,
+            });
+        },
+        [filterState, pagination],
+    );
+
+    /**
+     * 切換全選狀態
+     */
+    const handleToggleSelectAll = useCallback(
+        (checked: boolean) => {
+            setSelected(checked ? postData.map((post) => post.id) : []);
+        },
+        [postData],
+    );
+
+    /**
+     * 切換單筆公告的選取狀態
+     */
+    const handleToggleSelection = useCallback((postId: number) => {
+        setSelected((previous) => (previous.includes(postId) ? previous.filter((id) => id !== postId) : [...previous, postId]));
+    }, []);
+
+    // Inertia 表單處理批次操作
+    const bulkForm = useForm<{ action: 'publish' | 'unpublish' | 'delete'; ids: number[] }>({
+        action: 'publish',
+        ids: [],
+    });
+
+    /**
+     * 執行批次操作，涵蓋發布、取消發布與刪除
+     */
+    const performBulkAction = useCallback(
+        (action: 'publish' | 'unpublish' | 'delete') => {
+            if (selected.length === 0 || bulkForm.processing) {
+                return;
+            }
+
+            if (action === 'delete') {
+                const confirmed = window.confirm(
+                    t(
+                        'posts.index.bulk.delete_confirm',
+                        fallbackLanguage === 'zh'
+                            ? `確定要刪除選取的 ${selected.length} 筆公告嗎？此操作無法復原。`
+                            : `Are you sure you want to delete the selected ${selected.length} announcements? This action cannot be undone.`,
+                    ),
+                );
+
+                if (!confirmed) {
+                    return;
+                }
+            }
+
+            bulkForm.transform(() => ({
+                action,
+                ids: selected,
+            }));
+
+            bulkForm.post('/manage/posts/bulk', {
+                preserveScroll: true,
+                onSuccess: () => {
+                    setSelected([]);
+                    bulkForm.reset();
+                    skipFlashToastRef.current = true;
+
+                    const successMessages: Record<typeof action, string> = {
+                        publish: t('posts.index.bulk.publish_success', '已發布選取的公告'),
+                        unpublish: t('posts.index.bulk.unpublish_success', '已取消發布選取的公告'),
+                        delete: t('posts.index.bulk.delete_success', '已刪除選取的公告'),
+                    };
+
+                    showSuccess(t('posts.index.flash.success_title', '操作成功'), successMessages[action]);
+                },
+                onError: (errors) => {
+                    skipFlashToastRef.current = true;
+
+                    const errorMessages = Object.values(errors)
+                        .flat()
+                        .map((value) => String(value))
+                        .filter((value) => value.length > 0);
+
+                    const fallbackMessage = fallbackLanguage === 'zh' ? '批次操作失敗，請重新嘗試。' : 'Bulk action failed, please try again.';
+
+                    showBatchErrors(errorMessages.length > 0 ? errorMessages : [fallbackMessage], t('posts.index.flash.error_title', '操作失敗'));
+                },
+            });
+        },
+        [selected, bulkForm, t, fallbackLanguage, showSuccess, showBatchErrors],
+    );
+
+    /**
+     * 開始匯入時的提示，讓使用者了解背景流程
+     */
     const handleImportStart = useCallback(
         (message: string) => {
-            showToast({
-                type: 'info',
-                title: t('posts.index.import.start_title', fallbackLanguage === 'zh' ? '開始匯入' : 'Import started'),
-                description: message,
-            });
+            showInfo(t('posts.index.import.start_title', fallbackLanguage === 'zh' ? '開始匯入' : 'Import started'), message);
         },
-        [showToast, t, fallbackLanguage],
+        [showInfo, t, fallbackLanguage],
     );
 
+    /**
+     * 匯入成功時顯示提示並重新整理列表
+     */
     const handleImportSuccess = useCallback(
-        (message?: string) => {
+        (message: string) => {
             skipFlashToastRef.current = true;
-            showToast({
-                type: 'success',
-                title: t('posts.index.flash.success_title', '操作成功'),
-                description: message ?? t('posts.index.import.success_toast', '公告匯入已送出'),
-            });
+            showSuccess(t('posts.index.flash.success_title', '操作成功'), message);
+            router.reload({ only: ['posts'] });
         },
-        [showToast, t],
+        [showSuccess],
     );
 
+    /**
+     * 後端回傳的匯入錯誤整合顯示
+     */
     const handleImportError = useCallback(
         (messages: string[]) => {
             skipFlashToastRef.current = true;
-            showToast({
-                type: 'error',
-                title: t('posts.index.flash.error_title', '操作失敗'),
-                description:
-                    messages[0] ?? t('posts.index.import.error_fallback', '匯入失敗，請確認檔案內容或稍後再試。'),
-            });
+            showBatchErrors(messages, t('posts.index.import.error_title', fallbackLanguage === 'zh' ? '匯入錯誤' : 'Import errors'));
         },
-        [showToast, t],
+        [showBatchErrors, t, fallbackLanguage],
     );
 
+    /**
+     * 客戶端驗證失敗時給予友善提示
+     */
     const handleImportClientError = useCallback(
         (message: string) => {
-            showToast({
-                type: 'error',
-                title: t('posts.index.flash.error_title', '操作失敗'),
-                description: message,
-            });
+            showError(t('posts.index.flash.error_title', '操作失敗'), message);
         },
-        [showToast, t],
+        [showError, t],
     );
 
+    // 來源資料更新時重新建立篩選狀態，確保與伺服器同步
     useEffect(() => {
         setFilterState(createInitialFilterState(filters, defaultPerPage));
     }, [filters, defaultPerPage]);
 
+    // 切換頁面或資料量變化後清除選取狀態，避免誤操作
     useEffect(() => {
         setSelected([]);
     }, [pagination.current_page, pagination.total]);
 
-    // 根據後端 flash 訊息補上 toast 提示，確保使用者能即時掌握狀態。
+    // 監控後端 flash 訊息並顯示對應的 Toast
     useEffect(() => {
         if (skipFlashToastRef.current) {
             previousFlashRef.current = flashMessages;
@@ -1196,41 +336,33 @@ export default function PostsIndex({ posts, categories, authors, filters, status
         }
 
         if (flashMessages.success && flashMessages.success !== previousFlashRef.current.success) {
-            showToast({
-                type: 'success',
-                title: t('posts.index.flash.success_title', '操作成功'),
-                description: flashMessages.success,
-            });
+            showSuccess(t('posts.index.flash.success_title', '操作成功'), flashMessages.success);
         }
 
         if (flashMessages.error && flashMessages.error !== previousFlashRef.current.error) {
-            showToast({
-                type: 'error',
-                title: t('posts.index.flash.error_title', '操作失敗'),
-                description: flashMessages.error,
-            });
+            showError(t('posts.index.flash.error_title', '操作失敗'), flashMessages.error);
         }
 
-        const previousImportErrors = previousFlashRef.current.importErrors ?? [];
-        const currentImportErrors = flashMessages.importErrors ?? [];
+        if (flashMessages.info && flashMessages.info !== previousFlashRef.current.info) {
+            showInfo(t('posts.index.flash.info_title', '訊息'), flashMessages.info);
+        }
 
-        currentImportErrors
-            .filter((message) => !previousImportErrors.includes(message))
-            .forEach((message) => {
-                showToast({
-                    type: 'error',
-                    title: t('posts.index.import.error_title', '部分資料未匯入'),
-                    description: message,
-                });
-            });
+        const importErrors = flashMessages.importErrors ?? [];
+        const previousImportErrors = previousFlashRef.current.importErrors ?? [];
+        const newImportErrors = importErrors.filter((message) => !previousImportErrors.includes(message));
+
+        if (newImportErrors.length > 0) {
+            showBatchErrors(newImportErrors, t('posts.index.import.error_title', fallbackLanguage === 'zh' ? '匯入錯誤' : 'Import errors'));
+        }
 
         previousFlashRef.current = flashMessages;
-    }, [flashMessages, showToast, t]);
+    }, [flashMessages, showSuccess, showError, showInfo, showBatchErrors, t, fallbackLanguage]);
 
     return (
-        <ManageLayout role={layoutRole} breadcrumbs={breadcrumbs}>
+        <ManageLayout breadcrumbs={breadcrumbs}>
             <Head title={t('posts.index.title', '公告管理')} />
-            <PostToastContainer toasts={toasts} onDismiss={dismissToast} />
+
+            <ToastContainer toasts={toasts} onDismiss={dismissToast} position="bottom-right" />
 
             <section className="space-y-6">
                 {hasFlashAlerts && <PostFlashAlerts messages={flashMessages} t={t} />}
@@ -1238,20 +370,17 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                 <ManagePageHeader
                     badge={{ icon: <Filter className="h-4 w-4" />, label: t('posts.index.badge', '公告總覽') }}
                     title={t('posts.index.title', '公告管理')}
-                    description={t(
-                        'posts.index.description',
-                        '管理公告分類、排程發布及附件檔案，確保資訊即時且一致。',
-                    )}
+                    description={t('posts.index.description', '管理公告分類、排程發布及附件檔案，確保資訊即時且一致。')}
                     actions={
                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                             {can.bulk && (
-                                <PostImportUploader
+                                <BulkImportDialog
                                     t={t}
                                     fallbackLanguage={fallbackLanguage}
                                     trigger={
                                         <Button variant="outline" className="rounded-full px-6">
                                             <Upload className="mr-2 h-4 w-4" />
-                                            {t('posts.index.actions.import_csv', fallbackLanguage === 'zh' ? '批次發布' : 'Bulk import')}
+                                            {t('posts.index.actions.import_csv', fallbackLanguage === 'zh' ? '批次匯入' : 'Bulk import')}
                                         </Button>
                                     }
                                     onStart={handleImportStart}
@@ -1260,6 +389,7 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                                     onClientError={handleImportClientError}
                                 />
                             )}
+
                             {can.create && (
                                 <Button asChild className="rounded-full px-6">
                                     <Link href="/manage/posts/create">{t('posts.index.create', '新增公告')}</Link>
@@ -1287,8 +417,8 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                     posts={postData}
                     selectedIds={selected}
                     canBulk={can.bulk}
-                    onToggleSelectAll={toggleSelectAll}
-                    onToggleSelection={toggleSelection}
+                    onToggleSelectAll={handleToggleSelectAll}
+                    onToggleSelection={handleToggleSelection}
                     onBulkAction={performBulkAction}
                     bulkFormProcessing={bulkForm.processing}
                     pagination={pagination}


### PR DESCRIPTION
## Summary
- 重寫 manage/posts/index 頁面流程，重新整理匯入、批次操作與篩選邏輯以符合架構文件
- 整合 Toast 通知與後端 flash 訊息，確保成功與失敗情境皆有提示
- 串接 BulkImportDialog、PostFilterForm 與 PostTable 元件，改善分頁、篩選與批次操作體驗
- 新增 manage/admin/staff/index 頁面與 useTranslation 包裝，整合職員與教師分頁並補齊舊有型別引用

## Testing
- npm run types


------
https://chatgpt.com/codex/tasks/task_e_68d428901bb48323b45102fd5185c6a7