### PR TITLE
Fix post import trigger and update manage posts architecture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -132,6 +132,7 @@
     - pages/ (Inertia pages)
     - components/ui/ (最小化、可重用)
     - components/page/ (組成頁面的複合元件)
+    - components/manage/post/ (公告後台的共用元件，例如列表、篩選、批次匯入按鈕)
 
 - 資料流
     - 後端 Controller 查詢資料 -> 轉換為 Resource / DTO -> Inertia::render('Page', $props)
@@ -140,8 +141,22 @@
 - 渲染細節
     - Page 組件只做資料分發與小量邏輯，UI 元件純 display
     - 所有表單使用 unobtrusive validation（後端再次驗證）
+    - 後台頁面若需要檔案匯入，請使用 `PostImportUploader`（位於 `components/manage/post/post-import-uploader.tsx`），
+      並透過 props 注入 onStart/onSuccess/onError 以觸發 Toast 提示，避免在 Page 層重新實作匯入流程
 
 ---
+
+### 管理後台公告頁面規範
+
+- Page 位置：`resources/js/pages/manage/posts/index.tsx`
+    - 維持頁面僅處理資料狀態（篩選、分頁、勾選項目），不在此直接寫複雜 UI
+    - 批次匯入、篩選表單、列表等 UI 元件應集中放在 `components/manage/post/`
+    - 任何成功或失敗、錯誤情境都必須透過共用的 Toast 介面顯示
+- 新增/共用元件時，需於本文件補充目的、檔案路徑與基本使用說明，確保後續維護者清楚責任範疇
+- 若新增批次處理流程，需確保：
+    1. 送出前進行前端基本驗證，錯誤時即時顯示 Toast
+    2. 送出後若後端無訊息回傳，需在頁面端補上預設提示文字
+    3. 匯入成功或失敗後必須復原 UI 狀態（清除勾選、還原輸入框）
 
 ## 測試規範
 

--- a/resources/js/pages/manage/posts/index.tsx
+++ b/resources/js/pages/manage/posts/index.tsx
@@ -10,10 +10,10 @@ import ManageLayout from '@/layouts/manage/manage-layout';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslator } from '@/hooks/use-translator';
 
-import BulkImportDialog from '@/components/manage/post/bulk-import-dialog';
 import { PostFilterForm } from '@/components/manage/post/post-filter-form';
 import { PostFlashAlerts } from '@/components/manage/post/post-flash-alerts';
 import { PostTable } from '@/components/manage/post/post-table';
+import { PostImportUploader } from '@/components/manage/post/post-import-uploader';
 import type {
     AuthorOption,
     CategoryOption,
@@ -278,8 +278,15 @@ export default function PostsIndex({ posts, categories, authors, filters, status
      * 開始匯入時的提示，讓使用者了解背景流程
      */
     const handleImportStart = useCallback(
-        (message: string) => {
-            showInfo(t('posts.index.import.start_title', fallbackLanguage === 'zh' ? '開始匯入' : 'Import started'), message);
+        (message?: string) => {
+            // 以預設提示確保沒有訊息時仍能顯示友善文字
+            const fallbackMessage =
+                fallbackLanguage === 'zh' ? '開始匯入公告，請稍候…' : 'Import started, please wait…';
+
+            showInfo(
+                t('posts.index.import.start_title', fallbackLanguage === 'zh' ? '開始匯入' : 'Import started'),
+                message ?? fallbackMessage,
+            );
         },
         [showInfo, t, fallbackLanguage],
     );
@@ -288,12 +295,16 @@ export default function PostsIndex({ posts, categories, authors, filters, status
      * 匯入成功時顯示提示並重新整理列表
      */
     const handleImportSuccess = useCallback(
-        (message: string) => {
+        (message?: string) => {
             skipFlashToastRef.current = true;
-            showSuccess(t('posts.index.flash.success_title', '操作成功'), message);
+            // 若後端未提供提示訊息，套用預設文字以維持一致體驗
+            const fallbackMessage =
+                fallbackLanguage === 'zh' ? '公告匯入已送出' : 'Import request submitted';
+
+            showSuccess(t('posts.index.flash.success_title', '操作成功'), message ?? fallbackMessage);
             router.reload({ only: ['posts'] });
         },
-        [showSuccess],
+        [showSuccess, t, fallbackLanguage],
     );
 
     /**
@@ -374,7 +385,7 @@ export default function PostsIndex({ posts, categories, authors, filters, status
                     actions={
                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                             {can.bulk && (
-                                <BulkImportDialog
+                                <PostImportUploader
                                     t={t}
                                     fallbackLanguage={fallbackLanguage}
                                     trigger={


### PR DESCRIPTION
## Summary
- replace the manage posts CSV upload dialog with the shared PostImportUploader so bulk imports trigger reliably and provide fallback toast messages
- extend ARCHITECTURE.md with manage posts guidelines and document the reusable importer component location and usage

## Testing
- npm run test -- --watch=false *(fails: existing Jest configuration cannot resolve several aliased UI modules in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d43182ba0c8323862c79037e35ec7a