### PR TITLE
Fix manage header breadcrumb overflow

### DIFF
--- a/resources/js/components/breadcrumbs.tsx
+++ b/resources/js/components/breadcrumbs.tsx
@@ -7,7 +7,7 @@ export function Breadcrumbs({ breadcrumbs }: { breadcrumbs: BreadcrumbItemType[]
     return (
         <>
             {breadcrumbs.length > 0 && (
-                <Breadcrumb>
+                <Breadcrumb className="min-w-0 overflow-hidden">
                     <BreadcrumbList>
                         {breadcrumbs.map((item, index) => {
                             const isLast = index === breadcrumbs.length - 1;

--- a/resources/js/components/manage/manage-header.tsx
+++ b/resources/js/components/manage/manage-header.tsx
@@ -16,16 +16,18 @@ export default function ManageHeader({ breadcrumbs = [], role: roleOverride }: M
 
     return (
         <header className="flex h-16 shrink-0 items-center justify-between gap-3 border-b border-neutral-200 bg-white px-4 pr-6 text-neutral-700 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-6">
-            <div className="flex items-center gap-3">
+            <div className="flex min-w-0 flex-1 items-center gap-3">
                 <SidebarTrigger className="-ml-1 h-8 w-8 rounded-full border border-neutral-200 bg-white text-neutral-700 hover:bg-neutral-50" />
-                <div className="flex items-center gap-3">
+                <div className="flex min-w-0 items-center gap-3">
                     <div className="flex items-center gap-2 md:hidden">
                         <ManageBrand role={role} />
                     </div>
-                    <Breadcrumbs breadcrumbs={breadcrumbs} />
+                    <div className="min-w-0 flex-1">
+                        <Breadcrumbs breadcrumbs={breadcrumbs} />
+                    </div>
                 </div>
             </div>
-            <LanguageSwitcher variant="light" />
+            <LanguageSwitcher variant="light" className="flex-shrink-0" />
         </header>
     );
 }

--- a/resources/js/components/ui/breadcrumb.tsx
+++ b/resources/js/components/ui/breadcrumb.tsx
@@ -13,7 +13,7 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5",
+        "text-muted-foreground flex min-w-0 flex-nowrap items-center gap-1.5 text-sm sm:gap-2.5 overflow-hidden",
         className
       )}
       {...props}
@@ -25,7 +25,7 @@ function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
   return (
     <li
       data-slot="breadcrumb-item"
-      className={cn("inline-flex items-center gap-1.5", className)}
+      className={cn("inline-flex min-w-0 items-center gap-1.5", className)}
       {...props}
     />
   )
@@ -43,7 +43,7 @@ function BreadcrumbLink({
   return (
     <Comp
       data-slot="breadcrumb-link"
-      className={cn("hover:text-foreground transition-colors", className)}
+      className={cn("hover:text-foreground transition-colors whitespace-nowrap", className)}
       {...props}
     />
   )
@@ -56,7 +56,7 @@ function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
       role="link"
       aria-disabled="true"
       aria-current="page"
-      className={cn("text-foreground font-normal", className)}
+      className={cn("text-foreground font-normal truncate", className)}
       {...props}
     />
   )
@@ -72,7 +72,7 @@ function BreadcrumbSeparator({
       data-slot="breadcrumb-separator"
       role="presentation"
       aria-hidden="true"
-      className={cn("[&>svg]:size-3.5", className)}
+      className={cn("[&>svg]:size-3.5 flex-shrink-0", className)}
       {...props}
     >
       {children ?? <ChevronRight />}


### PR DESCRIPTION
## Summary
- prevent manage header breadcrumbs from wrapping by tightening flex layouts and limiting overflow
- ensure breadcrumb components truncate long items and keep separators fixed
- keep the language switcher from shrinking adjacent content

## Testing
- npm run types

------
https://chatgpt.com/codex/tasks/task_e_68d539d629ec8323a1aa89cab81a617c