### PR TITLE
Ensure post forms upload as FormData

### DIFF
--- a/resources/js/pages/manage/posts/create.tsx
+++ b/resources/js/pages/manage/posts/create.tsx
@@ -57,6 +57,7 @@ export default function CreatePost({ categories, statusOptions, availableTags }:
     const handleSubmit: PostFormSubmitHandler = (form) => {
         form.post('/manage/posts', {
             preserveScroll: true,
+            forceFormData: true,
         });
     };
 

--- a/resources/js/pages/manage/posts/edit.tsx
+++ b/resources/js/pages/manage/posts/edit.tsx
@@ -59,6 +59,7 @@ export default function EditPost({ post, categories, statusOptions, availableTag
     const handleSubmit: PostFormSubmitHandler = (form) => {
         form.put(`/manage/posts/${post.id}`, {
             preserveScroll: true,
+            forceFormData: true,
         });
     };
 


### PR DESCRIPTION
## Summary
- ensure the manage post create and edit forms always submit using FormData so file uploads are included correctly

## Testing
- npm run test -- --passWithNoTests *(fails: jest configuration cannot resolve module aliases in existing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d5547ba4fc8323b3e825a2eb858964