### PR TITLE
feat: add reusable tag selector for posts

### DIFF
--- a/resources/js/components/manage/tag-selector.tsx
+++ b/resources/js/components/manage/tag-selector.tsx
@@ -1,0 +1,87 @@
+import { Select } from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import { ChangeEvent, useMemo } from 'react';
+
+export interface TagSelectorOption {
+    value: string;
+    label: string;
+    description?: string | null;
+}
+
+interface TagSelectorProps {
+    id?: string;
+    value: string[];
+    options: TagSelectorOption[];
+    onChange: (value: string[]) => void;
+    helperText?: string;
+    emptyMessage?: string;
+    emptyOptionLabel?: string;
+    disabled?: boolean;
+    className?: string;
+}
+
+export default function TagSelector({
+    id,
+    value,
+    options,
+    onChange,
+    helperText,
+    emptyMessage,
+    emptyOptionLabel,
+    disabled = false,
+    className,
+}: TagSelectorProps) {
+    const resolvedSize = useMemo(() => {
+        if (options.length === 0) {
+            return 3;
+        }
+
+        return Math.min(Math.max(options.length, 3), 8);
+    }, [options.length]);
+
+    const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+        const selectedValues = Array.from(event.target.selectedOptions).map((option) => option.value);
+        onChange(selectedValues);
+    };
+
+    return (
+        <div className={cn('space-y-2', className)}>
+            <Select
+                id={id}
+                multiple
+                value={value}
+                onChange={handleChange}
+                size={resolvedSize}
+                disabled={disabled || options.length === 0}
+            >
+                {options.length === 0 ? (
+                    <option value="" disabled>
+                        {emptyOptionLabel ?? emptyMessage ?? '目前沒有可用的標籤。'}
+                    </option>
+                ) : (
+                    options.map((option) => (
+                        <option key={option.value} value={option.value} title={option.description ?? undefined}>
+                            #{option.label}
+                        </option>
+                    ))
+                )}
+            </Select>
+
+            {helperText && <p className="text-xs text-slate-500">{helperText}</p>}
+
+            {options.length === 0 && (
+                <p className="text-xs text-slate-500">{emptyMessage ?? '請先到標籤管理頁面新增標籤。'}</p>
+            )}
+
+            {value.length > 0 && options.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                    {value.map((tag) => (
+                        <span key={tag} className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-700">
+                            #{tag}
+                        </span>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/components/ui/select.tsx
+++ b/resources/js/components/ui/select.tsx
@@ -2,19 +2,21 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Select({ className, ...props }: React.ComponentProps<"select">) {
+function Select({ className, multiple, ...props }: React.ComponentProps<"select">) {
   return (
     <select
       className={cn(
-        // 預設背景與文字顏色，增強互動效果，添加下拉箭頭樣式
-        "border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-10 w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-4 py-2 pr-10 text-sm shadow-sm transition-all duration-200 outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 appearance-none bg-no-repeat bg-right bg-origin-content",
+        "border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground w-full rounded-lg border border-gray-300 bg-white text-gray-900 text-sm shadow-sm transition-all duration-200 outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
         "hover:border-gray-400 hover:shadow-md",
         "focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 focus:shadow-md",
         "aria-invalid:border-red-500 aria-invalid:ring-2 aria-invalid:ring-red-500/20",
-        // 添加自定義下拉箭頭
-        "bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 fill=%27none%27 viewBox=%270 0 24 24%27 stroke-width=%271.5%27 stroke=%27%236b7280%27%3E%3Cpath stroke-linecap=%27round%27 stroke-linejoin=%27round%27 d=%27M19.5 8.25l-7.5 7.5-7.5-7.5%27/%3E%3C/svg%3E')] bg-[length:20px_20px] bg-[right_8px_center]",
+        multiple
+          ? "min-h-[7.5rem] appearance-none px-3 py-2"
+          : "flex h-10 appearance-none bg-no-repeat bg-right bg-origin-content px-4 py-2 pr-10",
+        !multiple && "bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 fill=%27none%27 viewBox=%270 0 24 24%27 stroke-width=%271.5%27 stroke=%27%236b7280%27%3E%3Cpath stroke-linecap=%27round%27 stroke-linejoin=%27round%27 d=%27M19.5 8.25l-7.5 7.5-7.5-7.5%27/%3E%3C/svg%3E')] bg-[length:20px_20px] bg-[right_8px_center]",
         className
       )}
+      multiple={multiple}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- replace the post form tag input with a dedicated tag selector component that supports selecting multiple existing tags
- update the shared select component styling so it gracefully handles multiple selection states

## Testing
- npm run test -- --watch=false *(fails: existing jest configuration cannot resolve several mocked UI modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d575379e108323846c8f3f91ac939c