### PR TITLE
feat: improve post tag selection experience

### DIFF
--- a/lang/en/manage.php
+++ b/lang/en/manage.php
@@ -409,10 +409,13 @@ return [
                 ],
                 'tags' => [
                     'label' => 'Tags',
-                    'placeholder' => 'Separate with commas, e.g. Department, Event',
-                    'helper' => 'Use commas to separate multiple tags.',
+                    'placeholder' => 'Type and press Enter to add, or choose from the list below.',
+                    'helper' => 'Press Enter to add custom tags, or click a suggestion to include it.',
                     'suggestions_title' => 'Suggested tags',
-                    'suggestions_hint' => 'Click to add or remove.',
+                    'suggestions_hint' => 'Click a suggested tag to add or remove it.',
+                    'empty_option' => 'No suggestions yet — feel free to type and add new tags.',
+                    'empty_message' => 'Suggested tags are not set yet, but you can still type to add new ones.',
+                    'create_hint' => 'Press Enter to create ":keyword".',
                 ],
                 'pinned' => [
                     'label' => 'Pin announcement',

--- a/lang/zh-TW/manage.php
+++ b/lang/zh-TW/manage.php
@@ -409,10 +409,13 @@ return [
                 ],
                 'tags' => [
                     'label' => '標籤',
-                    'placeholder' => '以逗號分隔，如：系所公告, 活動',
-                    'helper' => '使用逗號分隔多個標籤。',
+                    'placeholder' => '輸入後按 Enter 新增，或從下方清單挑選。',
+                    'helper' => '輸入後按 Enter 建立標籤，或從建議列表點擊加入。',
                     'suggestions_title' => '常用標籤',
-                    'suggestions_hint' => '點擊即可加入或移除。',
+                    'suggestions_hint' => '點擊建議標籤即可加入或移除。',
+                    'empty_option' => '目前沒有建議標籤，您可以直接輸入新增。',
+                    'empty_message' => '尚未設定常用標籤，也可以直接輸入建立新標籤。',
+                    'create_hint' => '按 Enter 可新增「:keyword」。',
                 ],
                 'pinned' => [
                     'label' => '是否置頂',

--- a/resources/js/components/manage/post/post-form.tsx
+++ b/resources/js/components/manage/post/post-form.tsx
@@ -413,19 +413,27 @@ export default function PostForm({
                             value={data.tags}
                             onChange={(next) => setData('tags', next)}
                             options={tagOptions}
+                            placeholder={t(
+                                'posts.form.fields.tags.placeholder',
+                                fallbackText('輸入後按 Enter 新增，或從下方清單挑選。', 'Type and press Enter to add, or pick from the list below.')
+                            )}
                             helperText={tagOptions.length > 0
                                 ? t(
                                     'posts.form.fields.tags.helper',
-                                    fallbackText('按住 Ctrl 或 ⌘ 可多選標籤。', 'Hold Ctrl (or ⌘) to select multiple tags.')
+                                    fallbackText('輸入後按 Enter 建立標籤，或從建議列表點擊加入。', 'Press Enter to add custom tags, or click suggestions to include them.')
                                 )
                                 : undefined}
                             emptyOptionLabel={t(
                                 'posts.form.fields.tags.empty_option',
-                                fallbackText('目前沒有可用的標籤。', 'No tags available yet.')
+                                fallbackText('目前沒有建議標籤，您可以直接輸入新增。', 'No suggestions yet — feel free to type and add new tags.')
                             )}
                             emptyMessage={t(
                                 'posts.form.fields.tags.empty_message',
-                                fallbackText('請先至標籤管理頁面建立標籤。', 'Please create tags from the tag management page first.')
+                                fallbackText('尚未設定常用標籤，也可以直接輸入建立新標籤。', 'There are no suggested tags yet, but you can still type to add new ones.')
+                            )}
+                            createHint={t(
+                                'posts.form.fields.tags.create_hint',
+                                fallbackText('按 Enter 可新增「:keyword」。', 'Press Enter to create ":keyword".')
                             )}
                             disabled={processing}
                         />

--- a/resources/js/components/manage/tag-selector.tsx
+++ b/resources/js/components/manage/tag-selector.tsx
@@ -1,6 +1,8 @@
-import { Select } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
-import { ChangeEvent, useMemo } from 'react';
+import { X } from 'lucide-react';
+import { ChangeEvent, KeyboardEvent, useMemo, useRef, useState } from 'react';
 
 export interface TagSelectorOption {
     value: string;
@@ -18,6 +20,8 @@ interface TagSelectorProps {
     emptyOptionLabel?: string;
     disabled?: boolean;
     className?: string;
+    placeholder?: string;
+    createHint?: string;
 }
 
 export default function TagSelector({
@@ -30,57 +34,164 @@ export default function TagSelector({
     emptyOptionLabel,
     disabled = false,
     className,
+    placeholder,
+    createHint,
 }: TagSelectorProps) {
-    const resolvedSize = useMemo(() => {
-        if (options.length === 0) {
-            return 3;
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const [inputValue, setInputValue] = useState('');
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+    const resolvedEmptyLabel = emptyOptionLabel ?? emptyMessage ?? '目前沒有可用的標籤。';
+
+    // 依選中的標籤過濾出尚未使用的選項，避免重複加入
+    const availableOptions = useMemo(() => {
+        return options.filter((option) => !value.includes(option.value));
+    }, [options, value]);
+
+    // 依輸入文字篩選建議清單，提供快速搜尋
+    const filteredOptions = useMemo(() => {
+        const keyword = inputValue.trim().toLowerCase();
+
+        if (keyword.length === 0) {
+            return availableOptions;
         }
 
-        return Math.min(Math.max(options.length, 3), 8);
-    }, [options.length]);
+        return availableOptions.filter((option) => {
+            return option.label.toLowerCase().includes(keyword);
+        });
+    }, [availableOptions, inputValue]);
 
-    const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-        const selectedValues = Array.from(event.target.selectedOptions).map((option) => option.value);
-        onChange(selectedValues);
+    const updateTags = (next: string[]) => {
+        onChange(Array.from(new Set(next.map((tag) => tag.trim()).filter((tag) => tag.length > 0))));
+    };
+
+    const handleAddTag = (tag: string) => {
+        const trimmed = tag.trim();
+
+        if (!trimmed) {
+            return;
+        }
+
+        updateTags([...value, trimmed]);
+        setInputValue('');
+        // 重新聚焦於輸入框，持續讓使用者快速操作
+        inputRef.current?.focus();
+    };
+
+    const handleRemoveTag = (tag: string) => {
+        updateTags(value.filter((selected) => selected !== tag));
+        inputRef.current?.focus();
+    };
+
+    const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+        setInputValue(event.target.value);
+        setIsDropdownOpen(true);
+    };
+
+    const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter' || event.key === ',') {
+            event.preventDefault();
+            handleAddTag(inputValue);
+            return;
+        }
+
+        if (event.key === 'Backspace' && inputValue.length === 0 && value.length > 0) {
+            // 空字串下按退格，移除最後一個標籤以符合常見的標籤輸入體驗
+            event.preventDefault();
+            handleRemoveTag(value[value.length - 1]);
+        }
+    };
+
+    const handleInputFocus = () => {
+        setIsDropdownOpen(true);
+    };
+
+    const handleInputBlur = () => {
+        // 延遲收合，確保點擊選項時不會被輸入框先行觸發 blur
+        setTimeout(() => setIsDropdownOpen(false), 120);
+    };
+
+    const handleSelectOption = (optionValue: string) => {
+        handleAddTag(optionValue);
     };
 
     return (
         <div className={cn('space-y-2', className)}>
-            <Select
-                id={id}
-                multiple
-                value={value}
-                onChange={handleChange}
-                size={resolvedSize}
-                disabled={disabled || options.length === 0}
-            >
-                {options.length === 0 ? (
-                    <option value="" disabled>
-                        {emptyOptionLabel ?? emptyMessage ?? '目前沒有可用的標籤。'}
-                    </option>
-                ) : (
-                    options.map((option) => (
-                        <option key={option.value} value={option.value} title={option.description ?? undefined}>
-                            #{option.label}
-                        </option>
-                    ))
+            <div className={cn(
+                'relative w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition-all duration-200',
+                'focus-within:border-blue-500 focus-within:ring-2 focus-within:ring-blue-500/20',
+                disabled && 'pointer-events-none opacity-60'
+            )}>
+                <div className="flex flex-wrap items-center gap-2">
+                    {value.map((tag) => (
+                        <span
+                            key={tag}
+                            className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-700"
+                        >
+                            #{tag}
+                            {!disabled && (
+                                <button
+                                    type="button"
+                                    onClick={() => handleRemoveTag(tag)}
+                                    className="rounded-full p-0.5 text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-600"
+                                    aria-label={`移除標籤 ${tag}`}
+                                >
+                                    <X className="h-3 w-3" aria-hidden />
+                                </button>
+                            )}
+                        </span>
+                    ))}
+
+                    <Input
+                        id={id}
+                        ref={inputRef}
+                        value={inputValue}
+                        onChange={handleInputChange}
+                        onKeyDown={handleInputKeyDown}
+                        onFocus={handleInputFocus}
+                        onBlur={handleInputBlur}
+                        placeholder={placeholder ?? (options.length === 0 ? resolvedEmptyLabel : undefined)}
+                        disabled={disabled}
+                        className={cn(
+                            'flex-1 border-none px-0 py-0 text-sm shadow-none focus-visible:ring-0',
+                            'min-w-[120px] bg-transparent'
+                        )}
+                    />
+                </div>
+
+                {isDropdownOpen && filteredOptions.length > 0 && (
+                    <div className="absolute left-0 top-full z-10 mt-2 w-full rounded-lg border border-slate-200 bg-white p-1 text-sm shadow-lg">
+                        <ul className="max-h-48 overflow-auto">
+                            {filteredOptions.map((option) => (
+                                <li key={option.value}>
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        className="flex w-full items-start justify-between gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-slate-100"
+                                        onMouseDown={(event) => event.preventDefault()}
+                                        onClick={() => handleSelectOption(option.value)}
+                                    >
+                                        <span className="font-medium text-slate-700">#{option.label}</span>
+                                        {option.description && (
+                                            <span className="text-xs text-slate-500">{option.description}</span>
+                                        )}
+                                    </Button>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
                 )}
-            </Select>
+
+                {isDropdownOpen && filteredOptions.length === 0 && inputValue.trim().length > 0 && (
+                    <div className="absolute left-0 top-full z-10 mt-2 w-full rounded-lg border border-dashed border-slate-200 bg-white px-3 py-2 text-sm text-slate-500 shadow-lg">
+                        {(createHint ?? '按 Enter 可新增「:keyword」。').replace(':keyword', inputValue.trim())}
+                    </div>
+                )}
+            </div>
 
             {helperText && <p className="text-xs text-slate-500">{helperText}</p>}
 
             {options.length === 0 && (
                 <p className="text-xs text-slate-500">{emptyMessage ?? '請先到標籤管理頁面新增標籤。'}</p>
-            )}
-
-            {value.length > 0 && options.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                    {value.map((tag) => (
-                        <span key={tag} className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-700">
-                            #{tag}
-                        </span>
-                    ))}
-                </div>
             )}
         </div>
     );


### PR DESCRIPTION
## Summary
- replace the old multi-select with an interactive tag picker that supports chip removal, search, and quick creation
- refresh helper copy and locale strings to match the new interaction model for tag management

## Testing
- npm run types

------
https://chatgpt.com/codex/tasks/task_e_68d57f3da264832398756bb47c55db37