### PR TITLE
feat: rebuild manage users workflow

### DIFF
--- a/resources/js/components/manage/users/UserForm.tsx
+++ b/resources/js/components/manage/users/UserForm.tsx
@@ -7,38 +7,36 @@ import { Select } from '@/components/ui/select';
 import { Link, useForm } from '@inertiajs/react';
 import type { FormEvent } from 'react';
 
-interface OptionItem {
-    value: string;
-    label: string;
-}
-
-interface UserPayload {
-    id?: number;
-    name: string;
-    email: string;
-    role: 'admin' | 'teacher' | 'user';
-    status: 'active' | 'suspended';
-    email_verified_at?: string | null;
-}
+import type { OptionItem, UserFormPayload, UserRole, UserStatus } from './user-types';
 
 interface UserFormProps {
     mode: 'create' | 'edit';
-    user?: UserPayload | null;
+    user?: UserFormPayload | null;
     roleOptions: OptionItem[];
     statusOptions: OptionItem[];
 }
 
 export default function UserForm({ mode, user, roleOptions, statusOptions }: UserFormProps) {
-    const form = useForm({
+    // 使用 Inertia 表單管理狀態與驗證錯誤，統一處理送出流程。
+    const form = useForm<{
+        name: string;
+        email: string;
+        role: UserRole;
+        status: UserStatus;
+        password: string;
+        password_confirmation: string;
+        email_verified: boolean;
+    }>({
         name: user?.name ?? '',
         email: user?.email ?? '',
-        role: user?.role ?? (roleOptions[0]?.value ?? 'user'),
-        status: user?.status ?? (statusOptions[0]?.value ?? 'active'),
+        role: user?.role ?? ((roleOptions[0]?.value as UserRole) ?? 'user'),
+        status: user?.status ?? ((statusOptions[0]?.value as UserStatus) ?? 'active'),
         password: '',
         password_confirmation: '',
         email_verified: Boolean(user?.email_verified_at ?? false),
     });
 
+    // 表單送出時依模式決定呼叫新增或更新 API，並避免頁面重新整理。
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
 

--- a/resources/js/components/manage/users/UserTable.tsx
+++ b/resources/js/components/manage/users/UserTable.tsx
@@ -1,41 +1,16 @@
+import { useMemo } from 'react';
+import type { CheckedState } from '@radix-ui/react-checkbox';
+import { Download, Trash2, CircleCheck, CirclePause } from 'lucide-react';
+import { Link } from '@inertiajs/react';
+
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { cn } from '@/lib/utils';
-import { Link } from '@inertiajs/react';
-import { useMemo } from 'react';
-import type { CheckedState } from '@radix-ui/react-checkbox';
-import { CircleCheck, CirclePause, Trash2 } from 'lucide-react';
 
-export interface UserRow {
-    id: number;
-    name: string;
-    email: string;
-    role: 'admin' | 'teacher' | 'user';
-    status: 'active' | 'suspended';
-    avatar?: string | null;
-    email_verified_at?: string | null;
-    created_at?: string | null;
-    updated_at?: string | null;
-    deleted_at?: string | null;
-}
-
-export interface PaginationMeta {
-    current_page: number;
-    last_page: number;
-    per_page: number;
-    total: number;
-    from?: number | null;
-    to?: number | null;
-    links?: PaginationLink[];
-}
-
-export interface PaginationLink {
-    url: string | null;
-    label: string;
-    active: boolean;
-}
+import type { PaginationLink, PaginationMeta, UserRow } from './user-types';
 
 interface UserTableProps {
     data: UserRow[];
@@ -46,28 +21,35 @@ interface UserTableProps {
     onSelectAll: (checked: boolean) => void;
     onToggleStatus: (user: UserRow) => void;
     onDelete: (user: UserRow) => void;
+    onBulkDelete: () => void;
+    onExport: () => void;
+    bulkProcessing: boolean;
     canManage: boolean;
     authUserId: number;
+    locale: string;
 }
 
+// 角色標籤對照表，方便統一顯示中文角色名稱。
 const roleLabels: Record<UserRow['role'], string> = {
     admin: '管理員',
     teacher: '教師',
     user: '一般會員',
 };
 
+// 狀態標章設定，包含顏色與圖示，集中管理易於後續調整。
 const statusBadge: Record<UserRow['status'], { label: string; variant: 'default' | 'outline'; icon: typeof CircleCheck }> = {
     active: { label: '啟用', variant: 'default', icon: CircleCheck },
     suspended: { label: '停用', variant: 'outline', icon: CirclePause },
 };
 
-const formatDateTime = (value?: string | null) => {
+// 依據語系格式化日期時間，若解析失敗則回傳原字串避免錯誤。
+const formatDateTime = (value: string | null | undefined, locale: string) => {
     if (!value) {
         return '—';
     }
 
     try {
-        return new Date(value).toLocaleString('zh-TW', {
+        return new Date(value).toLocaleString(locale, {
             dateStyle: 'medium',
             timeStyle: 'short',
         });
@@ -76,6 +58,7 @@ const formatDateTime = (value?: string | null) => {
     }
 };
 
+// 產生縮寫作為頭像備援，避免缺少頭像時顯示空白方塊。
 const getInitials = (name: string) => {
     const trimmed = name.trim();
     if (trimmed === '') {
@@ -99,12 +82,16 @@ export default function UserTable({
     onSelectAll,
     onToggleStatus,
     onDelete,
+    onBulkDelete,
+    onExport,
+    bulkProcessing,
     canManage,
     authUserId,
+    locale,
 }: UserTableProps) {
     const allIds = useMemo(() => data.map((user) => user.id), [data]);
 
-    // 為了避免 API 回傳的連結格式不一致，預先轉換為陣列以供下方渲染使用
+    // 後端回傳的頁碼連結有時會嵌在 meta.links，因此統一轉換為陣列方便渲染。
     const paginationLinks = Array.isArray(links)
         ? links
         : Array.isArray(meta.links)
@@ -113,6 +100,7 @@ export default function UserTable({
 
     const isAllSelected = allIds.length > 0 && allIds.every((id) => selected.includes(id));
     const isIndeterminate = selected.length > 0 && !isAllSelected;
+    const selectedCount = selected.length;
 
     const handleSelectAll = (value: CheckedState) => {
         onSelectAll(value === true);
@@ -122,217 +110,249 @@ export default function UserTable({
         onSelect(userId, value === true);
     };
 
-    if (data.length === 0) {
-        return (
-            <div className="rounded-2xl border border-dashed border-neutral-200 bg-white p-10 text-center shadow-sm">
-                <p className="text-base font-medium text-neutral-900">目前沒有符合條件的使用者</p>
-                <p className="mt-2 text-sm text-neutral-500">請調整篩選條件或新增新的帳號。</p>
-            </div>
-        );
-    }
-
     return (
-        <div className="flex flex-col gap-4">
-            <div className="hidden overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/5 md:block">
-                <table className="min-w-full divide-y divide-neutral-100 text-sm">
-                    <thead className="bg-neutral-50/60 text-left text-xs font-semibold uppercase tracking-wide text-neutral-500">
-                        <tr>
-                            <th className="px-4 py-3">
-                                <Checkbox
-                                    checked={isAllSelected ? true : isIndeterminate ? 'indeterminate' : false}
-                                    onCheckedChange={handleSelectAll}
-                                    aria-label="選取全部"
-                                />
-                            </th>
-                            <th className="px-4 py-3 text-neutral-600">使用者</th>
-                            <th className="px-4 py-3 text-neutral-600">角色</th>
-                            <th className="px-4 py-3 text-neutral-600">狀態</th>
-                            <th className="px-4 py-3 text-neutral-600">建立時間</th>
-                            <th className="px-4 py-3 text-neutral-600">操作</th>
-                        </tr>
-                    </thead>
-                    <tbody className="divide-y divide-neutral-100 bg-white">
-                        {data.map((user) => {
-                            const statusMeta = statusBadge[user.status];
-                            const StatusIcon = statusMeta.icon;
-                            const disableSelfAction = authUserId === user.id;
+        <Card className="border border-slate-200 bg-white shadow-sm">
+            <CardHeader className="flex flex-col gap-4 border-b border-slate-100 pb-4 xl:flex-row xl:items-center xl:justify-between">
+                <div>
+                    <CardTitle className="text-lg font-semibold text-slate-900">使用者列表</CardTitle>
+                    <CardDescription>共 {meta.total} 筆資料</CardDescription>
+                    {selectedCount > 0 && (
+                        <p className="mt-1 text-sm text-slate-600">已選取 {selectedCount} 位使用者</p>
+                    )}
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                    <Button type="button" variant="outline" onClick={onExport}>
+                        <Download className="mr-2 h-4 w-4" /> 匯出 CSV
+                    </Button>
+                    {canManage && (
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            disabled={selectedCount === 0 || bulkProcessing}
+                            onClick={onBulkDelete}
+                        >
+                            <Trash2 className="mr-2 h-4 w-4" /> 刪除選取
+                        </Button>
+                    )}
+                </div>
+            </CardHeader>
+            <CardContent className="space-y-6">
+                {data.length === 0 ? (
+                    <div className="rounded-2xl border border-dashed border-neutral-200 bg-neutral-50/70 p-10 text-center">
+                        <p className="text-base font-medium text-neutral-900">目前沒有符合條件的使用者</p>
+                        <p className="mt-2 text-sm text-neutral-500">請調整篩選條件或建立新的帳號。</p>
+                    </div>
+                ) : (
+                    <>
+                        <div className="hidden overflow-hidden rounded-2xl ring-1 ring-black/5 xl:block">
+                            <table className="min-w-full divide-y divide-neutral-100 text-sm">
+                                <thead className="bg-neutral-50/60 text-left text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                                    <tr>
+                                        {canManage && (
+                                            <th className="px-4 py-3">
+                                                <Checkbox
+                                                    checked={isAllSelected ? true : isIndeterminate ? 'indeterminate' : false}
+                                                    onCheckedChange={handleSelectAll}
+                                                    aria-label="選取全部"
+                                                />
+                                            </th>
+                                        )}
+                                        <th className="px-4 py-3 text-neutral-600">使用者</th>
+                                        <th className="px-4 py-3 text-neutral-600">角色</th>
+                                        <th className="px-4 py-3 text-neutral-600">狀態</th>
+                                        <th className="px-4 py-3 text-neutral-600">建立時間</th>
+                                        <th className="px-4 py-3 text-neutral-600">操作</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-neutral-100 bg-white">
+                                    {data.map((user) => {
+                                        const statusMeta = statusBadge[user.status];
+                                        const StatusIcon = statusMeta.icon;
+                                        const disableSelfAction = authUserId === user.id;
 
-                            return (
-                                <tr key={user.id} className="hover:bg-neutral-50/60">
-                                    <td className="px-4 py-3">
-                                        <Checkbox
-                                            checked={selected.includes(user.id)}
-                                            onCheckedChange={handleSelect(user.id)}
-                                            aria-label={`選取 ${user.name}`}
-                                        />
-                                    </td>
-                                    <td className="px-4 py-3">
-                                        <div className="flex items-center gap-3">
-                                            <Avatar className="size-10">
-                                                <AvatarImage src={user.avatar ?? undefined} alt={user.name} />
-                                                <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
-                                            </Avatar>
-                                            <div className="flex flex-col">
-                                                <span className="font-medium text-neutral-900">{user.name}</span>
-                                                <span className="text-xs text-neutral-500">{user.email}</span>
+                                        return (
+                                            <tr key={user.id} className="hover:bg-neutral-50/60">
+                                                {canManage && (
+                                                    <td className="px-4 py-3">
+                                                        <Checkbox
+                                                            checked={selected.includes(user.id)}
+                                                            onCheckedChange={handleSelect(user.id)}
+                                                            aria-label={`選取 ${user.name}`}
+                                                        />
+                                                    </td>
+                                                )}
+                                                <td className="px-4 py-3">
+                                                    <div className="flex items-center gap-3">
+                                                        <Avatar className="size-10">
+                                                            <AvatarImage src={user.avatar ?? undefined} alt={user.name} />
+                                                            <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
+                                                        </Avatar>
+                                                        <div className="flex flex-col">
+                                                            <span className="font-medium text-neutral-900">{user.name}</span>
+                                                            <span className="text-xs text-neutral-500">{user.email}</span>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td className="px-4 py-3">
+                                                    <Badge variant="outline" className="font-medium text-neutral-700">
+                                                        {roleLabels[user.role]}
+                                                    </Badge>
+                                                </td>
+                                                <td className="px-4 py-3">
+                                                    <Badge
+                                                        variant={statusMeta.variant}
+                                                        className={cn('flex items-center gap-1.5 px-3 py-1 text-xs font-semibold', {
+                                                            'bg-emerald-50 text-emerald-700 ring-emerald-500/20': user.status === 'active',
+                                                            'bg-neutral-100 text-neutral-600 ring-neutral-400/20': user.status === 'suspended',
+                                                        })}
+                                                    >
+                                                        <StatusIcon className="size-3.5" />
+                                                        {statusMeta.label}
+                                                    </Badge>
+                                                </td>
+                                                <td className="px-4 py-3 text-neutral-600">{formatDateTime(user.created_at ?? null, locale)}</td>
+                                                <td className="px-4 py-3">
+                                                    <div className="flex flex-wrap items-center gap-2">
+                                                        <Button
+                                                            size="sm"
+                                                            variant="outline"
+                                                            onClick={() => onToggleStatus(user)}
+                                                            disabled={!canManage || disableSelfAction}
+                                                        >
+                                                            {user.status === 'active' ? '停用' : '啟用'}
+                                                        </Button>
+                                                        <Button size="sm" variant="ghost" asChild>
+                                                            <Link href={`/manage/users/${user.id}/edit`}>編輯</Link>
+                                                        </Button>
+                                                        <Button
+                                                            size="sm"
+                                                            variant="ghost"
+                                                            className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                                                            onClick={() => onDelete(user)}
+                                                            disabled={!canManage || disableSelfAction}
+                                                        >
+                                                            <Trash2 className="mr-1 size-4" />
+                                                            刪除
+                                                        </Button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <div className="grid gap-3 xl:hidden">
+                            {data.map((user) => {
+                                const statusMeta = statusBadge[user.status];
+                                const StatusIcon = statusMeta.icon;
+                                const disableSelfAction = authUserId === user.id;
+
+                                return (
+                                    <div key={user.id} className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm">
+                                        <div className="flex items-center justify-between">
+                                            <div className="flex items-center gap-3">
+                                                <Avatar className="size-12">
+                                                    <AvatarImage src={user.avatar ?? undefined} alt={user.name} />
+                                                    <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
+                                                </Avatar>
+                                                <div>
+                                                    <p className="text-base font-semibold text-neutral-900">{user.name}</p>
+                                                    <p className="text-xs text-neutral-500">{user.email}</p>
+                                                </div>
                                             </div>
+                                            {canManage && (
+                                                <Checkbox
+                                                    checked={selected.includes(user.id)}
+                                                    onCheckedChange={handleSelect(user.id)}
+                                                    aria-label={`選取 ${user.name}`}
+                                                />
+                                            )}
                                         </div>
-                                    </td>
-                                    <td className="px-4 py-3">
-                                        <Badge variant="outline" className="font-medium text-neutral-700">
-                                            {roleLabels[user.role]}
-                                        </Badge>
-                                    </td>
-                                    <td className="px-4 py-3">
-                                        <Badge
-                                            variant={statusMeta.variant}
-                                            className={cn('flex items-center gap-1.5 px-3 py-1 text-xs font-semibold', {
-                                                'bg-emerald-50 text-emerald-700 ring-emerald-500/20': user.status === 'active',
-                                                'bg-neutral-100 text-neutral-600 ring-neutral-400/20': user.status === 'suspended',
-                                            })}
-                                        >
-                                            <StatusIcon className="size-3.5" />
-                                            {statusMeta.label}
-                                        </Badge>
-                                    </td>
-                                    <td className="px-4 py-3 text-neutral-600">{formatDateTime(user.created_at)}</td>
-                                    <td className="px-4 py-3">
-                                        <div className="flex flex-wrap items-center gap-2">
+
+                                        <div className="mt-4 flex flex-wrap items-center gap-2 text-sm">
+                                            <Badge variant="outline">{roleLabels[user.role]}</Badge>
+                                            <Badge
+                                                variant={statusMeta.variant}
+                                                className={cn('flex items-center gap-1.5 px-3 py-1', {
+                                                    'bg-emerald-50 text-emerald-700 ring-emerald-500/20': user.status === 'active',
+                                                    'bg-neutral-100 text-neutral-600 ring-neutral-400/20': user.status === 'suspended',
+                                                })}
+                                            >
+                                                <StatusIcon className="size-3.5" />
+                                                {statusMeta.label}
+                                            </Badge>
+                                        </div>
+
+                                        <dl className="mt-3 grid grid-cols-1 gap-1 text-xs text-neutral-500">
+                                            <div className="flex items-center justify-between">
+                                                <dt>建立時間</dt>
+                                                <dd className="text-neutral-700">{formatDateTime(user.created_at ?? null, locale)}</dd>
+                                            </div>
+                                        </dl>
+
+                                        <div className="mt-4 flex flex-wrap items-center gap-2">
                                             <Button
                                                 size="sm"
                                                 variant="outline"
+                                                className="flex-1"
                                                 onClick={() => onToggleStatus(user)}
                                                 disabled={!canManage || disableSelfAction}
                                             >
                                                 {user.status === 'active' ? '停用' : '啟用'}
                                             </Button>
-                                            <Button size="sm" variant="ghost" asChild>
+                                            <Button size="sm" variant="secondary" className="flex-1" asChild>
                                                 <Link href={`/manage/users/${user.id}/edit`}>編輯</Link>
                                             </Button>
                                             <Button
                                                 size="sm"
                                                 variant="ghost"
-                                                className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                                                className="flex-1 text-red-600 hover:bg-red-50 hover:text-red-700"
                                                 onClick={() => onDelete(user)}
                                                 disabled={!canManage || disableSelfAction}
                                             >
-                                                <Trash2 className="mr-1 size-4" />
                                                 刪除
                                             </Button>
                                         </div>
-                                    </td>
-                                </tr>
-                            );
-                        })}
-                    </tbody>
-                </table>
-            </div>
-
-            <div className="grid gap-3 md:hidden">
-                {data.map((user) => {
-                    const statusMeta = statusBadge[user.status];
-                    const StatusIcon = statusMeta.icon;
-                    const disableSelfAction = authUserId === user.id;
-
-                    return (
-                        <div key={user.id} className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm">
-                            <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-3">
-                                    <Avatar className="size-12">
-                                        <AvatarImage src={user.avatar ?? undefined} alt={user.name} />
-                                        <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
-                                    </Avatar>
-                                    <div>
-                                        <p className="text-base font-semibold text-neutral-900">{user.name}</p>
-                                        <p className="text-xs text-neutral-500">{user.email}</p>
                                     </div>
-                                </div>
-                                <Checkbox
-                                    checked={selected.includes(user.id)}
-                                    onCheckedChange={handleSelect(user.id)}
-                                    aria-label={`選取 ${user.name}`}
-                                />
+                                );
+                            })}
+                        </div>
+
+                        <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
+                            <div>
+                                共 <span className="font-semibold text-neutral-900">{meta.total}</span> 筆資料
                             </div>
-
-                            <div className="mt-4 flex flex-wrap items-center gap-2 text-sm">
-                                <Badge variant="outline">{roleLabels[user.role]}</Badge>
-                                <Badge
-                                    variant={statusMeta.variant}
-                                    className={cn('flex items-center gap-1.5 px-3 py-1', {
-                                        'bg-emerald-50 text-emerald-700 ring-emerald-500/20': user.status === 'active',
-                                        'bg-neutral-100 text-neutral-600 ring-neutral-400/20': user.status === 'suspended',
-                                    })}
-                                >
-                                    <StatusIcon className="size-3.5" />
-                                    {statusMeta.label}
-                                </Badge>
-                            </div>
-
-                            <dl className="mt-3 grid grid-cols-1 gap-1 text-xs text-neutral-500">
-                                <div className="flex items-center justify-between">
-                                    <dt>建立時間</dt>
-                                    <dd className="text-neutral-700">{formatDateTime(user.created_at)}</dd>
-                                </div>
-                            </dl>
-
-                            <div className="mt-4 flex flex-wrap items-center gap-2">
-                                <Button
-                                    size="sm"
-                                    variant="outline"
-                                    className="flex-1"
-                                    onClick={() => onToggleStatus(user)}
-                                    disabled={!canManage || disableSelfAction}
-                                >
-                                    {user.status === 'active' ? '停用' : '啟用'}
-                                </Button>
-                                <Button size="sm" variant="secondary" className="flex-1" asChild>
-                                    <Link href={`/manage/users/${user.id}/edit`}>編輯</Link>
-                                </Button>
-                                <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    className="flex-1 text-red-600 hover:bg-red-50 hover:text-red-700"
-                                    onClick={() => onDelete(user)}
-                                    disabled={!canManage || disableSelfAction}
-                                >
-                                    刪除
-                                </Button>
+                            <div className="flex items-center gap-2">
+                                {paginationLinks.map((link, index) => {
+                                    const label = link.label.replace('&laquo;', '«').replace('&raquo;', '»');
+                                    const isDisabled = !link.url;
+                                    return (
+                                        <Button
+                                            key={`${label}-${index}`}
+                                            size="sm"
+                                            variant={link.active ? 'default' : 'ghost'}
+                                            className={cn('min-w-[2.25rem]', {
+                                                'pointer-events-none opacity-40': isDisabled,
+                                            })}
+                                            asChild={!isDisabled}
+                                        >
+                                            {isDisabled ? (
+                                                <span dangerouslySetInnerHTML={{ __html: label }} />
+                                            ) : (
+                                                <Link href={link.url!} preserveScroll preserveState>
+                                                    <span dangerouslySetInnerHTML={{ __html: label }} />
+                                                </Link>
+                                            )}
+                                        </Button>
+                                    );
+                                })}
                             </div>
                         </div>
-                    );
-                })}
-            </div>
-
-            <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-neutral-600">
-                <div>
-                    共 <span className="font-semibold text-neutral-900">{meta.total}</span> 筆資料
-                </div>
-                <div className="flex items-center gap-2">
-                    {paginationLinks.map((link, index) => {
-                        const label = link.label.replace('&laquo;', '«').replace('&raquo;', '»');
-                        const isDisabled = !link.url;
-                        return (
-                            <Button
-                                key={`${label}-${index}`}
-                                size="sm"
-                                variant={link.active ? 'default' : 'ghost'}
-                                className={cn('min-w-[2.25rem]', {
-                                    'pointer-events-none opacity-40': isDisabled,
-                                })}
-                                asChild={!isDisabled}
-                            >
-                                {isDisabled ? (
-                                    <span dangerouslySetInnerHTML={{ __html: label }} />
-                                ) : (
-                                    <Link href={link.url!} preserveScroll preserveState>
-                                        <span dangerouslySetInnerHTML={{ __html: label }} />
-                                    </Link>
-                                )}
-                            </Button>
-                        );
-                    })}
-                </div>
-            </div>
-        </div>
+                    </>
+                )}
+            </CardContent>
+        </Card>
     );
 }

--- a/resources/js/components/manage/users/user-filter-form.tsx
+++ b/resources/js/components/manage/users/user-filter-form.tsx
@@ -1,0 +1,178 @@
+import type { FormEvent } from 'react';
+import { Filter } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+
+import type { OptionItem, TranslatorFunction, UserFilterState } from './user-types';
+
+interface UserFilterFormProps {
+    filterState: UserFilterState;
+    roleOptions: OptionItem[];
+    statusOptions: OptionItem[];
+    sortOptions: OptionItem[];
+    perPageOptions: number[];
+    hasActiveFilters: boolean;
+    onChange: (key: keyof UserFilterState, value: string) => void;
+    onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+    onReset: () => void;
+    t: TranslatorFunction;
+    fallbackLanguage: 'zh' | 'en';
+}
+
+export function UserFilterForm({
+    filterState,
+    roleOptions,
+    statusOptions,
+    sortOptions,
+    perPageOptions,
+    hasActiveFilters,
+    onChange,
+    onSubmit,
+    onReset,
+    t,
+    fallbackLanguage,
+}: UserFilterFormProps) {
+    // 依語系提供預設字串，確保中英文介面都有合適提示。
+    const fallbackText = (zh: string, en: string) => (fallbackLanguage === 'zh' ? zh : en);
+
+    return (
+        <Card className="border border-slate-200 bg-white shadow-sm">
+            <CardHeader className="border-b border-slate-100 pb-4">
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+                    <Filter className="h-5 w-5" />
+                    {t('users.index.filters.title', fallbackText('篩選條件', 'Filters'))}
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                <form onSubmit={onSubmit} className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6">
+                    <div className="xl:col-span-2 space-y-1">
+                        <label htmlFor="filter-q" className="text-sm font-medium text-slate-700">
+                            {t('users.index.filters.keyword', fallbackText('關鍵字', 'Keyword'))}
+                        </label>
+                        <Input
+                            id="filter-q"
+                            value={filterState.q}
+                            onChange={(event) => onChange('q', event.target.value)}
+                            placeholder={t(
+                                'users.index.filters.keyword_placeholder',
+                                fallbackText('搜尋姓名或電子郵件', 'Search name or email'),
+                            )}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="filter-role" className="text-sm font-medium text-slate-700">
+                            {t('users.index.filters.role', fallbackText('角色', 'Role'))}
+                        </label>
+                        <Select
+                            id="filter-role"
+                            value={filterState.role}
+                            onChange={(event) => onChange('role', event.target.value)}
+                        >
+                            <option value="">{t('users.index.filters.all', fallbackText('全部', 'All'))}</option>
+                            {roleOptions.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="filter-status" className="text-sm font-medium text-slate-700">
+                            {t('users.index.filters.status', fallbackText('狀態', 'Status'))}
+                        </label>
+                        <Select
+                            id="filter-status"
+                            value={filterState.status}
+                            onChange={(event) => onChange('status', event.target.value)}
+                        >
+                            <option value="">{t('users.index.filters.all', fallbackText('全部', 'All'))}</option>
+                            {statusOptions.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="filter-created-from" className="text-sm font-medium text-slate-700">
+                            {t('users.index.filters.created_from', fallbackText('建立起始日', 'Created from'))}
+                        </label>
+                        <Input
+                            id="filter-created-from"
+                            type="date"
+                            value={filterState.created_from}
+                            onChange={(event) => onChange('created_from', event.target.value)}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="filter-created-to" className="text-sm font-medium text-slate-700">
+                            {t('users.index.filters.created_to', fallbackText('建立結束日', 'Created to'))}
+                        </label>
+                        <Input
+                            id="filter-created-to"
+                            type="date"
+                            value={filterState.created_to}
+                            onChange={(event) => onChange('created_to', event.target.value)}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="filter-sort" className="text-sm font-medium text-slate-700">
+                            {t('users.index.filters.sort', fallbackText('排序', 'Sort by'))}
+                        </label>
+                        <Select
+                            id="filter-sort"
+                            value={filterState.sort}
+                            onChange={(event) => onChange('sort', event.target.value)}
+                        >
+                            {sortOptions.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="filter-per-page" className="text-sm font-medium text-slate-700">
+                            {t('users.index.filters.per_page', fallbackText('每頁筆數', 'Per page'))}
+                        </label>
+                        <Select
+                            id="filter-per-page"
+                            value={filterState.per_page}
+                            onChange={(event) => onChange('per_page', event.target.value)}
+                        >
+                            {perPageOptions.map((option) => (
+                                <option key={option} value={option}>
+                                    {option}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="flex items-end gap-2">
+                        <Button type="submit" className="w-full rounded-full">
+                            {t('users.index.filters.apply', fallbackText('套用', 'Apply'))}
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            className="w-full rounded-full"
+                            disabled={!hasActiveFilters}
+                            onClick={onReset}
+                        >
+                            {t('users.index.filters.reset', fallbackText('重設', 'Reset'))}
+                        </Button>
+                    </div>
+                </form>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/manage/users/user-types.ts
+++ b/resources/js/components/manage/users/user-types.ts
@@ -1,0 +1,75 @@
+// 集中管理使用者管理頁面會共用的型別，避免重複宣告造成維護負擔。
+export type UserRole = 'admin' | 'teacher' | 'user';
+
+export type UserStatus = 'active' | 'suspended';
+
+export interface UserRow {
+    id: number;
+    name: string;
+    email: string;
+    role: UserRole;
+    status: UserStatus;
+    avatar?: string | null;
+    email_verified_at?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    deleted_at?: string | null;
+}
+
+export interface PaginationLink {
+    url: string | null;
+    label: string;
+    active: boolean;
+}
+
+export interface PaginationMeta {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from?: number | null;
+    to?: number | null;
+    links?: PaginationLink[];
+}
+
+export interface UserFilterState {
+    q: string;
+    role: string;
+    status: string;
+    created_from: string;
+    created_to: string;
+    sort: string;
+    per_page: string;
+}
+
+export interface UserFlashMessages {
+    success?: string;
+    error?: string;
+    info?: string;
+}
+
+export type TranslatorFunction = (
+    key: string,
+    fallbackText?: string,
+    replacements?: Record<string, string | number>,
+) => string;
+
+export interface OptionItem {
+    value: string;
+    label: string;
+}
+
+export interface UserFormPayload {
+    id?: number;
+    name: string;
+    email: string;
+    role: UserRole;
+    status: UserStatus;
+    email_verified_at?: string | null;
+}
+
+export interface UsersResponsePayload {
+    data: UserRow[];
+    links: PaginationLink[];
+    meta: PaginationMeta;
+}

--- a/resources/js/pages/manage/users/edit.tsx
+++ b/resources/js/pages/manage/users/edit.tsx
@@ -1,0 +1,81 @@
+import { Head, Link, usePage } from '@inertiajs/react';
+import { ArrowLeft } from 'lucide-react';
+import { useMemo } from 'react';
+
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+import UserForm from '@/components/manage/users/UserForm';
+import type { OptionItem, UserFormPayload } from '@/components/manage/users/user-types';
+import type { BreadcrumbItem, SharedData } from '@/types';
+import { useTranslator } from '@/hooks/use-translator';
+
+interface ManageUserEditProps {
+    mode: 'create' | 'edit';
+    user: UserFormPayload | null;
+    roleOptions: OptionItem[];
+    statusOptions: OptionItem[];
+}
+
+export default function ManageUserEdit({ mode, user, roleOptions, statusOptions }: ManageUserEditProps) {
+    const { auth } = usePage<SharedData>().props;
+    const { t } = useTranslator('manage');
+
+    const userRole = auth?.user?.role ?? 'user';
+    const layoutRole: 'admin' | 'teacher' | 'user' =
+        userRole === 'admin' ? 'admin' : userRole === 'teacher' ? 'teacher' : 'user';
+
+    const breadcrumbs: BreadcrumbItem[] = useMemo(
+        () => [
+            { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+            { title: t('layout.breadcrumbs.users', '使用者管理'), href: '/manage/users' },
+            mode === 'edit'
+                ? {
+                      title:
+                          user?.name ?? t('users.form.breadcrumb.edit', '編輯使用者'),
+                      href: user?.id ? `/manage/users/${user.id}/edit` : '/manage/users',
+                  }
+                : { title: t('users.form.breadcrumb.create', '新增使用者'), href: '/manage/users/create' },
+        ],
+        [mode, t, user?.id, user?.name],
+    );
+
+    const pageTitle =
+        mode === 'create'
+            ? t('users.form.title.create', '新增使用者')
+            : t('users.form.title.edit', '編輯使用者');
+    const pageDescription =
+        mode === 'create'
+            ? t('users.form.description.create', '建立新的後台帳號並設定角色與狀態。')
+            : t('users.form.description.edit', '調整帳號基本資訊、權限與登入設定。');
+
+    return (
+        <ManageLayout role={layoutRole} breadcrumbs={breadcrumbs}>
+            <Head title={pageTitle} />
+
+            <section className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+                <Card className="border border-slate-200 bg-white shadow-sm">
+                    <CardContent className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="space-y-2">
+                            <h1 className="text-3xl font-semibold text-slate-900">{pageTitle}</h1>
+                            <p className="text-sm text-slate-600">{pageDescription}</p>
+                        </div>
+                        <Button
+                            asChild
+                            variant="outline"
+                            className="rounded-full"
+                        >
+                            <Link href="/manage/users" className="inline-flex items-center gap-2">
+                                <ArrowLeft className="h-4 w-4" />
+                                {t('users.form.actions.back_to_index', '返回列表')}
+                            </Link>
+                        </Button>
+                    </CardContent>
+                </Card>
+
+                <UserForm mode={mode} user={user ?? undefined} roleOptions={roleOptions} statusOptions={statusOptions} />
+            </section>
+        </ManageLayout>
+    );
+}

--- a/resources/js/pages/manage/users/index.tsx
+++ b/resources/js/pages/manage/users/index.tsx
@@ -1,0 +1,447 @@
+import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ShieldCheck, UserPlus } from 'lucide-react';
+
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import ToastContainer from '@/components/ui/toast-container';
+import { Button } from '@/components/ui/button';
+
+import { useToast } from '@/hooks/use-toast';
+import { useTranslator } from '@/hooks/use-translator';
+
+import UserTable from '@/components/manage/users/UserTable';
+import { UserFilterForm } from '@/components/manage/users/user-filter-form';
+import type {
+    OptionItem,
+    UserFilterState,
+    UserFlashMessages,
+    UserRow,
+    UserRole,
+    UserStatus,
+    UsersResponsePayload,
+} from '@/components/manage/users/user-types';
+import type { BreadcrumbItem, SharedData } from '@/types';
+
+interface UsersIndexProps {
+    users: UsersResponsePayload;
+    filters: Partial<UserFilterState>;
+    roleOptions: OptionItem[];
+    statusOptions: OptionItem[];
+    sortOptions: OptionItem[];
+    perPageOptions: number[];
+    can: {
+        create: boolean;
+        manage: boolean;
+    };
+    authUserId: number;
+}
+
+const createInitialFilterState = (
+    filters: Partial<UserFilterState>,
+    defaultSort: string,
+    defaultPerPage: number,
+): UserFilterState => ({
+    q: filters.q ?? '',
+    role: filters.role ?? '',
+    status: filters.status ?? '',
+    created_from: filters.created_from ?? '',
+    created_to: filters.created_to ?? '',
+    sort: filters.sort ?? defaultSort,
+    per_page: filters.per_page ?? String(defaultPerPage),
+});
+
+export default function UsersIndex({
+    users,
+    filters,
+    roleOptions,
+    statusOptions,
+    sortOptions,
+    perPageOptions,
+    can,
+    authUserId,
+}: UsersIndexProps) {
+    const page = usePage<SharedData & { flash?: UserFlashMessages }>();
+    const flashMessages: UserFlashMessages = page.props.flash ?? {};
+    const locale = page.props.locale ?? 'zh-TW';
+
+    const { t } = useTranslator('manage');
+    const normalizedLocale = locale.toLowerCase().replace('_', '-');
+    const isTraditionalChinese = normalizedLocale.startsWith('zh');
+    const fallbackLanguage: 'zh' | 'en' = isTraditionalChinese ? 'zh' : 'en';
+    const dateLocale = isTraditionalChinese ? 'zh-TW' : 'en-US';
+
+    const { toasts, showSuccess, showError, showInfo, showBatchErrors, dismissToast } = useToast();
+
+    const defaultSort = sortOptions[0]?.value ?? '-created_at';
+    const defaultPerPage = perPageOptions[0] ?? 15;
+
+    // 使用本地狀態保存篩選條件與勾選清單，提供順暢的使用者體驗。
+    const [filterState, setFilterState] = useState<UserFilterState>(
+        createInitialFilterState(filters, defaultSort, defaultPerPage),
+    );
+    const [selected, setSelected] = useState<number[]>([]);
+
+    // Inertia 表單負責封裝與後端互動的請求，統一錯誤與載入狀態處理。
+    const bulkForm = useForm<{ action: 'delete'; ids: number[] }>({
+        action: 'delete',
+        ids: [],
+    });
+    const statusForm = useForm<{
+        name: string;
+        email: string;
+        role: UserRole;
+        status: UserStatus;
+        email_verified: boolean;
+    }>({
+        name: '',
+        email: '',
+        role: 'user',
+        status: 'active',
+        email_verified: false,
+    });
+    const deleteForm = useForm({});
+
+    const skipFlashToastRef = useRef(false);
+    const previousFlashRef = useRef<UserFlashMessages>({});
+
+    const userData = users?.data ?? [];
+    const paginationMeta = users?.meta ?? {
+        current_page: 1,
+        last_page: 1,
+        per_page: defaultPerPage,
+        total: userData.length,
+        from: userData.length > 0 ? 1 : 0,
+        to: userData.length,
+    };
+    const paginationLinks = users?.links ?? [];
+
+    const breadcrumbs: BreadcrumbItem[] = useMemo(
+        () => [
+            { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+            { title: t('layout.breadcrumbs.users', '使用者管理'), href: '/manage/users' },
+        ],
+        [t],
+    );
+
+    const hasActiveFilters = useMemo(
+        () =>
+            filterState.q !== '' ||
+            filterState.role !== '' ||
+            filterState.status !== '' ||
+            filterState.created_from !== '' ||
+            filterState.created_to !== '' ||
+            filterState.sort !== defaultSort,
+        [filterState, defaultSort],
+    );
+
+    const handleFilterChange = useCallback((key: keyof UserFilterState, value: string) => {
+        setFilterState((previous) => ({ ...previous, [key]: value }));
+    }, []);
+
+    const applyFilters = useCallback(
+        (event?: FormEvent<HTMLFormElement>) => {
+            event?.preventDefault();
+
+            const params = Object.fromEntries(
+                Object.entries(filterState).filter(([, value]) => value !== ''),
+            );
+
+            router.get('/manage/users', params, {
+                preserveScroll: true,
+                preserveState: true,
+            });
+        },
+        [filterState],
+    );
+
+    const resetFilters = useCallback(() => {
+        const initialState = createInitialFilterState({}, defaultSort, defaultPerPage);
+        setFilterState(initialState);
+
+        router.get(
+            '/manage/users',
+            { sort: initialState.sort, per_page: initialState.per_page },
+            {
+                preserveScroll: true,
+                preserveState: true,
+            },
+        );
+    }, [defaultSort, defaultPerPage]);
+
+    const handleSelectAll = useCallback(
+        (checked: boolean) => {
+            setSelected(checked ? userData.map((user) => user.id) : []);
+        },
+        [userData],
+    );
+
+    const handleSelect = useCallback((userId: number, value: boolean) => {
+        setSelected((previous) =>
+            value ? [...previous, userId] : previous.filter((id) => id !== userId),
+        );
+    }, []);
+
+    // 批次刪除所有勾選的使用者，執行前會再次向使用者確認。
+    const performBulkDelete = useCallback(() => {
+        if (!can.manage || selected.length === 0 || bulkForm.processing) {
+            return;
+        }
+
+        const confirmed = window.confirm(
+            fallbackLanguage === 'zh'
+                ? `確定要刪除選取的 ${selected.length} 位使用者嗎？`
+                : `Delete the selected ${selected.length} users?`,
+        );
+
+        if (!confirmed) {
+            return;
+        }
+
+        bulkForm.transform(() => ({
+            action: 'delete',
+            ids: selected,
+        }));
+
+        bulkForm.post('/manage/users/bulk', {
+            preserveScroll: true,
+            onSuccess: () => {
+                setSelected([]);
+                bulkForm.reset();
+            },
+            onError: (errors) => {
+                skipFlashToastRef.current = true;
+                const errorMessages = Object.values(errors)
+                    .flat()
+                    .map((message) => String(message))
+                    .filter((message) => message.length > 0);
+                const fallbackMessage =
+                    fallbackLanguage === 'zh'
+                        ? '批次刪除失敗，請稍後再試。'
+                        : 'Bulk deletion failed. Please try again later.';
+                showBatchErrors(
+                    errorMessages.length > 0 ? errorMessages : [fallbackMessage],
+                    fallbackLanguage === 'zh' ? '操作失敗' : 'Operation failed',
+                );
+            },
+        });
+    }, [can.manage, selected, bulkForm, fallbackLanguage, showBatchErrors]);
+
+    // 切換使用者的啟用／停用狀態，確保不會對自己或重複操作。
+    const handleToggleStatus = useCallback(
+        (user: UserRow) => {
+            if (!can.manage || statusForm.processing) {
+                return;
+            }
+
+            const nextStatus: UserStatus = user.status === 'active' ? 'suspended' : 'active';
+
+            statusForm.transform(() => ({
+                name: user.name,
+                email: user.email,
+                role: user.role,
+                status: nextStatus,
+                email_verified: Boolean(user.email_verified_at),
+            }));
+
+            statusForm.put(`/manage/users/${user.id}`, {
+                preserveScroll: true,
+                onSuccess: () => {
+                    setSelected((previous) => previous.filter((id) => id !== user.id));
+                },
+                onError: (errors) => {
+                    skipFlashToastRef.current = true;
+                    const errorMessages = Object.values(errors)
+                        .flat()
+                        .map((message) => String(message))
+                        .filter((message) => message.length > 0);
+                    const fallbackMessage =
+                        fallbackLanguage === 'zh'
+                            ? '更新狀態時發生錯誤，請稍後再試。'
+                            : 'Failed to update status. Please try again later.';
+                    showBatchErrors(
+                        errorMessages.length > 0 ? errorMessages : [fallbackMessage],
+                        fallbackLanguage === 'zh' ? '操作失敗' : 'Operation failed',
+                    );
+                },
+                onFinish: () => {
+                    statusForm.reset();
+                },
+            });
+        },
+        [can.manage, statusForm, fallbackLanguage, showBatchErrors],
+    );
+
+    // 刪除單一使用者並從已勾選名單中移除。
+    const handleDeleteUser = useCallback(
+        (user: UserRow) => {
+            if (!can.manage || deleteForm.processing) {
+                return;
+            }
+
+            const confirmed = window.confirm(
+                fallbackLanguage === 'zh'
+                    ? `確定要刪除「${user.name}」帳號嗎？`
+                    : `Delete the account for “${user.name}”?`,
+            );
+
+            if (!confirmed) {
+                return;
+            }
+
+            deleteForm.delete(`/manage/users/${user.id}`, {
+                preserveScroll: true,
+                onSuccess: () => {
+                    setSelected((previous) => previous.filter((id) => id !== user.id));
+                },
+                onError: (errors) => {
+                    skipFlashToastRef.current = true;
+                    const errorMessages = Object.values(errors)
+                        .flat()
+                        .map((message) => String(message))
+                        .filter((message) => message.length > 0);
+                    const fallbackMessage =
+                        fallbackLanguage === 'zh'
+                            ? '刪除帳號時發生錯誤，請稍後再試。'
+                            : 'Failed to delete the user. Please try again later.';
+                    showBatchErrors(
+                        errorMessages.length > 0 ? errorMessages : [fallbackMessage],
+                        fallbackLanguage === 'zh' ? '操作失敗' : 'Operation failed',
+                    );
+                },
+            });
+        },
+        [can.manage, deleteForm, fallbackLanguage, showBatchErrors],
+    );
+
+    // 依目前篩選條件與勾選名單匯出 CSV，並顯示提示避免使用者重複操作。
+    const handleExport = useCallback(() => {
+        const params = new URLSearchParams();
+
+        Object.entries(filterState).forEach(([key, value]) => {
+            if (value !== '') {
+                params.append(key, value);
+            }
+        });
+
+        selected.forEach((id) => params.append('ids[]', String(id)));
+
+        const url = `/manage/users/export${params.toString() ? `?${params.toString()}` : ''}`;
+
+        showInfo(
+            fallbackLanguage === 'zh' ? '開始匯出' : 'Export started',
+            fallbackLanguage === 'zh'
+                ? '系統已依目前條件準備匯出，檔案將自動下載。'
+                : 'Preparing CSV with the current filters. The download will start shortly.',
+        );
+
+        if (typeof window !== 'undefined') {
+            window.location.href = url;
+        }
+    }, [filterState, selected, showInfo, fallbackLanguage]);
+
+    useEffect(() => {
+        setFilterState(createInitialFilterState(filters, defaultSort, defaultPerPage));
+    }, [filters, defaultSort, defaultPerPage]);
+
+    useEffect(() => {
+        setSelected([]);
+    }, [paginationMeta.current_page, paginationMeta.total]);
+
+    // 監看伺服器返回的 flash 訊息並轉換為 Toast，統一前端提示行為。
+    useEffect(() => {
+        if (skipFlashToastRef.current) {
+            previousFlashRef.current = flashMessages;
+            skipFlashToastRef.current = false;
+            return;
+        }
+
+        if (flashMessages.success && flashMessages.success !== previousFlashRef.current.success) {
+            showSuccess(
+                t('users.index.flash.success_title', fallbackLanguage === 'zh' ? '操作成功' : 'Success'),
+                flashMessages.success,
+            );
+        }
+
+        if (flashMessages.error && flashMessages.error !== previousFlashRef.current.error) {
+            showError(
+                t('users.index.flash.error_title', fallbackLanguage === 'zh' ? '操作失敗' : 'Error'),
+                flashMessages.error,
+            );
+        }
+
+        if (flashMessages.info && flashMessages.info !== previousFlashRef.current.info) {
+            showInfo(
+                t('users.index.flash.info_title', fallbackLanguage === 'zh' ? '提示訊息' : 'Notice'),
+                flashMessages.info,
+            );
+        }
+
+        previousFlashRef.current = flashMessages;
+    }, [flashMessages, showSuccess, showError, showInfo, t, fallbackLanguage]);
+
+    const pageTitle = t('users.index.title', fallbackLanguage === 'zh' ? '使用者管理' : 'User management');
+    const pageDescription = t(
+        'users.index.description',
+        fallbackLanguage === 'zh'
+            ? '檢視並管理後台帳號，調整角色、狀態與權限。'
+            : 'Review and manage accounts, including roles and status.',
+    );
+
+    return (
+        <ManageLayout breadcrumbs={breadcrumbs}>
+            <Head title={pageTitle} />
+
+            <ToastContainer toasts={toasts} onDismiss={dismissToast} position="bottom-right" />
+
+            <section className="space-y-6">
+                <ManagePageHeader
+                    badge={{ icon: <ShieldCheck className="h-4 w-4" />, label: t('users.index.badge', '帳號控管') }}
+                    title={pageTitle}
+                    description={pageDescription}
+                    actions={
+                        can.create ? (
+                            <Button asChild className="rounded-full px-6">
+                                <Link href="/manage/users/create">
+                                    <UserPlus className="mr-2 h-4 w-4" />
+                                    {t('users.index.actions.create', fallbackLanguage === 'zh' ? '新增使用者' : 'New user')}
+                                </Link>
+                            </Button>
+                        ) : null
+                    }
+                />
+
+                <UserFilterForm
+                    filterState={filterState}
+                    roleOptions={roleOptions}
+                    statusOptions={statusOptions}
+                    sortOptions={sortOptions}
+                    perPageOptions={perPageOptions}
+                    hasActiveFilters={hasActiveFilters}
+                    onChange={handleFilterChange}
+                    onSubmit={applyFilters}
+                    onReset={resetFilters}
+                    t={t}
+                    fallbackLanguage={fallbackLanguage}
+                />
+
+                <UserTable
+                    data={userData}
+                    meta={paginationMeta}
+                    links={paginationLinks}
+                    selected={selected}
+                    onSelect={handleSelect}
+                    onSelectAll={handleSelectAll}
+                    onToggleStatus={handleToggleStatus}
+                    onDelete={handleDeleteUser}
+                    onBulkDelete={performBulkDelete}
+                    onExport={handleExport}
+                    bulkProcessing={bulkForm.processing}
+                    canManage={can.manage}
+                    authUserId={authUserId}
+                    locale={dateLocale}
+                />
+            </section>
+        </ManageLayout>
+    );
+}


### PR DESCRIPTION
## Summary
- extract shared user management types and introduce a reusable filter form for the manage users area
- redesign the manage users table to include bulk controls, export action, and responsive layout with localized formatting
- implement the manage users index and edit pages with toast-driven feedback, bulk operations, and the typed user form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5886571908323b80781d514dbfbcf