### PR TITLE
feat: enhance contact message management

### DIFF
--- a/resources/js/components/manage/contact/contact-detail-card.tsx
+++ b/resources/js/components/manage/contact/contact-detail-card.tsx
@@ -1,0 +1,110 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { CalendarClock, Mail, UserCircle } from 'lucide-react';
+import type { ContactMessageItem } from './contact-types';
+import { contactStatusBadgeVariant, contactStatusLabels } from './contact-types';
+
+interface ContactDetailCardProps {
+    message: ContactMessageItem;
+    fallbackLanguage: 'zh' | 'en';
+    localeForDate: 'zh-TW' | 'en';
+}
+
+/**
+ * 顯示單筆聯絡訊息詳細資料的卡片
+ */
+export function ContactDetailCard({ message, fallbackLanguage, localeForDate }: ContactDetailCardProps) {
+    const formatDateTime = (value: string | null): string => {
+        if (!value) {
+            return fallbackLanguage === 'zh' ? '尚未提供' : 'Not available';
+        }
+
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) {
+            return fallbackLanguage === 'zh' ? '格式錯誤' : 'Invalid format';
+        }
+
+        return parsed.toLocaleString(localeForDate === 'zh-TW' ? 'zh-TW' : 'en-US', {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+        });
+    };
+
+    const statusLabel = contactStatusLabels[message.status][fallbackLanguage];
+    const badgeVariant = contactStatusBadgeVariant[message.status];
+
+    return (
+        <Card className="border border-slate-200 bg-white shadow-sm">
+            <CardHeader className="space-y-4 border-b border-slate-100 pb-6">
+                <div className="flex items-center justify-between gap-4">
+                    <CardTitle className="text-2xl font-semibold text-slate-900">
+                        {message.subject || (fallbackLanguage === 'zh' ? '未填寫主旨' : 'No subject')}
+                    </CardTitle>
+                    <Badge variant={badgeVariant}>{statusLabel}</Badge>
+                </div>
+                <div className="grid gap-2 text-sm text-slate-600 md:grid-cols-2">
+                    <div className="flex items-center gap-2">
+                        <UserCircle className="h-5 w-5 text-slate-500" />
+                        <span className="font-medium text-slate-900">{message.name}</span>
+                        {message.locale && (
+                            <span className="text-xs text-slate-500">{`Locale：${message.locale}`}</span>
+                        )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Mail className="h-5 w-5 text-slate-500" />
+                        <a href={`mailto:${message.email}`} className="text-blue-600 hover:underline">
+                            {message.email}
+                        </a>
+                    </div>
+                </div>
+                <div className="text-xs text-slate-500">
+                    {fallbackLanguage === 'zh' ? '送出時間：' : 'Submitted at: '}
+                    {formatDateTime(message.created_at)}
+                </div>
+            </CardHeader>
+            <CardContent className="space-y-6 p-6">
+                <section>
+                    <h2 className="text-base font-semibold text-slate-900">
+                        {fallbackLanguage === 'zh' ? '訊息內容' : 'Message'}
+                    </h2>
+                    <Separator className="my-2" />
+                    <p className="whitespace-pre-line text-sm leading-relaxed text-slate-700">{message.message}</p>
+                    {message.file_url && (
+                        <a
+                            href={message.file_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-3 inline-flex text-sm text-blue-600 hover:underline"
+                        >
+                            {fallbackLanguage === 'zh' ? '下載附件' : 'Download attachment'}
+                        </a>
+                    )}
+                </section>
+
+                <section>
+                    <h2 className="text-base font-semibold text-slate-900">
+                        {fallbackLanguage === 'zh' ? '處理紀錄' : 'Processing history'}
+                    </h2>
+                    <Separator className="my-2" />
+                    {message.processor ? (
+                        <div className="space-y-2 text-sm text-slate-700">
+                            <div className="flex items-center gap-2">
+                                <UserCircle className="h-5 w-5 text-slate-500" />
+                                <span className="font-medium text-slate-900">{message.processor.name}</span>
+                            </div>
+                            <div className="flex items-center gap-2 text-xs text-slate-500">
+                                <CalendarClock className="h-4 w-4" />
+                                <span>{formatDateTime(message.processed_at)}</span>
+                            </div>
+                        </div>
+                    ) : (
+                        <p className="text-sm text-slate-600">
+                            {fallbackLanguage === 'zh' ? '尚未指派處理人員。' : 'No processor assigned yet.'}
+                        </p>
+                    )}
+                </section>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/manage/contact/contact-filter-form.tsx
+++ b/resources/js/components/manage/contact/contact-filter-form.tsx
@@ -1,0 +1,107 @@
+import { FormEvent } from 'react';
+import { Filter } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+import type { ContactFilterState, ContactStatusOption } from './contact-types';
+
+interface ContactFilterFormProps {
+    state: ContactFilterState;
+    statusOptions: ContactStatusOption[];
+    perPageOptions: number[];
+    onChange: (key: keyof ContactFilterState, value: string) => void;
+    onSubmit: (event?: FormEvent<HTMLFormElement>) => void;
+    onReset: () => void;
+    hasActiveFilters: boolean;
+}
+
+/**
+ * 聯絡訊息篩選表單元件
+ * - 與頁面邏輯分離，便於日後維護或共用
+ * - 傳入的狀態、每頁筆數等皆以 props 控制，維持單向資料流
+ */
+export function ContactFilterForm({
+    state,
+    statusOptions,
+    perPageOptions,
+    onChange,
+    onSubmit,
+    onReset,
+    hasActiveFilters,
+}: ContactFilterFormProps) {
+    return (
+        <Card className="border border-slate-200 bg-white shadow-sm">
+            <CardHeader className="flex flex-row items-center justify-between border-b border-slate-100 pb-4">
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+                    <Filter className="h-4 w-4" />
+                    聯絡訊息篩選
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                <form
+                    className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4"
+                    onSubmit={(event) => onSubmit(event)}
+                >
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="contact-search">搜尋關鍵字</Label>
+                        <Input
+                            id="contact-search"
+                            value={state.search}
+                            placeholder="輸入姓名、Email 或主旨"
+                            onChange={(event) => onChange('search', event.target.value)}
+                        />
+                    </div>
+
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="contact-status">處理狀態</Label>
+                        <Select
+                            id="contact-status"
+                            value={state.status}
+                            onChange={(event) => onChange('status', event.target.value)}
+                        >
+                            <option value="">全部狀態</option>
+                            {statusOptions.map((option) => (
+                                <option key={option.value || 'all'} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="contact-per-page">每頁顯示</Label>
+                        <Select
+                            id="contact-per-page"
+                            value={state.per_page}
+                            onChange={(event) => onChange('per_page', event.target.value)}
+                        >
+                            {perPageOptions.map((option) => (
+                                <option key={option} value={option}>
+                                    每頁 {option} 筆
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="flex items-end gap-2">
+                        <Button type="submit" className="w-full">
+                            套用篩選
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            className="w-full"
+                            disabled={!hasActiveFilters}
+                            onClick={onReset}
+                        >
+                            清除條件
+                        </Button>
+                    </div>
+                </form>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/manage/contact/contact-table.tsx
+++ b/resources/js/components/manage/contact/contact-table.tsx
@@ -1,0 +1,456 @@
+import { Link } from '@inertiajs/react';
+import type { ReactElement } from 'react';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { CalendarClock, CheckCircle2, Eye, Loader2, Mail, MoreVertical, Trash2, Undo2, ShieldAlert } from 'lucide-react';
+import type {
+    ContactMessageItem,
+    ContactPaginationLink,
+    ContactPaginationMeta,
+    ContactMessageStatus,
+} from './contact-types';
+import { contactStatusBadgeVariant, contactStatusLabels } from './contact-types';
+
+interface ContactTableProps {
+    messages: ContactMessageItem[];
+    pagination: ContactPaginationMeta;
+    paginationLinks: ContactPaginationLink[];
+    changePage: (page: number) => void;
+    iconActionClass: string;
+    fallbackLanguage: 'zh' | 'en';
+    localeForDate: 'zh-TW' | 'en';
+    onUpdateStatus: (id: number, status: ContactMessageStatus) => void;
+    onDelete: (id: number) => void;
+    processingId: number | null;
+    deletingId: number | null;
+}
+
+/**
+ * 轉換日期字串為對應語系格式，若傳入值無效則回傳空字串
+ */
+const formatDateTime = (value: string | null, locale: 'zh-TW' | 'en'): string => {
+    if (!value) {
+        return '';
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        return '';
+    }
+
+    return parsed.toLocaleString(locale === 'zh-TW' ? 'zh-TW' : 'en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    });
+};
+
+/**
+ * 根據語系提供預設文案，避免英文環境仍顯示中文
+ */
+const fallbackText = (fallbackLanguage: 'zh' | 'en', zh: string, en: string) =>
+    fallbackLanguage === 'zh' ? zh : en;
+
+/**
+ * 聯絡訊息列表元件，負責展示資料與操作入口
+ */
+export function ContactTable({
+    messages,
+    pagination,
+    paginationLinks,
+    changePage,
+    iconActionClass,
+    fallbackLanguage,
+    localeForDate,
+    onUpdateStatus,
+    onDelete,
+    processingId,
+    deletingId,
+}: ContactTableProps) {
+    const hasData = messages.length > 0;
+
+    const buildStatusActionLabel = (status: ContactMessageStatus): string => {
+        const labels: Record<ContactMessageStatus, { zh: string; en: string }> = {
+            new: { zh: '標記為未處理', en: 'Mark as new' },
+            in_progress: { zh: '標記為處理中', en: 'Mark as in progress' },
+            resolved: { zh: '標記為已完成', en: 'Mark as resolved' },
+            spam: { zh: '標記為垃圾訊息', en: 'Mark as spam' },
+        };
+
+        const label = labels[status];
+        return fallbackText(fallbackLanguage, label.zh, label.en);
+    };
+
+    const actionIconMap: Record<ContactMessageStatus, ReactElement> = {
+        new: <Undo2 className="h-4 w-4" />, // 將狀態還原為未處理
+        in_progress: <Loader2 className="h-4 w-4" />, // 設為處理中
+        resolved: <CheckCircle2 className="h-4 w-4" />, // 設為已完成
+        spam: <ShieldAlert className="h-4 w-4" />, // 標記為垃圾訊息
+    };
+
+    const availableStatusActions: ContactMessageStatus[] = ['new', 'in_progress', 'resolved', 'spam'];
+
+    return (
+        <Card className="border border-slate-200 bg-white shadow-sm">
+            <CardHeader className="flex flex-col gap-2 border-b border-slate-100 pb-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <CardTitle className="text-lg font-semibold text-slate-900">
+                        {fallbackText(fallbackLanguage, '聯絡訊息列表', 'Contact messages')}
+                    </CardTitle>
+                    <p className="text-sm text-slate-600">
+                        {fallbackText(
+                            fallbackLanguage,
+                            `共 ${pagination.total} 筆資料`,
+                            `Total ${pagination.total} records`,
+                        )}
+                    </p>
+                </div>
+            </CardHeader>
+            <CardContent className="space-y-6">
+                <div className="hidden lg:block">
+                    <Table>
+                        <TableHeader>
+                            <TableRow className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                <TableHead className="w-64">{fallbackText(fallbackLanguage, '聯絡人', 'Contact')}</TableHead>
+                                <TableHead>{fallbackText(fallbackLanguage, '主旨', 'Subject')}</TableHead>
+                                <TableHead>{fallbackText(fallbackLanguage, '訊息', 'Message')}</TableHead>
+                                <TableHead className="w-32">{fallbackText(fallbackLanguage, '狀態', 'Status')}</TableHead>
+                                <TableHead className="w-40">{fallbackText(fallbackLanguage, '建立時間', 'Created at')}</TableHead>
+                                <TableHead className="w-40">{fallbackText(fallbackLanguage, '處理資訊', 'Processing')}</TableHead>
+                                <TableHead className="w-20 text-right">{fallbackText(fallbackLanguage, '操作', 'Actions')}</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {!hasData && (
+                                <TableRow>
+                                    <TableCell colSpan={7} className="py-8 text-center text-sm text-slate-500">
+                                        {fallbackText(
+                                            fallbackLanguage,
+                                            '目前尚無符合條件的聯絡訊息。',
+                                            'No contact messages match the filters yet.',
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {hasData &&
+                                messages.map((message) => {
+                                    const statusLabel = contactStatusLabels[message.status];
+                                    const badgeVariant = contactStatusBadgeVariant[message.status];
+                                    const createdAtLabel = formatDateTime(message.created_at, localeForDate);
+                                    const processedAtLabel = formatDateTime(message.processed_at, localeForDate);
+                                    const isProcessing = processingId === message.id;
+                                    const isDeleting = deletingId === message.id;
+
+                                    return (
+                                        <TableRow key={message.id} className="align-top">
+                                            <TableCell>
+                                                <div className="flex flex-col gap-1">
+                                                    <span className="font-semibold text-slate-900">{message.name}</span>
+                                                    <span className="inline-flex items-center gap-1 text-sm text-slate-600">
+                                                        <Mail className="h-4 w-4" />
+                                                        <a
+                                                            href={`mailto:${message.email}`}
+                                                            className="text-blue-600 hover:underline"
+                                                        >
+                                                            {message.email}
+                                                        </a>
+                                                    </span>
+                                                    {message.locale && (
+                                                        <span className="text-xs text-slate-500">{`Locale：${message.locale}`}</span>
+                                                    )}
+                                                </div>
+                                            </TableCell>
+                                            <TableCell>
+                                                <span className="block font-medium text-slate-800">
+                                                    {message.subject || fallbackText(fallbackLanguage, '未填寫主旨', 'No subject')}
+                                                </span>
+                                            </TableCell>
+                                            <TableCell>
+                                                <p className="line-clamp-3 whitespace-pre-line text-sm text-slate-600">
+                                                    {message.message}
+                                                </p>
+                                                {message.file_url && (
+                                                    <a
+                                                        href={message.file_url}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        className="mt-2 inline-flex text-xs text-blue-600 hover:underline"
+                                                    >
+                                                        {fallbackText(fallbackLanguage, '下載附件', 'Download attachment')}
+                                                    </a>
+                                                )}
+                                            </TableCell>
+                                            <TableCell>
+                                                <Badge variant={badgeVariant}>{statusLabel[fallbackLanguage]}</Badge>
+                                            </TableCell>
+                                            <TableCell>
+                                                <div className="flex flex-col text-sm text-slate-600">
+                                                    <span>{createdAtLabel || fallbackText(fallbackLanguage, '尚未提供', 'Not available')}</span>
+                                                </div>
+                                            </TableCell>
+                                            <TableCell>
+                                                <div className="flex flex-col gap-1 text-sm text-slate-600">
+                                                    {message.processor ? (
+                                                        <span className="font-medium text-slate-800">{message.processor.name}</span>
+                                                    ) : (
+                                                        <span>{fallbackText(fallbackLanguage, '尚未指定負責人', 'No processor yet')}</span>
+                                                    )}
+                                                    {processedAtLabel && (
+                                                        <span className="inline-flex items-center gap-1 text-xs text-slate-500">
+                                                            <CalendarClock className="h-4 w-4" />
+                                                            {processedAtLabel}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            </TableCell>
+                                            <TableCell className="text-right">
+                                                <DropdownMenu>
+                                                    <DropdownMenuTrigger asChild>
+                                                        <Button
+                                                            type="button"
+                                                            variant="outline"
+                                                            size="icon"
+                                                            className={iconActionClass}
+                                                            disabled={isProcessing || isDeleting}
+                                                        >
+                                                            <MoreVertical className="h-4 w-4" />
+                                                        </Button>
+                                                    </DropdownMenuTrigger>
+                                                    <DropdownMenuContent align="end" className="w-48">
+                                                        <DropdownMenuLabel>
+                                                            {fallbackText(fallbackLanguage, '操作選單', 'Actions')}
+                                                        </DropdownMenuLabel>
+                                                        <DropdownMenuItem asChild>
+                                                            <Link href={`/manage/contact-messages/${message.id}`} className="flex items-center gap-2">
+                                                                <Eye className="h-4 w-4" />
+                                                                {fallbackText(fallbackLanguage, '檢視詳情', 'View details')}
+                                                            </Link>
+                                                        </DropdownMenuItem>
+                                                        <DropdownMenuSeparator />
+                                                        {availableStatusActions.map((status) => {
+                                                            if (status === message.status) {
+                                                                return null;
+                                                            }
+
+                                                            return (
+                                                                <DropdownMenuItem
+                                                                    key={`${message.id}-${status}`}
+                                                                    onClick={() => onUpdateStatus(message.id, status)}
+                                                                    disabled={isProcessing}
+                                                                >
+                                                                    {actionIconMap[status]}
+                                                                    {buildStatusActionLabel(status)}
+                                                                </DropdownMenuItem>
+                                                            );
+                                                        })}
+                                                        <DropdownMenuSeparator />
+                                                        <DropdownMenuItem
+                                                            onClick={() => onDelete(message.id)}
+                                                            disabled={isDeleting}
+                                                            variant="destructive"
+                                                        >
+                                                            <Trash2 className="h-4 w-4" />
+                                                            {fallbackText(fallbackLanguage, '刪除訊息', 'Delete message')}
+                                                        </DropdownMenuItem>
+                                                    </DropdownMenuContent>
+                                                </DropdownMenu>
+                                            </TableCell>
+                                        </TableRow>
+                                    );
+                                })}
+                        </TableBody>
+                    </Table>
+                </div>
+
+                <div className="grid gap-4 lg:hidden">
+                    {!hasData && (
+                        <div className="rounded-xl border border-slate-200 bg-white p-6 text-center text-sm text-slate-500 shadow-sm">
+                            {fallbackText(
+                                fallbackLanguage,
+                                '目前尚未收到聯絡訊息或條件過於嚴格。',
+                                'No contact messages found for the current filters.',
+                            )}
+                        </div>
+                    )}
+
+                    {hasData &&
+                        messages.map((message) => {
+                            const statusLabel = contactStatusLabels[message.status];
+                            const badgeVariant = contactStatusBadgeVariant[message.status];
+                            const createdAtLabel = formatDateTime(message.created_at, localeForDate);
+                            const processedAtLabel = formatDateTime(message.processed_at, localeForDate);
+                            const isProcessing = processingId === message.id;
+                            const isDeleting = deletingId === message.id;
+
+                            return (
+                                <div key={`mobile-${message.id}`} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                                    <div className="flex items-start justify-between">
+                                        <div>
+                                            <p className="text-base font-semibold text-slate-900">{message.name}</p>
+                                            <a
+                                                href={`mailto:${message.email}`}
+                                                className="mt-1 inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+                                            >
+                                                <Mail className="h-4 w-4" />
+                                                {message.email}
+                                            </a>
+                                        </div>
+                                        <Badge variant={badgeVariant}>{statusLabel[fallbackLanguage]}</Badge>
+                                    </div>
+
+                                    <div className="mt-3 space-y-2 text-sm text-slate-600">
+                                        <p className="font-medium text-slate-800">
+                                            {message.subject || fallbackText(fallbackLanguage, '未填寫主旨', 'No subject')}
+                                        </p>
+                                        <p className="whitespace-pre-line">{message.message}</p>
+                                        {message.file_url && (
+                                            <a
+                                                href={message.file_url}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="inline-flex text-xs text-blue-600 hover:underline"
+                                            >
+                                                {fallbackText(fallbackLanguage, '下載附件', 'Download attachment')}
+                                            </a>
+                                        )}
+                                    </div>
+
+                                    <div className="mt-4 flex flex-col gap-1 text-xs text-slate-500">
+                                        <span>
+                                            {fallbackText(fallbackLanguage, '建立時間：', 'Created: ')}
+                                            {createdAtLabel || fallbackText(fallbackLanguage, '尚未提供', 'Not available')}
+                                        </span>
+                                        <span>
+                                            {fallbackText(fallbackLanguage, '處理資訊：', 'Processing: ')}
+                                            {message.processor
+                                                ? `${message.processor.name}${processedAtLabel ? ` · ${processedAtLabel}` : ''}`
+                                                : fallbackText(fallbackLanguage, '尚未指定負責人', 'No processor yet')}
+                                        </span>
+                                    </div>
+
+                                    <div className="mt-4 flex flex-wrap items-center gap-2">
+                                        <Button asChild size="sm" variant="outline">
+                                            <Link href={`/manage/contact-messages/${message.id}`} className="flex items-center gap-2">
+                                                <Eye className="h-4 w-4" />
+                                                {fallbackText(fallbackLanguage, '檢視詳情', 'View details')}
+                                            </Link>
+                                        </Button>
+
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button
+                                                    type="button"
+                                                    size="sm"
+                                                    variant="secondary"
+                                                    disabled={isProcessing || isDeleting}
+                                                    className="flex items-center gap-2"
+                                                >
+                                                    <MoreVertical className="h-4 w-4" />
+                                                    {fallbackText(fallbackLanguage, '更多操作', 'More actions')}
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent align="start" className="w-48">
+                                                {availableStatusActions.map((status) => {
+                                                    if (status === message.status) {
+                                                        return null;
+                                                    }
+
+                                                    return (
+                                                        <DropdownMenuItem
+                                                            key={`mobile-${message.id}-${status}`}
+                                                            onClick={() => onUpdateStatus(message.id, status)}
+                                                            disabled={isProcessing}
+                                                        >
+                                                            {actionIconMap[status]}
+                                                            {buildStatusActionLabel(status)}
+                                                        </DropdownMenuItem>
+                                                    );
+                                                })}
+                                                <DropdownMenuSeparator />
+                                                <DropdownMenuItem
+                                                    onClick={() => onDelete(message.id)}
+                                                    disabled={isDeleting}
+                                                    variant="destructive"
+                                                >
+                                                    <Trash2 className="h-4 w-4" />
+                                                    {fallbackText(fallbackLanguage, '刪除訊息', 'Delete message')}
+                                                </DropdownMenuItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </div>
+                                </div>
+                            );
+                        })}
+                </div>
+
+                {hasData && (
+                    <div className="flex flex-col gap-4 border-t border-slate-100 pt-4 lg:flex-row lg:items-center lg:justify-between">
+                        <p className="text-sm text-slate-600">
+                            {fallbackText(
+                                fallbackLanguage,
+                                `顯示第 ${pagination.from ?? 0} - ${pagination.to ?? 0} 筆，共 ${pagination.total} 筆`,
+                                `Showing ${pagination.from ?? 0} - ${pagination.to ?? 0} of ${pagination.total} records`,
+                            )}
+                        </p>
+                        <div className="flex flex-wrap items-center gap-2">
+                            <Button
+                                type="button"
+                                size="icon"
+                                variant="outline"
+                                className="h-9 w-9"
+                                onClick={() => changePage(pagination.current_page - 1)}
+                                disabled={pagination.current_page <= 1}
+                                aria-label={fallbackText(fallbackLanguage, '上一頁', 'Previous page')}
+                            >
+                                ‹
+                            </Button>
+                            {paginationLinks.map((link, index) => {
+                                if (!link.url) {
+                                    return null;
+                                }
+
+                                const url = new URL(link.url);
+                                const pageParam = url.searchParams.get('page');
+                                const pageNumber = pageParam ? Number(pageParam) : 1;
+                                const label = link.label.replace(/&laquo;|&raquo;|&nbsp;/g, '') || pageNumber.toString();
+
+                                return (
+                                    <Button
+                                        type="button"
+                                        key={`${link.label}-${index}`}
+                                        variant={link.active ? 'default' : 'outline'}
+                                        size="sm"
+                                        className="min-w-9"
+                                        onClick={() => changePage(pageNumber)}
+                                    >
+                                        {label}
+                                    </Button>
+                                );
+                            })}
+                            <Button
+                                type="button"
+                                size="icon"
+                                variant="outline"
+                                className="h-9 w-9"
+                                onClick={() => changePage(pagination.current_page + 1)}
+                                disabled={pagination.current_page >= pagination.last_page}
+                                aria-label={fallbackText(fallbackLanguage, '下一頁', 'Next page')}
+                            >
+                                ›
+                            </Button>
+                        </div>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/manage/contact/contact-types.ts
+++ b/resources/js/components/manage/contact/contact-types.ts
@@ -1,0 +1,89 @@
+import type { PaginationLink } from '@/components/manage/post/post-types';
+
+/**
+ * 聯絡訊息狀態列舉，對應資料表中的 status 欄位
+ */
+export type ContactMessageStatus = 'new' | 'in_progress' | 'resolved' | 'spam';
+
+/**
+ * 聯絡訊息資料介面
+ */
+export interface ContactMessageItem {
+    id: number;
+    locale: string | null;
+    name: string;
+    email: string;
+    subject: string | null;
+    message: string;
+    file_url: string | null;
+    status: ContactMessageStatus;
+    processed_by: number | null;
+    processed_at: string | null;
+    created_at: string;
+    updated_at: string;
+    processor?: {
+        id: number;
+        name: string;
+        email?: string | null;
+    } | null;
+}
+
+/**
+ * 篩選狀態，封裝搜尋關鍵字、狀態與每頁筆數
+ */
+export interface ContactFilterState {
+    search: string;
+    status: string;
+    per_page: string;
+}
+
+/**
+ * 分頁中 meta 資料定義
+ */
+export interface ContactPaginationMeta {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number | null;
+    to: number | null;
+}
+
+/**
+ * Toast 用的閃存訊息
+ */
+export interface ContactFlashMessages {
+    success?: string;
+    error?: string;
+    info?: string;
+}
+
+/**
+ * 狀態下拉選項定義
+ */
+export interface ContactStatusOption {
+    value: ContactMessageStatus | '';
+    label: string;
+}
+
+/**
+ * 狀態顯示用文字，區分中英文預設字詞
+ */
+export const contactStatusLabels: Record<ContactMessageStatus, { zh: string; en: string }> = {
+    new: { zh: '未處理', en: 'New' },
+    in_progress: { zh: '處理中', en: 'In progress' },
+    resolved: { zh: '已完成', en: 'Resolved' },
+    spam: { zh: '垃圾訊息', en: 'Spam' },
+};
+
+/**
+ * Badge 樣式對照，提供更明顯的狀態顏色
+ */
+export const contactStatusBadgeVariant: Record<ContactMessageStatus, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+    new: 'secondary',
+    in_progress: 'default',
+    resolved: 'outline',
+    spam: 'destructive',
+};
+
+export type ContactPaginationLink = PaginationLink;

--- a/resources/js/pages/manage/admin/contact-messages/edit.tsx
+++ b/resources/js/pages/manage/admin/contact-messages/edit.tsx
@@ -1,0 +1,8 @@
+import ContactMessageShow from './show';
+
+/**
+ * 編輯頁面沿用詳情頁，提供相同的狀態調整與刪除功能
+ */
+export default function ContactMessageEdit(props: Parameters<typeof ContactMessageShow>[0]) {
+    return <ContactMessageShow {...props} />;
+}

--- a/resources/js/pages/manage/admin/contact-messages/index.tsx
+++ b/resources/js/pages/manage/admin/contact-messages/index.tsx
@@ -1,0 +1,327 @@
+import { Head, router, usePage } from '@inertiajs/react';
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import { ContactFilterForm } from '@/components/manage/contact/contact-filter-form';
+import { ContactTable } from '@/components/manage/contact/contact-table';
+import { contactStatusLabels } from '@/components/manage/contact/contact-types';
+import type {
+    ContactFilterState,
+    ContactFlashMessages,
+    ContactMessageItem,
+    ContactPaginationLink,
+    ContactPaginationMeta,
+    ContactStatusOption,
+    ContactMessageStatus,
+} from '@/components/manage/contact/contact-types';
+import ManageLayout from '@/layouts/manage/manage-layout';
+import ToastContainer from '@/components/ui/toast-container';
+import { useToast } from '@/hooks/use-toast';
+import type { BreadcrumbItem, SharedData } from '@/types';
+
+/**
+ * 頁面 props 定義，對應後端 Controller 回傳結構
+ */
+interface ContactMessagesIndexProps {
+    messages: {
+        data: ContactMessageItem[];
+        links: ContactPaginationLink[];
+        meta: ContactPaginationMeta;
+    };
+    filters: Partial<ContactFilterState>;
+    statusOptions: Record<ContactMessageStatus, ContactMessageStatus>;
+    perPageOptions: number[];
+}
+
+/**
+ * 建立篩選表單預設值
+ */
+const createInitialFilterState = (
+    filters: Partial<ContactFilterState>,
+    defaultPerPage: number,
+): ContactFilterState => ({
+    search: filters.search ?? '',
+    status: filters.status ?? '',
+    per_page: filters.per_page ?? String(defaultPerPage),
+});
+
+export default function ContactMessagesIndex({ messages, filters, statusOptions, perPageOptions }: ContactMessagesIndexProps) {
+    const page = usePage<SharedData & { flash?: ContactFlashMessages }>();
+    const flashMessages: ContactFlashMessages = page.props.flash ?? {};
+    const locale = page.props.locale ?? 'zh-TW';
+
+    const { toasts, showSuccess, showError, showInfo, showBatchErrors, dismissToast } = useToast();
+
+    const normalizedLocale = locale.toLowerCase().replace('_', '-');
+    const isTraditionalChinese = normalizedLocale.startsWith('zh');
+    const fallbackLanguage: 'zh' | 'en' = isTraditionalChinese ? 'zh' : 'en';
+    const localeForDate: 'zh-TW' | 'en' = isTraditionalChinese ? 'zh-TW' : 'en';
+
+    const defaultPerPage = perPageOptions[0] ?? 15;
+    const messageData = messages?.data ?? [];
+    const paginationMeta = messages?.meta ?? {
+        current_page: 1,
+        last_page: 1,
+        per_page: defaultPerPage,
+        total: messageData.length,
+        from: messageData.length > 0 ? 1 : 0,
+        to: messageData.length,
+    };
+
+    const pagination: ContactPaginationMeta = {
+        current_page: paginationMeta.current_page ?? 1,
+        last_page: paginationMeta.last_page ?? 1,
+        per_page: paginationMeta.per_page ?? defaultPerPage,
+        total: paginationMeta.total ?? messageData.length,
+        from: paginationMeta.from ?? (messageData.length > 0 ? 1 : 0),
+        to: paginationMeta.to ?? messageData.length,
+    };
+
+    const paginationLinks = messages?.links ?? [];
+
+    const [filterState, setFilterState] = useState<ContactFilterState>(createInitialFilterState(filters, defaultPerPage));
+    const [processingId, setProcessingId] = useState<number | null>(null);
+    const [deletingId, setDeletingId] = useState<number | null>(null);
+
+    const skipFlashToastRef = useRef(false);
+    const previousFlashRef = useRef<ContactFlashMessages>({});
+
+    const iconActionClass = useMemo(
+        () =>
+            'inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500/60',
+        [],
+    );
+
+    const breadcrumbs: BreadcrumbItem[] = useMemo(
+        () => [
+            { title: fallbackLanguage === 'zh' ? '管理首頁' : 'Dashboard', href: '/manage/dashboard' },
+            { title: fallbackLanguage === 'zh' ? '聯絡訊息管理' : 'Contact messages', href: '/manage/contact-messages' },
+        ],
+        [fallbackLanguage],
+    );
+
+    const statusOptionsList: ContactStatusOption[] = useMemo(() => {
+        const fallbackLabels = contactStatusLabels;
+        return Object.keys(statusOptions ?? {}).map((key) => {
+            const statusKey = key as ContactMessageStatus;
+            const label = fallbackLabels[statusKey]?.[fallbackLanguage] ?? statusKey;
+            return { value: statusKey, label };
+        });
+    }, [statusOptions, fallbackLanguage]);
+
+    const hasActiveFilters = useMemo(
+        () => filterState.search !== '' || filterState.status !== '' || filterState.per_page !== String(defaultPerPage),
+        [filterState, defaultPerPage],
+    );
+
+    const handleFilterChange = useCallback((key: keyof ContactFilterState, value: string) => {
+        setFilterState((previous) => ({ ...previous, [key]: value }));
+    }, []);
+
+    const applyFilters = useCallback(
+        (event?: FormEvent<HTMLFormElement>) => {
+            event?.preventDefault();
+
+            const params = Object.fromEntries(
+                Object.entries(filterState).filter(([, value]) => value !== ''),
+            );
+
+            router.get('/manage/contact-messages', params, {
+                preserveScroll: true,
+                preserveState: true,
+            });
+        },
+        [filterState],
+    );
+
+    const resetFilters = useCallback(() => {
+        const initialState = createInitialFilterState({}, defaultPerPage);
+        setFilterState(initialState);
+
+        router.get(
+            '/manage/contact-messages',
+            { per_page: defaultPerPage },
+            {
+                preserveScroll: true,
+                preserveState: true,
+            },
+        );
+    }, [defaultPerPage]);
+
+    const changePage = useCallback(
+        (pageNumber: number) => {
+            if (pageNumber <= 0 || pageNumber > pagination.last_page || pageNumber === pagination.current_page) {
+                return;
+            }
+
+            const params = Object.fromEntries(
+                Object.entries(filterState).filter(([, value]) => value !== ''),
+            );
+
+            params.page = pageNumber.toString();
+
+            router.get('/manage/contact-messages', params, {
+                preserveScroll: true,
+                preserveState: true,
+            });
+        },
+        [filterState, pagination],
+    );
+
+    const handleUpdateStatus = useCallback(
+        (id: number, status: ContactMessageStatus) => {
+            if (processingId !== null) {
+                return;
+            }
+
+            setProcessingId(id);
+
+            router.patch(`/manage/contact-messages/${id}`, { status }, {
+                preserveScroll: true,
+                onSuccess: () => {
+                    skipFlashToastRef.current = true;
+                    showSuccess(
+                        fallbackLanguage === 'zh' ? '狀態更新成功' : 'Status updated',
+                        fallbackLanguage === 'zh' ? '已更新聯絡訊息狀態。' : 'The contact message status has been updated.',
+                    );
+                },
+                onError: (errors) => {
+                    const errorMessages = Object.values(errors ?? {})
+                        .flat()
+                        .map((value) => String(value))
+                        .filter((value) => value.length > 0);
+
+                    const fallbackMessage =
+                        fallbackLanguage === 'zh'
+                            ? '狀態更新失敗，請稍後再試。'
+                            : 'Failed to update status, please try again.';
+
+                    showBatchErrors(errorMessages.length > 0 ? errorMessages : [fallbackMessage]);
+                },
+                onFinish: () => {
+                    setProcessingId(null);
+                },
+            });
+        },
+        [processingId, showSuccess, showBatchErrors, fallbackLanguage],
+    );
+
+    const handleDelete = useCallback(
+        (id: number) => {
+            if (deletingId !== null) {
+                return;
+            }
+
+            const confirmed = window.confirm(
+                fallbackLanguage === 'zh'
+                    ? '確定要刪除此聯絡訊息嗎？此操作無法復原。'
+                    : 'Are you sure you want to delete this contact message? This action cannot be undone.',
+            );
+
+            if (!confirmed) {
+                return;
+            }
+
+            setDeletingId(id);
+
+            router.delete(`/manage/contact-messages/${id}`, {
+                preserveScroll: true,
+                onSuccess: () => {
+                    skipFlashToastRef.current = true;
+                    showSuccess(
+                        fallbackLanguage === 'zh' ? '刪除成功' : 'Deleted',
+                        fallbackLanguage === 'zh' ? '聯絡訊息已刪除。' : 'The contact message has been deleted.',
+                    );
+                },
+                onError: (errors) => {
+                    const errorMessages = Object.values(errors ?? {})
+                        .flat()
+                        .map((value) => String(value))
+                        .filter((value) => value.length > 0);
+
+                    const fallbackMessage =
+                        fallbackLanguage === 'zh'
+                            ? '刪除失敗，請稍後再試。'
+                            : 'Failed to delete, please try again later.';
+
+                    showBatchErrors(errorMessages.length > 0 ? errorMessages : [fallbackMessage]);
+                },
+                onFinish: () => {
+                    setDeletingId(null);
+                },
+            });
+        },
+        [deletingId, showSuccess, showBatchErrors, fallbackLanguage],
+    );
+
+    useEffect(() => {
+        setFilterState(createInitialFilterState(filters, defaultPerPage));
+    }, [filters, defaultPerPage]);
+
+    useEffect(() => {
+        if (skipFlashToastRef.current) {
+            previousFlashRef.current = flashMessages;
+            skipFlashToastRef.current = false;
+            return;
+        }
+
+        if (flashMessages.success && flashMessages.success !== previousFlashRef.current.success) {
+            showSuccess(fallbackLanguage === 'zh' ? '操作成功' : 'Success', flashMessages.success);
+        }
+
+        if (flashMessages.error && flashMessages.error !== previousFlashRef.current.error) {
+            showError(fallbackLanguage === 'zh' ? '操作失敗' : 'Error', flashMessages.error);
+        }
+
+        if (flashMessages.info && flashMessages.info !== previousFlashRef.current.info) {
+            showInfo(fallbackLanguage === 'zh' ? '提示' : 'Info', flashMessages.info);
+        }
+
+        previousFlashRef.current = flashMessages;
+    }, [flashMessages, showSuccess, showError, showInfo, fallbackLanguage]);
+
+    const pageTitle = fallbackLanguage === 'zh' ? '聯絡訊息管理' : 'Contact messages management';
+    const pageDescription =
+        fallbackLanguage === 'zh'
+            ? '檢視與處理網站訪客透過聯絡我們表單送出的訊息，確保每則需求均獲妥善回覆。'
+            : 'Review and process messages submitted from the contact form to ensure every request is handled properly.';
+
+    return (
+        <ManageLayout role="admin" breadcrumbs={breadcrumbs}>
+            <Head title={pageTitle} />
+
+            <ToastContainer toasts={toasts} onDismiss={dismissToast} position="bottom-right" />
+
+            <section className="space-y-6">
+                <ManagePageHeader
+                    title={pageTitle}
+                    description={pageDescription}
+                />
+
+                <ContactFilterForm
+                    state={filterState}
+                    statusOptions={statusOptionsList}
+                    perPageOptions={perPageOptions}
+                    onChange={handleFilterChange}
+                    onSubmit={applyFilters}
+                    onReset={resetFilters}
+                    hasActiveFilters={hasActiveFilters}
+                />
+
+                <ContactTable
+                    messages={messageData}
+                    pagination={pagination}
+                    paginationLinks={paginationLinks}
+                    changePage={changePage}
+                    iconActionClass={iconActionClass}
+                    fallbackLanguage={fallbackLanguage}
+                    localeForDate={localeForDate}
+                    onUpdateStatus={handleUpdateStatus}
+                    onDelete={handleDelete}
+                    processingId={processingId}
+                    deletingId={deletingId}
+                />
+            </section>
+        </ManageLayout>
+    );
+}

--- a/resources/js/pages/manage/admin/contact-messages/show.tsx
+++ b/resources/js/pages/manage/admin/contact-messages/show.tsx
@@ -1,0 +1,245 @@
+import { Head, Link, router, usePage } from '@inertiajs/react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import { ContactDetailCard } from '@/components/manage/contact/contact-detail-card';
+import type {
+    ContactFlashMessages,
+    ContactMessageItem,
+    ContactMessageStatus,
+    ContactStatusOption,
+} from '@/components/manage/contact/contact-types';
+import { contactStatusLabels } from '@/components/manage/contact/contact-types';
+import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+import ToastContainer from '@/components/ui/toast-container';
+import { useToast } from '@/hooks/use-toast';
+import type { BreadcrumbItem, SharedData } from '@/types';
+
+interface ContactMessageShowProps {
+    message: ContactMessageItem;
+    statusOptions?: Record<ContactMessageStatus, ContactMessageStatus>;
+}
+
+export default function ContactMessageShow({ message, statusOptions }: ContactMessageShowProps) {
+    const page = usePage<SharedData & { flash?: ContactFlashMessages }>();
+    const flashMessages: ContactFlashMessages = page.props.flash ?? {};
+    const locale = page.props.locale ?? 'zh-TW';
+
+    const { toasts, showSuccess, showError, showInfo, showBatchErrors, dismissToast } = useToast();
+
+    const normalizedLocale = locale.toLowerCase().replace('_', '-');
+    const isTraditionalChinese = normalizedLocale.startsWith('zh');
+    const fallbackLanguage: 'zh' | 'en' = isTraditionalChinese ? 'zh' : 'en';
+    const localeForDate: 'zh-TW' | 'en' = isTraditionalChinese ? 'zh-TW' : 'en';
+
+    const [status, setStatus] = useState<ContactMessageStatus>(message.status);
+    const [processing, setProcessing] = useState(false);
+
+    const skipFlashToastRef = useRef(false);
+    const previousFlashRef = useRef<ContactFlashMessages>({});
+
+    const breadcrumbs: BreadcrumbItem[] = useMemo(
+        () => [
+            { title: fallbackLanguage === 'zh' ? '管理首頁' : 'Dashboard', href: '/manage/dashboard' },
+            { title: fallbackLanguage === 'zh' ? '聯絡訊息管理' : 'Contact messages', href: '/manage/contact-messages' },
+            { title: fallbackLanguage === 'zh' ? '訊息詳情' : 'Message detail', href: `/manage/contact-messages/${message.id}` },
+        ],
+        [fallbackLanguage, message.id],
+    );
+
+    const statusOptionsList: ContactStatusOption[] = useMemo(() => {
+        const fallbackLabels = contactStatusLabels;
+        const available = statusOptions ?? {
+            new: 'new',
+            in_progress: 'in_progress',
+            resolved: 'resolved',
+            spam: 'spam',
+        };
+
+        return Object.keys(available).map((key) => {
+            const statusKey = key as ContactMessageStatus;
+            const label = fallbackLabels[statusKey]?.[fallbackLanguage] ?? statusKey;
+            return { value: statusKey, label };
+        });
+    }, [statusOptions, fallbackLanguage]);
+
+    useEffect(() => {
+        setStatus(message.status);
+    }, [message.status]);
+
+    useEffect(() => {
+        if (skipFlashToastRef.current) {
+            previousFlashRef.current = flashMessages;
+            skipFlashToastRef.current = false;
+            return;
+        }
+
+        if (flashMessages.success && flashMessages.success !== previousFlashRef.current.success) {
+            showSuccess(fallbackLanguage === 'zh' ? '操作成功' : 'Success', flashMessages.success);
+        }
+
+        if (flashMessages.error && flashMessages.error !== previousFlashRef.current.error) {
+            showError(fallbackLanguage === 'zh' ? '操作失敗' : 'Error', flashMessages.error);
+        }
+
+        if (flashMessages.info && flashMessages.info !== previousFlashRef.current.info) {
+            showInfo(fallbackLanguage === 'zh' ? '提示' : 'Info', flashMessages.info);
+        }
+
+        previousFlashRef.current = flashMessages;
+    }, [flashMessages, showSuccess, showError, showInfo, fallbackLanguage]);
+
+    const handleStatusSubmit = useCallback(() => {
+        if (processing || status === message.status) {
+            if (status === message.status) {
+                showInfo(
+                    fallbackLanguage === 'zh' ? '狀態未變更' : 'No changes',
+                    fallbackLanguage === 'zh' ? '請選擇不同的狀態後再儲存。' : 'Select a different status before saving.',
+                );
+            }
+            return;
+        }
+
+        setProcessing(true);
+
+        router.patch(`/manage/contact-messages/${message.id}`, { status }, {
+            preserveScroll: true,
+            onSuccess: () => {
+                skipFlashToastRef.current = true;
+                showSuccess(
+                    fallbackLanguage === 'zh' ? '狀態已更新' : 'Status updated',
+                    fallbackLanguage === 'zh' ? '聯絡訊息狀態已更新。' : 'The contact message status has been updated.',
+                );
+            },
+            onError: (errors) => {
+                const errorMessages = Object.values(errors ?? {})
+                    .flat()
+                    .map((value) => String(value))
+                    .filter((value) => value.length > 0);
+
+                const fallbackMessage =
+                    fallbackLanguage === 'zh'
+                        ? '狀態更新失敗，請稍後再試。'
+                        : 'Failed to update status, please try again later.';
+
+                showBatchErrors(errorMessages.length > 0 ? errorMessages : [fallbackMessage]);
+            },
+            onFinish: () => setProcessing(false),
+        });
+    }, [processing, status, message.id, message.status, showSuccess, showInfo, showBatchErrors, fallbackLanguage]);
+
+    const handleDelete = useCallback(() => {
+        if (processing) {
+            return;
+        }
+
+        const confirmed = window.confirm(
+            fallbackLanguage === 'zh'
+                ? '確定要刪除此聯絡訊息嗎？此操作無法復原。'
+                : 'Are you sure you want to delete this contact message? This action cannot be undone.',
+        );
+
+        if (!confirmed) {
+            return;
+        }
+
+        setProcessing(true);
+
+        router.delete(`/manage/contact-messages/${message.id}`, {
+            preserveScroll: true,
+            onSuccess: () => {
+                skipFlashToastRef.current = true;
+                showSuccess(
+                    fallbackLanguage === 'zh' ? '刪除成功' : 'Deleted',
+                    fallbackLanguage === 'zh' ? '已刪除此聯絡訊息。' : 'The contact message has been deleted.',
+                );
+                router.visit('/manage/contact-messages');
+            },
+            onError: (errors) => {
+                const errorMessages = Object.values(errors ?? {})
+                    .flat()
+                    .map((value) => String(value))
+                    .filter((value) => value.length > 0);
+
+                const fallbackMessage =
+                    fallbackLanguage === 'zh'
+                        ? '刪除失敗，請稍後再試。'
+                        : 'Failed to delete, please try again later.';
+
+                showBatchErrors(errorMessages.length > 0 ? errorMessages : [fallbackMessage]);
+            },
+            onFinish: () => setProcessing(false),
+        });
+    }, [processing, message.id, showSuccess, showBatchErrors, fallbackLanguage]);
+
+    const pageTitle = fallbackLanguage === 'zh' ? '聯絡訊息詳情' : 'Contact message detail';
+    const pageDescription =
+        fallbackLanguage === 'zh'
+            ? '查看訪客填寫的聯絡內容與處理紀錄，並可更新狀態或刪除訊息。'
+            : 'Review the submitted message, processing history, and update the status or delete the entry.';
+
+    return (
+        <ManageLayout role="admin" breadcrumbs={breadcrumbs}>
+            <Head title={pageTitle} />
+
+            <ToastContainer toasts={toasts} onDismiss={dismissToast} position="bottom-right" />
+
+            <section className="space-y-6">
+                <ManagePageHeader
+                    title={pageTitle}
+                    description={pageDescription}
+                    actions={
+                        <div className="flex flex-col gap-2 sm:flex-row">
+                            <Button asChild variant="outline" className="rounded-full px-6">
+                                <Link href="/manage/contact-messages">
+                                    {fallbackLanguage === 'zh' ? '返回列表' : 'Back to list'}
+                                </Link>
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="destructive"
+                                onClick={handleDelete}
+                                disabled={processing}
+                                className="rounded-full px-6"
+                            >
+                                {fallbackLanguage === 'zh' ? '刪除訊息' : 'Delete message'}
+                            </Button>
+                        </div>
+                    }
+                />
+
+                <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+                    <ContactDetailCard message={message} fallbackLanguage={fallbackLanguage} localeForDate={localeForDate} />
+
+                    <aside className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <div className="space-y-2">
+                            <h2 className="text-lg font-semibold text-slate-900">
+                                {fallbackLanguage === 'zh' ? '更新狀態' : 'Update status'}
+                            </h2>
+                            <p className="text-sm text-slate-600">
+                                {fallbackLanguage === 'zh'
+                                    ? '選擇新的處理狀態後按下更新，系統會紀錄負責人與時間。'
+                                    : 'Select a new status and update to log the processor and timestamp.'}
+                            </p>
+                        </div>
+
+                        <div className="space-y-3">
+                            <Select value={status} onChange={(event) => setStatus(event.target.value as ContactMessageStatus)}>
+                                {statusOptionsList.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </Select>
+                            <Button type="button" onClick={handleStatusSubmit} disabled={processing} className="w-full">
+                                {fallbackLanguage === 'zh' ? '儲存狀態' : 'Save status'}
+                            </Button>
+                        </div>
+                    </aside>
+                </div>
+            </section>
+        </ManageLayout>
+    );
+}


### PR DESCRIPTION
## Summary
- add dedicated contact management types, filter form, detail view card and responsive table components for reusable UI
- implement admin contact message index with filtering, pagination, toast feedback and action handling
- reuse the detail page for edit routes with status updates, deletion flow, and localized messaging support

## Testing
- npm run types

------
https://chatgpt.com/codex/tasks/task_e_68d5884151688323a556539a1fa16a3d