### PR TITLE
feat: add manage attachments page

### DIFF
--- a/resources/js/components/manage/attachment/attachment-filter-form.tsx
+++ b/resources/js/components/manage/attachment/attachment-filter-form.tsx
@@ -1,0 +1,225 @@
+import type { FormEvent } from 'react';
+import { Filter } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+
+import type {
+    AttachmentFilterState,
+    SortOption,
+    TranslatorFunction,
+} from './attachment-types';
+
+interface AttachmentFilterFormProps {
+    filterState: AttachmentFilterState;
+    typeOptions: string[];
+    visibilityOptions: string[];
+    attachedTypeOptions: string[];
+    perPageOptions: number[];
+    sortOptions: SortOption[];
+    hasActiveFilters: boolean;
+    onChange: (key: keyof AttachmentFilterState, value: string) => void;
+    onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+    onReset: () => void;
+    t: TranslatorFunction;
+    fallbackLanguage: 'zh' | 'en';
+}
+
+// 依據語系切換備援文案，避免翻譯缺漏時出現混雜語言。
+const fallbackText = (language: 'zh' | 'en', zh: string, en: string) => (language === 'zh' ? zh : en);
+
+export function AttachmentFilterForm({
+    filterState,
+    typeOptions,
+    visibilityOptions,
+    attachedTypeOptions,
+    perPageOptions,
+    sortOptions,
+    hasActiveFilters,
+    onChange,
+    onSubmit,
+    onReset,
+    t,
+    fallbackLanguage,
+}: AttachmentFilterFormProps) {
+    return (
+        <Card className="border border-slate-200 bg-white shadow-sm">
+            <CardHeader className="border-b border-slate-100 pb-4">
+                <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+                    <Filter className="h-5 w-5" />
+                    {t('attachments.index.filters_title', fallbackText(fallbackLanguage, '篩選條件', 'Filters'))}
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                {/* 將篩選欄位整理成表單，讓父層專注於狀態與資料請求。 */}
+                <form onSubmit={onSubmit} className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6">
+                    <div className="xl:col-span-2 space-y-1">
+                        <label className="text-sm font-medium text-slate-700" htmlFor="attachment-filter-search">
+                            {t('attachments.index.filters.search', fallbackText(fallbackLanguage, '搜尋附件', 'Search attachments'))}
+                        </label>
+                        <Input
+                            id="attachment-filter-search"
+                            value={filterState.search}
+                            onChange={(event) => onChange('search', event.target.value)}
+                            placeholder={t(
+                                'attachments.index.filters.search_placeholder',
+                                fallbackText(fallbackLanguage, '輸入標題、檔名或 MIME', 'Enter title, filename or MIME'),
+                            )}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-slate-700" htmlFor="attachment-filter-type">
+                            {t('attachments.index.filters.type', fallbackText(fallbackLanguage, '附件類型', 'Attachment type'))}
+                        </label>
+                        <Select
+                            id="attachment-filter-type"
+                            value={filterState.type}
+                            onChange={(event) => onChange('type', event.target.value)}
+                        >
+                            <option value="">
+                                {t('attachments.index.filters.all_types', fallbackText(fallbackLanguage, '全部類型', 'All types'))}
+                            </option>
+                            {typeOptions.map((option) => (
+                                <option key={option} value={option}>
+                                    {t(`attachments.type.${option}`, option)}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-slate-700" htmlFor="attachment-filter-visibility">
+                            {t('attachments.index.filters.visibility', fallbackText(fallbackLanguage, '公開狀態', 'Visibility'))}
+                        </label>
+                        <Select
+                            id="attachment-filter-visibility"
+                            value={filterState.visibility}
+                            onChange={(event) => onChange('visibility', event.target.value)}
+                        >
+                            <option value="">
+                                {t(
+                                    'attachments.index.filters.active_only',
+                                    fallbackText(fallbackLanguage, '僅顯示現存', 'Active only'),
+                                )}
+                            </option>
+                            {visibilityOptions.map((option) => (
+                                <option key={option} value={option}>
+                                    {t(`attachments.visibility.${option}`, fallbackText(fallbackLanguage, option, option))}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-slate-700" htmlFor="attachment-filter-attached-type">
+                            {t('attachments.index.filters.attachable', fallbackText(fallbackLanguage, '來源資料', 'Source type'))}
+                        </label>
+                        <Select
+                            id="attachment-filter-attached-type"
+                            value={filterState.attached_to_type}
+                            onChange={(event) => onChange('attached_to_type', event.target.value)}
+                        >
+                            <option value="">
+                                {t('attachments.index.filters.all_sources', fallbackText(fallbackLanguage, '全部來源', 'All sources'))}
+                            </option>
+                            {attachedTypeOptions.map((option) => (
+                                <option key={option} value={option}>
+                                    {option.split('\\').pop() ?? option}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-slate-700" htmlFor="attachment-filter-attached-id">
+                            {t('attachments.index.filters.source_id', fallbackText(fallbackLanguage, '來源 ID', 'Source ID'))}
+                        </label>
+                        <Input
+                            id="attachment-filter-attached-id"
+                            value={filterState.attached_to_id}
+                            inputMode="numeric"
+                            onChange={(event) => onChange('attached_to_id', event.target.value)}
+                            placeholder={t(
+                                'attachments.index.filters.source_id_placeholder',
+                                fallbackText(fallbackLanguage, '輸入來源資料 ID', 'Enter source ID'),
+                            )}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-slate-700" htmlFor="attachment-filter-trashed">
+                            {t('attachments.index.filters.trashed', fallbackText(fallbackLanguage, '刪除範圍', 'Trashed scope'))}
+                        </label>
+                        <Select
+                            id="attachment-filter-trashed"
+                            value={filterState.trashed}
+                            onChange={(event) => onChange('trashed', event.target.value)}
+                        >
+                            <option value="">
+                                {t('attachments.index.filters.active_only', fallbackText(fallbackLanguage, '僅顯示現存', 'Active only'))}
+                            </option>
+                            <option value="with">
+                                {t('attachments.index.filters.include_deleted', fallbackText(fallbackLanguage, '含已刪除', 'Include deleted'))}
+                            </option>
+                            <option value="only">
+                                {t('attachments.index.filters.deleted_only', fallbackText(fallbackLanguage, '僅已刪除', 'Deleted only'))}
+                            </option>
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-slate-700" htmlFor="attachment-filter-sort">
+                            {t('attachments.index.filters.sort', fallbackText(fallbackLanguage, '排序方式', 'Sort by'))}
+                        </label>
+                        <Select
+                            id="attachment-filter-sort"
+                            value={filterState.sort}
+                            onChange={(event) => onChange('sort', event.target.value)}
+                        >
+                            {sortOptions.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <label className="text-sm font-medium text-slate-700" htmlFor="attachment-filter-per-page">
+                            {t('attachments.index.filters.per_page', fallbackText(fallbackLanguage, '每頁數量', 'Per page'))}
+                        </label>
+                        <Select
+                            id="attachment-filter-per-page"
+                            value={filterState.per_page}
+                            onChange={(event) => onChange('per_page', event.target.value)}
+                        >
+                            {perPageOptions.map((option) => (
+                                <option key={option} value={option}>
+                                    {option}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="flex items-end gap-2">
+                        <Button type="submit" className="w-full rounded-full">
+                            {t('attachments.index.filters.apply', fallbackText(fallbackLanguage, '套用', 'Apply'))}
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            className="w-full rounded-full"
+                            disabled={!hasActiveFilters}
+                            onClick={onReset}
+                        >
+                            {t('attachments.index.filters.reset', fallbackText(fallbackLanguage, '重設', 'Reset'))}
+                        </Button>
+                    </div>
+                </form>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/manage/attachment/attachment-table.tsx
+++ b/resources/js/components/manage/attachment/attachment-table.tsx
@@ -1,0 +1,603 @@
+import {
+    Badge,
+} from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Download, ExternalLink, RotateCcw, Trash2, XCircle, FileText, Paperclip, User2, HardDrive, CalendarClock, ChevronLeft, ChevronRight } from 'lucide-react';
+import type {
+    AttachmentItem,
+    PaginationLink,
+    PaginationMeta,
+    TranslatorFunction,
+} from './attachment-types';
+
+interface AttachmentTableProps {
+    attachments: AttachmentItem[];
+    selectedIds: number[];
+    onToggleSelectAll: (checked: boolean) => void;
+    onToggleSelection: (attachmentId: number) => void;
+    onDelete: (attachment: AttachmentItem) => void;
+    onRestore: (attachment: AttachmentItem) => void;
+    onForceDelete: (attachment: AttachmentItem) => void;
+    onBulkAction: (action: 'delete' | 'force') => void;
+    bulkProcessing: boolean;
+    pagination: PaginationMeta;
+    paginationLinks: PaginationLink[];
+    changePage: (page: number) => void;
+    iconActionClass: string;
+    t: TranslatorFunction;
+    fallbackLanguage: 'zh' | 'en';
+    localeForDate: 'zh-TW' | 'en';
+}
+
+const typeLabels: Record<string, { zh: string; en: string }> = {
+    image: { zh: '圖片', en: 'Image' },
+    document: { zh: '文件', en: 'Document' },
+    link: { zh: '連結', en: 'Link' },
+};
+
+const visibilityLabels: Record<string, { zh: string; en: string }> = {
+    public: { zh: '公開', en: 'Public' },
+    private: { zh: '私人', en: 'Private' },
+};
+
+// 將檔案大小轉換為易讀格式，提升列表可讀性。
+const formatBytes = (bytes: number | null): string => {
+    if (!bytes || bytes <= 0) {
+        return '0 B';
+    }
+
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let size = bytes;
+    let unitIndex = 0;
+
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex += 1;
+    }
+
+    return `${size.toFixed(size >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+};
+
+// 格式化時間字串，容錯處理異常值。
+const formatDateTime = (value: string | null, locale: 'zh-TW' | 'en'): string | null => {
+    if (!value) {
+        return null;
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    const localeCode = locale === 'zh-TW' ? 'zh-TW' : 'en-US';
+    return date.toLocaleString(localeCode, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    });
+};
+
+const fallbackText = (language: 'zh' | 'en', zh: string, en: string) => (language === 'zh' ? zh : en);
+
+// 將完整類別名稱轉為精簡標籤，例如 App\\Models\\Post -> Post。
+const resolveAttachedTypeLabel = (type: string | null | undefined) => {
+    if (!type) {
+        return null;
+    }
+    return type.split('\\').pop() ?? type;
+};
+
+const buildSourceLabel = (
+    attachment: AttachmentItem,
+    t: TranslatorFunction,
+    fallbackLanguage: 'zh' | 'en',
+): string => {
+    const typeLabel = resolveAttachedTypeLabel(attachment.attached_to_type);
+
+    if (!typeLabel) {
+        return t(
+            'attachments.index.status.unassigned',
+            fallbackText(fallbackLanguage, '未關聯', 'Unassigned'),
+        );
+    }
+
+    if (attachment.attached_to_id !== null) {
+        return t(
+            'attachments.index.status.generic_with_identifier',
+            fallbackText(fallbackLanguage, `${typeLabel} · ${attachment.attached_to_id}`, `${typeLabel} · ${attachment.attached_to_id}`),
+            {
+                type: typeLabel,
+                identifier: attachment.attached_to_id,
+            },
+        );
+    }
+
+    return t(
+        'attachments.index.status.generic_without_identifier',
+        fallbackText(fallbackLanguage, `${typeLabel} #:id`, `${typeLabel} #:id`),
+        {
+            type: typeLabel,
+            id: attachment.id,
+        },
+    );
+};
+
+const buildAttachmentTitle = (
+    attachment: AttachmentItem,
+    t: TranslatorFunction,
+    fallbackLanguage: 'zh' | 'en',
+): string => {
+    if (attachment.title && attachment.title.trim() !== '') {
+        return attachment.title;
+    }
+
+    if (attachment.filename && attachment.filename.trim() !== '') {
+        return attachment.filename;
+    }
+
+    return t(
+        'attachments.index.table.meta.type',
+        fallbackText(fallbackLanguage, '附件', 'Attachment'),
+    );
+};
+
+export function AttachmentTable({
+    attachments,
+    selectedIds,
+    onToggleSelectAll,
+    onToggleSelection,
+    onDelete,
+    onRestore,
+    onForceDelete,
+    onBulkAction,
+    bulkProcessing,
+    pagination,
+    paginationLinks,
+    changePage,
+    iconActionClass,
+    t,
+    fallbackLanguage,
+    localeForDate,
+}: AttachmentTableProps) {
+    const selectedCount = selectedIds.length;
+    const allSelected = attachments.length > 0 && selectedCount === attachments.length;
+    const fallback = (zh: string, en: string) => fallbackText(fallbackLanguage, zh, en);
+
+    return (
+        <Card className="border border-slate-200 bg-white shadow-sm">
+            <CardHeader className="flex flex-col gap-4 border-b border-slate-100 pb-4 xl:flex-row xl:items-center xl:justify-between">
+                <div>
+                    <CardTitle className="text-lg font-semibold text-slate-900">
+                        {t('attachments.index.table.title', fallback('附件列表', 'Attachments'))}
+                    </CardTitle>
+                    <p className="text-sm text-slate-600">
+                        {t('attachments.index.table.records_total', fallback('共 :total 筆資料', 'Total :total records'), {
+                            total: pagination.total,
+                        })}
+                    </p>
+                </div>
+
+                {attachments.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-2">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            disabled={selectedCount === 0 || bulkProcessing}
+                            onClick={() => onBulkAction('delete')}
+                        >
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            {t('attachments.index.actions.delete', fallback('刪除附件', 'Move to recycle bin'))}
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            disabled={selectedCount === 0 || bulkProcessing}
+                            onClick={() => onBulkAction('force')}
+                        >
+                            <XCircle className="mr-2 h-4 w-4" />
+                            {t('attachments.index.actions.force_delete', fallback('永久刪除', 'Permanently delete'))}
+                        </Button>
+                    </div>
+                )}
+            </CardHeader>
+
+            <CardContent className="space-y-6">
+                <div className="hidden xl:block">
+                    <table className="min-w-full divide-y divide-slate-200 text-sm">
+                        <thead className="bg-slate-50 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                            <tr>
+                                <th className="px-4 py-3">
+                                    <Checkbox
+                                        checked={allSelected}
+                                        onCheckedChange={(value) => onToggleSelectAll(Boolean(value))}
+                                        aria-label={t('attachments.index.table.select_all', fallback('選取全部', 'Select all'))}
+                                    />
+                                </th>
+                                <th className="px-4 py-3 w-[28%]">
+                                    {t('attachments.index.table.columns.attachment', fallback('附件資訊', 'Attachment'))}
+                                </th>
+                                <th className="px-4 py-3">
+                                    {t('attachments.index.table.columns.source', fallback('來源', 'Source'))}
+                                </th>
+                                <th className="px-4 py-3">
+                                    {t('attachments.index.table.columns.size', fallback('大小', 'Size'))}
+                                </th>
+                                <th className="px-4 py-3">
+                                    {t('attachments.index.table.columns.updated_at', fallback('更新時間', 'Updated at'))}
+                                </th>
+                                <th className="px-4 py-3 text-right">
+                                    {t('attachments.index.table.columns.actions', fallback('操作', 'Actions'))}
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-100 bg-white text-slate-700">
+                            {attachments.length === 0 ? (
+                                <tr>
+                                    <td colSpan={6} className="px-4 py-6 text-center text-sm text-slate-500">
+                                        {t('attachments.index.table.empty', fallback('目前尚無符合條件的附件。', 'No attachments match the filters.'))}
+                                    </td>
+                                </tr>
+                            ) : (
+                                attachments.map((attachment) => {
+                                    const isSelected = selectedIds.includes(attachment.id);
+                                    const typeLabel = typeLabels[attachment.type]?.[fallbackLanguage] ?? attachment.type;
+                                    const visibilityLabel = attachment.visibility
+                                        ? visibilityLabels[attachment.visibility]?.[fallbackLanguage] ?? attachment.visibility
+                                        : fallback('未設定', 'Not set');
+                                    const sourceLabel = buildSourceLabel(attachment, t, fallbackLanguage);
+                                    const updatedLabel = formatDateTime(attachment.updated_at ?? attachment.created_at, localeForDate);
+                                    const isTrashed = Boolean(attachment.deleted_at);
+                                    const title = buildAttachmentTitle(attachment, t, fallbackLanguage);
+                                    const downloadUrl = attachment.download_url ?? attachment.file_url;
+                                    const externalUrl = attachment.external_url;
+
+                                    return (
+                                        <tr key={attachment.id} className={isSelected ? 'bg-slate-50/60' : undefined}>
+                                            <td className="px-4 py-3">
+                                                <Checkbox
+                                                    checked={isSelected}
+                                                    onCheckedChange={() => onToggleSelection(attachment.id)}
+                                                    aria-label={t('attachments.index.table.select_row', fallback('選取附件', 'Select attachment'))}
+                                                />
+                                            </td>
+                                            <td className="px-4 py-3">
+                                                <div className="flex flex-col gap-2">
+                                                    <div className="flex items-center gap-2">
+                                                        <Paperclip className="h-4 w-4 text-slate-400" />
+                                                        <span className="font-semibold text-slate-900 break-words">{title}</span>
+                                                    </div>
+                                                    <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                                                        <Badge variant="outline" className="border-slate-200 text-slate-600">
+                                                            {typeLabel}
+                                                        </Badge>
+                                                        {attachment.mime_type && (
+                                                            <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500">
+                                                                {attachment.mime_type}
+                                                            </span>
+                                                        )}
+                                                        {attachment.visibility && (
+                                                            <Badge variant="secondary">{visibilityLabel}</Badge>
+                                                        )}
+                                                        {isTrashed && (
+                                                            <Badge variant="destructive" className="bg-rose-50 text-rose-600">
+                                                                {t('attachments.index.badges.trashed', fallback('已刪除', 'Trashed'))}
+                                                            </Badge>
+                                                        )}
+                                                    </div>
+                                                    {attachment.filename && (
+                                                        <p className="text-xs text-slate-500 break-all">
+                                                            {attachment.filename}
+                                                        </p>
+                                                    )}
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-3">
+                                                <div className="flex flex-col gap-1 text-sm text-slate-600">
+                                                    <div className="flex items-center gap-2">
+                                                        <FileText className="h-4 w-4" />
+                                                        <span className="break-words">{sourceLabel}</span>
+                                                    </div>
+                                                    <div className="flex items-center gap-2 text-xs text-slate-500">
+                                                        <User2 className="h-3.5 w-3.5" />
+                                                        <span>
+                                                            {attachment.uploader?.name ?? t('attachments.index.table.uploader_unknown', fallback('未知上傳者', 'Unknown uploader'))}
+                                                        </span>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-3 text-slate-600">
+                                                <div className="flex items-center gap-2">
+                                                    <HardDrive className="h-4 w-4" />
+                                                    <span>{formatBytes(attachment.size)}</span>
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-3 text-slate-600">
+                                                <div className="flex items-center gap-2">
+                                                    <CalendarClock className="h-4 w-4" />
+                                                    <span>{
+                                                        updatedLabel ?? t('attachments.index.table.not_available', fallback('無資料', 'N/A'))
+                                                    }</span>
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-3">
+                                                <div className="flex items-center justify-end gap-2">
+                                                    {externalUrl && (
+                                                        <Tooltip>
+                                                            <TooltipTrigger asChild>
+                                                                <a
+                                                                    href={externalUrl}
+                                                                    target="_blank"
+                                                                    rel="noopener noreferrer"
+                                                                    className={iconActionClass}
+                                                                    aria-label={t('attachments.index.actions.visit_external', fallback('開啟外部連結', 'Open external link'))}
+                                                                >
+                                                                    <ExternalLink className="h-4 w-4" />
+                                                                </a>
+                                                            </TooltipTrigger>
+                                                            <TooltipContent>
+                                                                {t('attachments.index.actions.visit_external', fallback('開啟外部連結', 'Open external link'))}
+                                                            </TooltipContent>
+                                                        </Tooltip>
+                                                    )}
+                                                    {downloadUrl && (
+                                                        <Tooltip>
+                                                            <TooltipTrigger asChild>
+                                                                <a
+                                                                    href={downloadUrl}
+                                                                    className={iconActionClass}
+                                                                    aria-label={t('attachments.index.actions.download', fallback('下載附件', 'Download attachment'))}
+                                                                >
+                                                                    <Download className="h-4 w-4" />
+                                                                </a>
+                                                            </TooltipTrigger>
+                                                            <TooltipContent>
+                                                                {t('attachments.index.actions.download', fallback('下載附件', 'Download attachment'))}
+                                                            </TooltipContent>
+                                                        </Tooltip>
+                                                    )}
+                                                    <Tooltip>
+                                                        <TooltipTrigger asChild>
+                                                            <button
+                                                                type="button"
+                                                                className={iconActionClass}
+                                                                onClick={() => onRestore(attachment)}
+                                                                disabled={!isTrashed}
+                                                                aria-label={t('attachments.index.actions.restore', fallback('還原附件', 'Restore attachment'))}
+                                                            >
+                                                                <RotateCcw className="h-4 w-4" />
+                                                            </button>
+                                                        </TooltipTrigger>
+                                                        <TooltipContent>
+                                                            {t('attachments.index.actions.restore', fallback('還原附件', 'Restore attachment'))}
+                                                        </TooltipContent>
+                                                    </Tooltip>
+                                                    <Tooltip>
+                                                        <TooltipTrigger asChild>
+                                                            <button
+                                                                type="button"
+                                                                className={iconActionClass}
+                                                                onClick={() => onDelete(attachment)}
+                                                                disabled={isTrashed}
+                                                                aria-label={t('attachments.index.actions.delete', fallback('刪除附件', 'Move to recycle bin'))}
+                                                            >
+                                                                <Trash2 className="h-4 w-4" />
+                                                            </button>
+                                                        </TooltipTrigger>
+                                                        <TooltipContent>
+                                                            {t('attachments.index.actions.delete', fallback('刪除附件', 'Move to recycle bin'))}
+                                                        </TooltipContent>
+                                                    </Tooltip>
+                                                    <Tooltip>
+                                                        <TooltipTrigger asChild>
+                                                            <button
+                                                                type="button"
+                                                                className={iconActionClass}
+                                                                onClick={() => onForceDelete(attachment)}
+                                                                aria-label={t('attachments.index.actions.force_delete', fallback('永久刪除', 'Permanently delete'))}
+                                                            >
+                                                                <XCircle className="h-4 w-4" />
+                                                            </button>
+                                                        </TooltipTrigger>
+                                                        <TooltipContent>
+                                                            {t('attachments.index.actions.force_delete', fallback('永久刪除', 'Permanently delete'))}
+                                                        </TooltipContent>
+                                                    </Tooltip>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    );
+                                })
+                            )}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div className="grid gap-3 xl:hidden">
+                    {attachments.length === 0 ? (
+                        <div className="rounded-2xl border border-slate-200 bg-white p-6 text-center text-sm text-slate-500">
+                            {t('attachments.index.table.empty', fallback('目前尚無符合條件的附件。', 'No attachments match the filters.'))}
+                        </div>
+                    ) : (
+                        attachments.map((attachment) => {
+                            const isSelected = selectedIds.includes(attachment.id);
+                            const typeLabel = typeLabels[attachment.type]?.[fallbackLanguage] ?? attachment.type;
+                            const visibilityLabel = attachment.visibility
+                                ? visibilityLabels[attachment.visibility]?.[fallbackLanguage] ?? attachment.visibility
+                                : fallback('未設定', 'Not set');
+                            const sourceLabel = buildSourceLabel(attachment, t, fallbackLanguage);
+                            const updatedLabel = formatDateTime(attachment.updated_at ?? attachment.created_at, localeForDate);
+                            const isTrashed = Boolean(attachment.deleted_at);
+                            const title = buildAttachmentTitle(attachment, t, fallbackLanguage);
+                            const downloadUrl = attachment.download_url ?? attachment.file_url;
+                            const externalUrl = attachment.external_url;
+
+                            return (
+                                <div key={`mobile-attachment-${attachment.id}`} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                                    <div className="flex flex-col gap-3">
+                                        <div className="flex flex-col gap-2">
+                                            <div className="flex items-start justify-between gap-3">
+                                                <div className="flex items-center gap-2 text-slate-900">
+                                                    <Paperclip className="h-4 w-4 text-slate-400" />
+                                                    <span className="text-base font-semibold break-words">{title}</span>
+                                                </div>
+                                                {attachment.visibility && (
+                                                    <Badge variant="secondary">{visibilityLabel}</Badge>
+                                                )}
+                                            </div>
+                                            <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                                                <Badge variant="outline" className="border-slate-200 text-slate-600">
+                                                    {typeLabel}
+                                                </Badge>
+                                                {attachment.mime_type && (
+                                                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500">
+                                                        {attachment.mime_type}
+                                                    </span>
+                                                )}
+                                                {isTrashed && (
+                                                    <Badge variant="destructive" className="bg-rose-50 text-rose-600">
+                                                        {t('attachments.index.badges.trashed', fallback('已刪除', 'Trashed'))}
+                                                    </Badge>
+                                                )}
+                                            </div>
+                                        </div>
+
+                                        <div className="grid gap-3 text-sm text-slate-600">
+                                            <div className="flex items-center gap-2">
+                                                <FileText className="h-4 w-4" />
+                                                <span className="break-words">{sourceLabel}</span>
+                                            </div>
+                                            <div className="flex items-center gap-2 text-xs text-slate-500">
+                                                <User2 className="h-3.5 w-3.5" />
+                                                <span>
+                                                    {attachment.uploader?.name ?? t('attachments.index.table.uploader_unknown', fallback('未知上傳者', 'Unknown uploader'))}
+                                                </span>
+                                            </div>
+                                            <div className="flex items-center gap-2">
+                                                <HardDrive className="h-4 w-4" />
+                                                <span>{formatBytes(attachment.size)}</span>
+                                            </div>
+                                            <div className="flex items-center gap-2">
+                                                <CalendarClock className="h-4 w-4" />
+                                                <span>{updatedLabel ?? t('attachments.index.table.not_available', fallback('無資料', 'N/A'))}</span>
+                                            </div>
+                                        </div>
+
+                                        <div className="flex flex-wrap items-center justify-between gap-3">
+                                            <div className="flex items-center gap-2">
+                                                <Checkbox
+                                                    checked={isSelected}
+                                                    onCheckedChange={() => onToggleSelection(attachment.id)}
+                                                    aria-label={t('attachments.index.table.select_row', fallback('選取附件', 'Select attachment'))}
+                                                />
+                                                <span className="text-xs text-slate-600">
+                                                    {isSelected
+                                                        ? t('attachments.index.mobile.selected', fallback('已選取', 'Selected'))
+                                                        : t('attachments.index.mobile.select', fallback('選取', 'Select'))}
+                                                </span>
+                                            </div>
+                                            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:justify-end">
+                                                {externalUrl && (
+                                                    <Button asChild variant="outline" size="sm" className="w-full sm:w-auto">
+                                                        <a
+                                                            href={externalUrl}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                        >
+                                                            <ExternalLink className="mr-1 h-4 w-4" />
+                                                            {t('attachments.index.actions.visit_external', fallback('開啟外部連結', 'Open external link'))}
+                                                        </a>
+                                                    </Button>
+                                                )}
+                                                {downloadUrl && (
+                                                    <Button asChild variant="outline" size="sm" className="w-full sm:w-auto">
+                                                        <a href={downloadUrl}>
+                                                            <Download className="mr-1 h-4 w-4" />
+                                                            {t('attachments.index.actions.download', fallback('下載附件', 'Download attachment'))}
+                                                        </a>
+                                                    </Button>
+                                                )}
+                                                <Button
+                                                    type="button"
+                                                    variant="outline"
+                                                    size="sm"
+                                                    className="w-full sm:w-auto"
+                                                    onClick={() => onRestore(attachment)}
+                                                    disabled={!isTrashed}
+                                                >
+                                                    <RotateCcw className="mr-1 h-4 w-4" />
+                                                    {t('attachments.index.actions.restore', fallback('還原附件', 'Restore attachment'))}
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    variant="outline"
+                                                    size="sm"
+                                                    className="w-full sm:w-auto"
+                                                    onClick={() => onDelete(attachment)}
+                                                    disabled={isTrashed}
+                                                >
+                                                    <Trash2 className="mr-1 h-4 w-4" />
+                                                    {t('attachments.index.actions.delete', fallback('刪除附件', 'Move to recycle bin'))}
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    variant="destructive"
+                                                    size="sm"
+                                                    className="w-full sm:w-auto"
+                                                    onClick={() => onForceDelete(attachment)}
+                                                >
+                                                    <XCircle className="mr-1 h-4 w-4" />
+                                                    {t('attachments.index.actions.force_delete', fallback('永久刪除', 'Permanently delete'))}
+                                                </Button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        })
+                    )}
+                </div>
+
+                {paginationLinks.length > 0 && (
+                    <div className="flex flex-col gap-4 border-t border-slate-100 pt-4 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+                        <p>
+                            {t('attachments.index.pagination.summary', fallback('第 :current / :last 頁', 'Page :current of :last'), {
+                                current: pagination.current_page,
+                                last: pagination.last_page,
+                            })}
+                            ，
+                            {t('attachments.index.table.records_total', fallback('共 :total 筆資料', 'Total :total records'), {
+                                total: pagination.total,
+                            })}
+                        </p>
+                        <div className="flex items-center gap-2">
+                            <Button
+                                type="button"
+                                size="icon"
+                                variant="outline"
+                                className="h-9 w-9"
+                                onClick={() => changePage(pagination.current_page - 1)}
+                                disabled={pagination.current_page <= 1}
+                                aria-label={t('attachments.index.pagination.previous', fallback('上一頁', 'Previous page'))}
+                            >
+                                <ChevronLeft className="h-4 w-4" />
+                            </Button>
+                            <Button
+                                type="button"
+                                size="icon"
+                                variant="outline"
+                                className="h-9 w-9"
+                                onClick={() => changePage(pagination.current_page + 1)}
+                                disabled={pagination.current_page >= pagination.last_page}
+                                aria-label={t('attachments.index.pagination.next', fallback('下一頁', 'Next page'))}
+                            >
+                                <ChevronRight className="h-4 w-4" />
+                            </Button>
+                        </div>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/manage/attachment/attachment-types.ts
+++ b/resources/js/components/manage/attachment/attachment-types.ts
@@ -1,0 +1,66 @@
+// 附件管理頁面共用的型別定義，統一管理以方便日後維護。
+export type AttachmentType = 'image' | 'document' | 'link';
+export type AttachmentVisibility = 'public' | 'private';
+
+export interface AttachmentItem {
+    id: number;
+    type: AttachmentType;
+    title: string | null;
+    filename: string | null;
+    file_url: string | null;
+    external_url: string | null;
+    download_url: string | null;
+    mime_type: string | null;
+    size: number | null;
+    visibility: AttachmentVisibility | null;
+    attached_to_type: string | null;
+    attached_to_id: number | null;
+    uploaded_by: number | null;
+    uploader: { id: number; name: string; email: string } | null;
+    created_at: string | null;
+    updated_at: string | null;
+    deleted_at: string | null;
+}
+
+export interface PaginationLink {
+    url: string | null;
+    label: string;
+    active: boolean;
+}
+
+export interface PaginationMeta {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number | null;
+    to: number | null;
+}
+
+export type AttachmentFilterState = {
+    search: string;
+    type: string;
+    attached_to_type: string;
+    attached_to_id: string;
+    visibility: string;
+    trashed: string;
+    per_page: string;
+    sort: string;
+};
+
+export interface AttachmentFlashMessages {
+    success?: string;
+    error?: string;
+    info?: string;
+}
+
+export type TranslatorFunction = (
+    key: string,
+    fallbackText?: string,
+    replacements?: Record<string, string | number>,
+) => string;
+
+export interface SortOption {
+    value: string;
+    label: string;
+}

--- a/resources/js/pages/manage/attachments/index.tsx
+++ b/resources/js/pages/manage/attachments/index.tsx
@@ -1,0 +1,547 @@
+import { Head, router, useForm, usePage } from '@inertiajs/react';
+import type { FormEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Paperclip } from 'lucide-react';
+
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import ToastContainer from '@/components/ui/toast-container';
+import { Button } from '@/components/ui/button';
+
+import { AttachmentFilterForm } from '@/components/manage/attachment/attachment-filter-form';
+import { AttachmentTable } from '@/components/manage/attachment/attachment-table';
+import type {
+    AttachmentFilterState,
+    AttachmentFlashMessages,
+    AttachmentItem,
+    PaginationLink,
+    PaginationMeta,
+    SortOption,
+} from '@/components/manage/attachment/attachment-types';
+import type { BreadcrumbItem, SharedData } from '@/types';
+import { useToast } from '@/hooks/use-toast';
+import { useTranslator } from '@/hooks/use-translator';
+
+interface AttachmentIndexProps {
+    attachments: {
+        data: AttachmentItem[];
+        links: PaginationLink[];
+        meta: PaginationMeta;
+    };
+    filters: Partial<AttachmentFilterState>;
+    typeOptions: string[];
+    visibilityOptions: string[];
+    attachedTypeOptions: string[];
+    perPageOptions: number[];
+    sortOptions: SortOption[];
+}
+
+// 建立初始篩選狀態，確保重新整理時狀態保持一致。
+const createInitialFilterState = (
+    filters: Partial<AttachmentFilterState>,
+    defaultPerPage: number,
+    defaultSort: string,
+): AttachmentFilterState => ({
+    search: filters.search ?? '',
+    type: filters.type ?? '',
+    attached_to_type: filters.attached_to_type ?? '',
+    attached_to_id: filters.attached_to_id ?? '',
+    visibility: filters.visibility ?? '',
+    trashed: filters.trashed ?? '',
+    per_page: filters.per_page ?? String(defaultPerPage),
+    sort: filters.sort ?? defaultSort,
+});
+
+export default function AttachmentIndex({
+    attachments,
+    filters,
+    typeOptions,
+    visibilityOptions,
+    attachedTypeOptions,
+    perPageOptions,
+    sortOptions,
+}: AttachmentIndexProps) {
+    const page = usePage<SharedData & { flash?: AttachmentFlashMessages }>();
+    const flashMessages: AttachmentFlashMessages = page.props.flash ?? {};
+    const locale = page.props.locale ?? 'zh-TW';
+
+    const { t } = useTranslator('manage');
+    // 支援 zh_TW、zh-TW 等變體，確保語系判斷穩定。
+    const normalizedLocale = locale.toLowerCase().replace('_', '-');
+    const isTraditionalChinese = normalizedLocale.startsWith('zh');
+    const fallbackLanguage: 'zh' | 'en' = isTraditionalChinese ? 'zh' : 'en';
+    const localeForDate: 'zh-TW' | 'en' = isTraditionalChinese ? 'zh-TW' : 'en';
+
+    const defaultPerPage = perPageOptions[0] ?? 15;
+    const defaultSort = sortOptions[0]?.value ?? '-created_at';
+
+    const attachmentData = attachments?.data ?? [];
+    const paginationMeta = attachments?.meta ?? {
+        current_page: 1,
+        last_page: 1,
+        per_page: defaultPerPage,
+        total: attachmentData.length,
+        from: attachmentData.length > 0 ? 1 : 0,
+        to: attachmentData.length,
+    };
+
+    const pagination: PaginationMeta = {
+        current_page: paginationMeta.current_page,
+        last_page: paginationMeta.last_page,
+        per_page: paginationMeta.per_page,
+        total: paginationMeta.total,
+        from: paginationMeta.from,
+        to: paginationMeta.to,
+    };
+
+    const paginationLinks = attachments?.links ?? [];
+
+    const { toasts, showSuccess, showError, showInfo, showBatchErrors, dismissToast } = useToast();
+
+    const [filterState, setFilterState] = useState<AttachmentFilterState>(
+        createInitialFilterState(filters, defaultPerPage, defaultSort),
+    );
+    const [selected, setSelected] = useState<number[]>([]);
+
+    // 避免成功操作後重複顯示 flash 訊息的旗標。
+    const skipFlashToastRef = useRef(false);
+    const previousFlashRef = useRef<AttachmentFlashMessages>({});
+
+    const iconActionClass = useMemo(
+        () =>
+            'inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500/60',
+        [],
+    );
+
+    const breadcrumbs: BreadcrumbItem[] = useMemo(
+        () => [
+            { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+            {
+                title: t(
+                    'attachments.index.title',
+                    fallbackLanguage === 'zh' ? '附件管理' : 'Attachment manager',
+                ),
+                href: '/manage/attachments',
+            },
+        ],
+        [t, fallbackLanguage],
+    );
+
+    const hasActiveFilters = useMemo(
+        () =>
+            filterState.search !== '' ||
+            filterState.type !== '' ||
+            filterState.attached_to_type !== '' ||
+            filterState.attached_to_id !== '' ||
+            filterState.visibility !== '' ||
+            filterState.trashed !== '',
+        [filterState],
+    );
+
+    const handleFilterChange = useCallback((key: keyof AttachmentFilterState, value: string) => {
+        setFilterState((previous) => ({ ...previous, [key]: value }));
+    }, []);
+
+    const applyFilters = useCallback(
+        (event?: FormEvent<HTMLFormElement>) => {
+            event?.preventDefault();
+
+            const params = Object.fromEntries(
+                Object.entries(filterState).filter(([key, value]) => {
+                    if (key === 'per_page' || key === 'sort') {
+                        return true;
+                    }
+
+                    return value !== '';
+                }),
+            );
+
+            router.get('/manage/attachments', params, {
+                preserveState: true,
+                preserveScroll: true,
+            });
+        },
+        [filterState],
+    );
+
+    const resetFilters = useCallback(() => {
+        const initialState = createInitialFilterState({}, defaultPerPage, defaultSort);
+        setFilterState(initialState);
+        router.get(
+            '/manage/attachments',
+            { per_page: defaultPerPage, sort: defaultSort },
+            {
+                preserveState: true,
+                preserveScroll: true,
+            },
+        );
+    }, [defaultPerPage, defaultSort]);
+
+    const changePage = useCallback(
+        (pageNumber: number) => {
+            if (pageNumber <= 0 || pageNumber > pagination.last_page || pageNumber === pagination.current_page) {
+                return;
+            }
+
+            const params = Object.fromEntries(
+                Object.entries(filterState).filter(([key, value]) => {
+                    if (key === 'per_page' || key === 'sort') {
+                        return true;
+                    }
+
+                    return value !== '';
+                }),
+            );
+
+            params.page = pageNumber.toString();
+
+            router.get('/manage/attachments', params, {
+                preserveState: true,
+                preserveScroll: true,
+            });
+        },
+        [filterState, pagination],
+    );
+
+    const handleToggleSelectAll = useCallback(
+        (checked: boolean) => {
+            setSelected(checked ? attachmentData.map((attachment) => attachment.id) : []);
+        },
+        [attachmentData],
+    );
+
+    const handleToggleSelection = useCallback((attachmentId: number) => {
+        setSelected((previous) =>
+            previous.includes(attachmentId)
+                ? previous.filter((id) => id !== attachmentId)
+                : [...previous, attachmentId],
+        );
+    }, []);
+
+    const bulkForm = useForm<{ action: 'delete' | 'force'; ids: number[] }>({
+        action: 'delete',
+        ids: [],
+    });
+
+    const performBulkAction = useCallback(
+        (action: 'delete' | 'force') => {
+            if (selected.length === 0 || bulkForm.processing) {
+                return;
+            }
+
+            if (action === 'delete') {
+                const confirmed = window.confirm(
+                    fallbackLanguage === 'zh'
+                        ? `確定要刪除選取的 ${selected.length} 筆附件嗎？附件將移至回收桶。`
+                        : `Are you sure you want to delete the selected ${selected.length} attachment(s)? They will be moved to recycle bin.`,
+                );
+
+                if (!confirmed) {
+                    return;
+                }
+            }
+
+            if (action === 'force') {
+                const confirmed = window.confirm(
+                    fallbackLanguage === 'zh'
+                        ? `確定要永久刪除選取的 ${selected.length} 筆附件嗎？此操作無法復原。`
+                        : `Permanently delete the selected ${selected.length} attachment(s)? This action cannot be undone.`,
+                );
+
+                if (!confirmed) {
+                    return;
+                }
+            }
+
+            bulkForm.transform(() => ({
+                action,
+                ids: selected,
+            }));
+
+            bulkForm.post('/manage/attachments/bulk', {
+                preserveScroll: true,
+                onSuccess: (pageResponse) => {
+                    setSelected([]);
+                    bulkForm.reset();
+                    skipFlashToastRef.current = true;
+
+                    const successMessage =
+                        (pageResponse?.props?.flash as AttachmentFlashMessages | undefined)?.success ??
+                        (fallbackLanguage === 'zh'
+                            ? action === 'delete'
+                                ? '已將選取的附件移至回收桶。'
+                                : '已永久刪除選取的附件。'
+                            : action === 'delete'
+                                ? 'Selected attachments moved to recycle bin.'
+                                : 'Selected attachments permanently deleted.');
+
+                    showSuccess(t('attachments.index.flash.success', '操作成功'), successMessage);
+                },
+                onError: (errors) => {
+                    skipFlashToastRef.current = true;
+                    const errorMessages = Object.values(errors)
+                        .flat()
+                        .map((value) => String(value))
+                        .filter((value) => value.length > 0);
+
+                    const fallbackMessage =
+                        fallbackLanguage === 'zh'
+                            ? '批次操作失敗，請稍後再試。'
+                            : 'Bulk action failed. Please try again later.';
+
+                    showBatchErrors(
+                        errorMessages.length > 0 ? errorMessages : [fallbackMessage],
+                        t('attachments.index.flash.error', '操作失敗'),
+                    );
+                },
+            });
+        },
+        [selected, bulkForm, fallbackLanguage, t, showSuccess, showBatchErrors],
+    );
+
+    const handleDelete = useCallback(
+        (attachment: AttachmentItem) => {
+            if (attachment.deleted_at) {
+                showInfo(
+                    t(
+                        'attachments.index.info.already_deleted',
+                        fallbackLanguage === 'zh' ? '附件已在回收桶中' : 'Attachment is already in recycle bin',
+                    ),
+                );
+                return;
+            }
+
+            const confirmed = window.confirm(
+                t(
+                    'attachments.index.dialogs.delete_confirm',
+                    fallbackLanguage === 'zh'
+                        ? `確定要移除附件「${attachment.title ?? attachment.filename ?? attachment.id}」嗎？`
+                        : `Delete attachment "${attachment.title ?? attachment.filename ?? attachment.id}"?`,
+                    {
+                        name: attachment.title ?? attachment.filename ?? String(attachment.id),
+                    },
+                ),
+            );
+
+            if (!confirmed) {
+                return;
+            }
+
+            router.delete(`/manage/attachments/${attachment.id}`, {
+                preserveScroll: true,
+                onSuccess: (pageResponse) => {
+                    skipFlashToastRef.current = true;
+                    const successMessage =
+                        (pageResponse?.props?.flash as AttachmentFlashMessages | undefined)?.success ??
+                        (fallbackLanguage === 'zh' ? '附件已移至回收桶。' : 'Attachment moved to recycle bin.');
+
+                    showSuccess(t('attachments.index.flash.success', '操作成功'), successMessage);
+                },
+                onError: (errors) => {
+                    skipFlashToastRef.current = true;
+                    const errorMessages = Object.values(errors)
+                        .flat()
+                        .map((value) => String(value))
+                        .filter((value) => value.length > 0);
+
+                    const fallbackMessage =
+                        fallbackLanguage === 'zh' ? '刪除失敗，請稍後再試。' : 'Failed to delete attachment.';
+
+                    showBatchErrors(
+                        errorMessages.length > 0 ? errorMessages : [fallbackMessage],
+                        t('attachments.index.flash.error', '操作失敗'),
+                    );
+                },
+            });
+        },
+        [fallbackLanguage, showInfo, showSuccess, showBatchErrors, t],
+    );
+
+    const handleRestore = useCallback(
+        (attachment: AttachmentItem) => {
+            if (!attachment.deleted_at) {
+                showInfo(
+                    t(
+                        'attachments.index.info.not_deleted',
+                        fallbackLanguage === 'zh' ? '附件尚未刪除' : 'Attachment is not deleted',
+                    ),
+                );
+                return;
+            }
+
+            router.patch(`/manage/attachments/${attachment.id}/restore`, undefined, {
+                preserveScroll: true,
+                onSuccess: (pageResponse) => {
+                    skipFlashToastRef.current = true;
+                    const successMessage =
+                        (pageResponse?.props?.flash as AttachmentFlashMessages | undefined)?.success ??
+                        (fallbackLanguage === 'zh' ? '附件已還原。' : 'Attachment restored.');
+
+                    showSuccess(t('attachments.index.flash.success', '操作成功'), successMessage);
+                },
+                onError: (errors) => {
+                    skipFlashToastRef.current = true;
+                    const errorMessages = Object.values(errors)
+                        .flat()
+                        .map((value) => String(value))
+                        .filter((value) => value.length > 0);
+
+                    const fallbackMessage =
+                        fallbackLanguage === 'zh' ? '還原失敗，請稍後再試。' : 'Failed to restore attachment.';
+
+                    showBatchErrors(
+                        errorMessages.length > 0 ? errorMessages : [fallbackMessage],
+                        t('attachments.index.flash.error', '操作失敗'),
+                    );
+                },
+            });
+        },
+        [fallbackLanguage, showInfo, showSuccess, showBatchErrors, t],
+    );
+
+    const handleForceDelete = useCallback(
+        (attachment: AttachmentItem) => {
+            const confirmed = window.confirm(
+                t(
+                    'attachments.index.dialogs.force_delete_confirm',
+                    fallbackLanguage === 'zh'
+                        ? '確定要永久刪除此附件？此動作無法復原。'
+                        : 'Permanently delete this attachment? This action cannot be undone.',
+                ),
+            );
+
+            if (!confirmed) {
+                return;
+            }
+
+            router.delete(`/manage/attachments/${attachment.id}/force`, {
+                preserveScroll: true,
+                onSuccess: (pageResponse) => {
+                    skipFlashToastRef.current = true;
+                    const successMessage =
+                        (pageResponse?.props?.flash as AttachmentFlashMessages | undefined)?.success ??
+                        (fallbackLanguage === 'zh' ? '附件已永久刪除。' : 'Attachment permanently deleted.');
+
+                    showSuccess(t('attachments.index.flash.success', '操作成功'), successMessage);
+                },
+                onError: (errors) => {
+                    skipFlashToastRef.current = true;
+                    const errorMessages = Object.values(errors)
+                        .flat()
+                        .map((value) => String(value))
+                        .filter((value) => value.length > 0);
+
+                    const fallbackMessage =
+                        fallbackLanguage === 'zh' ? '刪除失敗，請稍後再試。' : 'Failed to delete attachment.';
+
+                    showBatchErrors(
+                        errorMessages.length > 0 ? errorMessages : [fallbackMessage],
+                        t('attachments.index.flash.error', '操作失敗'),
+                    );
+                },
+            });
+        },
+        [fallbackLanguage, showSuccess, showBatchErrors, t],
+    );
+
+    useEffect(() => {
+        setFilterState(createInitialFilterState(filters, defaultPerPage, defaultSort));
+    }, [filters, defaultPerPage, defaultSort]);
+
+    useEffect(() => {
+        setSelected([]);
+    }, [pagination.current_page, pagination.total]);
+
+    useEffect(() => {
+        if (skipFlashToastRef.current) {
+            previousFlashRef.current = flashMessages;
+            skipFlashToastRef.current = false;
+            return;
+        }
+
+        if (flashMessages.success && flashMessages.success !== previousFlashRef.current.success) {
+            showSuccess(t('attachments.index.flash.success', '操作成功'), flashMessages.success);
+        }
+
+        if (flashMessages.error && flashMessages.error !== previousFlashRef.current.error) {
+            showError(t('attachments.index.flash.error', '操作失敗'), flashMessages.error);
+        }
+
+        if (flashMessages.info && flashMessages.info !== previousFlashRef.current.info) {
+            showInfo(t('attachments.index.flash.info', '訊息'), flashMessages.info);
+        }
+
+        previousFlashRef.current = flashMessages;
+    }, [flashMessages, showSuccess, showError, showInfo, t]);
+
+    return (
+        <ManageLayout breadcrumbs={breadcrumbs}>
+            <Head title={t('attachments.index.title', fallbackLanguage === 'zh' ? '附件管理' : 'Attachment manager')} />
+
+            <ToastContainer toasts={toasts} onDismiss={dismissToast} position="bottom-right" />
+
+            <section className="space-y-6">
+                <ManagePageHeader
+                    badge={{
+                        icon: <Paperclip className="h-4 w-4" />,
+                        label: t(
+                            'attachments.index.badge',
+                            fallbackLanguage === 'zh' ? '附件總覽' : 'Attachment overview',
+                        ),
+                    }}
+                    title={t('attachments.index.title', fallbackLanguage === 'zh' ? '附件管理' : 'Attachment manager')}
+                    description={t(
+                        'attachments.index.description',
+                        fallbackLanguage === 'zh'
+                            ? '檢視與維護公告、頁面所使用的檔案與連結資源。'
+                            : 'Review and maintain files or links used across posts and pages.',
+                    )}
+                    actions={
+                        <Button
+                            type="button"
+                            variant="outline"
+                            className="rounded-full"
+                            onClick={() => router.get('/manage/posts')}
+                        >
+                            {t('attachments.index.back_to_posts', fallbackLanguage === 'zh' ? '回公告列表' : 'Back to posts')}
+                        </Button>
+                    }
+                />
+
+                <AttachmentFilterForm
+                    filterState={filterState}
+                    typeOptions={typeOptions}
+                    visibilityOptions={visibilityOptions}
+                    attachedTypeOptions={attachedTypeOptions}
+                    perPageOptions={perPageOptions}
+                    sortOptions={sortOptions}
+                    hasActiveFilters={hasActiveFilters}
+                    onChange={handleFilterChange}
+                    onSubmit={applyFilters}
+                    onReset={resetFilters}
+                    t={t}
+                    fallbackLanguage={fallbackLanguage}
+                />
+
+                <AttachmentTable
+                    attachments={attachmentData}
+                    selectedIds={selected}
+                    onToggleSelectAll={handleToggleSelectAll}
+                    onToggleSelection={handleToggleSelection}
+                    onDelete={handleDelete}
+                    onRestore={handleRestore}
+                    onForceDelete={handleForceDelete}
+                    onBulkAction={performBulkAction}
+                    bulkProcessing={bulkForm.processing}
+                    pagination={pagination}
+                    paginationLinks={paginationLinks}
+                    changePage={changePage}
+                    iconActionClass={iconActionClass}
+                    t={t}
+                    fallbackLanguage={fallbackLanguage}
+                    localeForDate={localeForDate}
+                />
+            </section>
+        </ManageLayout>
+    );
+}


### PR DESCRIPTION
## Summary
- add shared attachment management types, filter form, and table components under components/manage/attachment
- build manage/attachments Inertia page with filtering, pagination, bulk actions, and toast feedback following existing posts architecture
- ensure attachment actions (delete, restore, force delete) surface toasts and guard against invalid interactions

## Testing
- npm run test -- --runInBand *(fails: existing Jest moduleNameMapper configuration cannot resolve several mocked UI components)*

------
https://chatgpt.com/codex/tasks/task_e_68d5881e62348323bbdc49ccff928867