### PR TITLE
feat: add admin tag management pages

### DIFF
--- a/resources/js/components/manage/tags/tag-detail-card.tsx
+++ b/resources/js/components/manage/tags/tag-detail-card.tsx
@@ -1,0 +1,79 @@
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { useTranslator } from '@/hooks/use-translator';
+import type { TagDetail } from './tag-types';
+
+interface TagDetailCardProps {
+    /** 要呈現的標籤資料 */
+    tag: TagDetail;
+}
+
+export function TagDetailCard({ tag }: TagDetailCardProps) {
+    const { t, localeKey } = useTranslator('manage');
+
+    const formatDate = (value: string | null | undefined) => {
+        if (!value) {
+            return t('tags.show.meta.not_available', '未提供');
+        }
+
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return t('tags.show.meta.not_available', '未提供');
+        }
+
+        return date.toLocaleString(localeKey === 'zh-TW' ? 'zh-TW' : 'en-US', {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+        });
+    };
+
+    return (
+        <Card className="border border-slate-200 bg-white shadow-sm">
+            <CardHeader className="border-b border-slate-100 pb-4">
+                <div className="flex flex-col gap-3">
+                    <Badge className="w-max rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                        {t('tags.show.context.badge', 'Context：:context', { context: tag.context })}
+                    </Badge>
+                    <CardTitle className="text-2xl font-semibold text-slate-900">{tag.name}</CardTitle>
+                    <p className="text-sm text-slate-600">
+                        {tag.description && tag.description.trim() !== ''
+                            ? tag.description
+                            : t('tags.show.description.empty', '尚未提供描述內容。')}
+                    </p>
+                </div>
+            </CardHeader>
+            <CardContent className="space-y-6 py-6">
+                <div className="grid gap-6 md:grid-cols-2">
+                    <div className="space-y-2">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                            {t('tags.show.fields.slug', '網址代稱')}
+                        </p>
+                        <p className="text-sm font-mono text-slate-800">{tag.slug}</p>
+                    </div>
+                    <div className="space-y-2">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                            {t('tags.show.fields.sort_order', '排序優先度')}
+                        </p>
+                        <p className="text-sm text-slate-800">{tag.sort_order ?? 0}</p>
+                    </div>
+                </div>
+            </CardContent>
+            <CardFooter className="grid gap-4 border-t border-slate-100 bg-slate-50/70 px-6 py-4 text-sm text-slate-600 sm:grid-cols-2">
+                <div className="space-y-1">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        {t('tags.show.meta.created_at', '建立時間')}
+                    </p>
+                    <p>{formatDate(tag.created_at)}</p>
+                </div>
+                <div className="space-y-1">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        {t('tags.show.meta.updated_at', '最後更新')}
+                    </p>
+                    <p>{formatDate(tag.updated_at)}</p>
+                </div>
+            </CardFooter>
+        </Card>
+    );
+}
+
+export default TagDetailCard;

--- a/resources/js/components/manage/tags/tag-table.tsx
+++ b/resources/js/components/manage/tags/tag-table.tsx
@@ -1,0 +1,207 @@
+import { useMemo } from 'react';
+import { Link } from '@inertiajs/react';
+import { Eye, Pen, Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { useTranslator } from '@/hooks/use-translator';
+
+import type { TagContextOption } from './tag-form';
+import type { TagListItem } from './tag-types';
+
+interface TagTableProps {
+    /** 標籤資料列 */
+    tags: TagListItem[];
+    /** 後端提供的管理場景選項，維持顯示順序 */
+    contextOptions: TagContextOption[];
+    /** 刪除操作的回呼，讓頁面層負責實際的刪除流程 */
+    onDelete: (tag: TagListItem) => void;
+}
+
+/**
+ * 將 ISO 時間字串依語系格式化，若沒有值則回傳破折號。
+ */
+const formatDate = (value: string | null | undefined, locale: 'zh-TW' | 'en') => {
+    if (!value) {
+        return '—';
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return '—';
+    }
+
+    return date.toLocaleString(locale === 'zh-TW' ? 'zh-TW' : 'en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    });
+};
+
+export function TagTable({ tags, contextOptions, onDelete }: TagTableProps) {
+    const { t, localeKey } = useTranslator('manage');
+
+    // 依據 context 建立索引，確保呈現順序與後端一致。
+    const contexts = useMemo(() => {
+        const known = new Map(contextOptions.map((option) => [option.value, option.label] as const));
+        const contextOrder: Array<{ value: string; label: string }> = contextOptions.map((option) => ({
+            value: option.value,
+            label: option.label,
+        }));
+
+        // 加入未定義於選項中的 context，避免資料遺漏。
+        tags.forEach((tag) => {
+            if (!known.has(tag.context)) {
+                known.set(tag.context, tag.context_label ?? tag.context);
+                contextOrder.push({ value: tag.context, label: tag.context_label ?? tag.context });
+            }
+        });
+
+        return contextOrder;
+    }, [contextOptions, tags]);
+
+    const tagsByContext = useMemo(() => {
+        const grouped = new Map<string, TagListItem[]>();
+        tags.forEach((tag) => {
+            const list = grouped.get(tag.context) ?? [];
+            list.push(tag);
+            grouped.set(tag.context, list);
+        });
+        return grouped;
+    }, [tags]);
+
+    if (tags.length === 0) {
+        return (
+            <Card className="border border-slate-200 bg-white shadow-sm">
+                <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+                    <Badge variant="outline" className="rounded-full px-3 py-1 text-xs font-semibold text-slate-500">
+                        {t('tags.table.empty.badge', '尚未建立標籤')}
+                    </Badge>
+                    <h2 className="text-2xl font-semibold text-slate-900">
+                        {t('tags.table.empty.title', '目前沒有任何標籤資料')}
+                    </h2>
+                    <p className="max-w-md text-sm text-slate-600">
+                        {t('tags.table.empty.description', '點擊右上角的「新增標籤」以建立第一筆資料，協助其他管理頁面完成分類。')}
+                    </p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            {contexts
+                .map(({ value, label }) => {
+                    const items = tagsByContext.get(value) ?? [];
+                    return { value, label, items };
+                })
+                .filter((context) => context.items.length > 0)
+                .map((context) => (
+                    <Card key={context.value} className="border border-slate-200 bg-white shadow-sm">
+                        <CardHeader className="border-b border-slate-100 pb-4">
+                            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                <div>
+                                    <CardTitle className="text-lg font-semibold text-slate-900">{context.label}</CardTitle>
+                                    <p className="text-sm text-slate-600">
+                                        {t('tags.table.context.description', '共 :count 個標籤，依排序優先度由小到大排列。', {
+                                            count: String(context.items.length),
+                                        })}
+                                    </p>
+                                </div>
+                                <Badge className="rounded-full bg-slate-100 text-slate-700">
+                                    {t('tags.table.context.badge', 'Context：:context', { context: context.value })}
+                                </Badge>
+                            </div>
+                        </CardHeader>
+                        <CardContent className="p-0">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow className="bg-slate-50/80">
+                                        <TableHead className="w-[28%] px-6 py-3 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                                            {t('tags.table.columns.name', '標籤名稱')}
+                                        </TableHead>
+                                        <TableHead className="w-[30%] px-6 py-3 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                                            {t('tags.table.columns.description', '描述')}
+                                        </TableHead>
+                                        <TableHead className="w-[12%] px-6 py-3 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                                            {t('tags.table.columns.sort_order', '排序')}
+                                        </TableHead>
+                                        <TableHead className="w-[18%] px-6 py-3 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                                            {t('tags.table.columns.updated_at', '最後更新')}
+                                        </TableHead>
+                                        <TableHead className="w-[12%] px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-600">
+                                            {t('tags.table.columns.actions', '操作')}
+                                        </TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {context.items.map((tag) => (
+                                        <TableRow key={tag.id} className="border-slate-100">
+                                            <TableCell className="px-6 py-4 align-top">
+                                                <div className="flex flex-col gap-1">
+                                                    <span className="text-sm font-semibold text-slate-900">{tag.name}</span>
+                                                    <span className="text-xs text-slate-500">
+                                                        {t('tags.table.row.slug', '網址代稱：:slug', { slug: tag.slug })}
+                                                    </span>
+                                                </div>
+                                            </TableCell>
+                                            <TableCell className="px-6 py-4 align-top text-sm text-slate-600">
+                                                {tag.description && tag.description.trim() !== ''
+                                                    ? tag.description
+                                                    : t('tags.table.row.no_description', '未提供描述')}
+                                            </TableCell>
+                                            <TableCell className="px-6 py-4 align-top text-sm font-semibold text-slate-700">
+                                                {tag.sort_order ?? 0}
+                                            </TableCell>
+                                            <TableCell className="px-6 py-4 align-top text-sm text-slate-600">
+                                                {formatDate(tag.updated_at ?? tag.created_at, localeKey)}
+                                            </TableCell>
+                                            <TableCell className="px-6 py-4 align-top text-right text-sm">
+                                                <div className="flex items-center justify-end gap-2">
+                                                    <Button
+                                                        asChild
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="h-9 w-9 rounded-full text-slate-600 hover:text-slate-900"
+                                                    >
+                                                        <Link href={`/manage/tags/${tag.id}`} aria-label={t('tags.table.actions.view', '檢視標籤')}>
+                                                            <Eye className="h-4 w-4" />
+                                                            <span className="sr-only">{t('tags.table.actions.view', '檢視標籤')}</span>
+                                                        </Link>
+                                                    </Button>
+                                                    <Button
+                                                        asChild
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="h-9 w-9 rounded-full text-slate-600 hover:text-slate-900"
+                                                    >
+                                                        <Link href={`/manage/tags/${tag.id}/edit`} aria-label={t('tags.table.actions.edit', '編輯標籤')}>
+                                                            <Pen className="h-4 w-4" />
+                                                            <span className="sr-only">{t('tags.table.actions.edit', '編輯標籤')}</span>
+                                                        </Link>
+                                                    </Button>
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="h-9 w-9 rounded-full text-red-500 hover:bg-red-50 hover:text-red-600"
+                                                        onClick={() => onDelete(tag)}
+                                                    >
+                                                        <Trash2 className="h-4 w-4" />
+                                                        <span className="sr-only">{t('tags.table.actions.delete', '刪除標籤')}</span>
+                                                    </Button>
+                                                </div>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </CardContent>
+                    </Card>
+                ))}
+        </div>
+    );
+}
+
+export default TagTable;

--- a/resources/js/components/manage/tags/tag-types.ts
+++ b/resources/js/components/manage/tags/tag-types.ts
@@ -1,0 +1,25 @@
+import type { TagResource } from './tag-form';
+
+/**
+ * 標籤列表項目的結構定義，延伸表單使用的 TagResource 以避免重複型別宣告。
+ */
+export interface TagListItem extends TagResource {
+    id: number;
+    context_label: string;
+    created_at?: string | null;
+    updated_at?: string | null;
+}
+
+/**
+ * 顯示用的標籤詳細資料結構，與列表項目相同但語意上區隔用途。
+ */
+export type TagDetail = TagListItem;
+
+/**
+ * 後端透過 Flash 帶入的訊息結構，提供頁面呈現 Toast 時使用。
+ */
+export interface TagFlashMessages {
+    success?: string;
+    error?: string;
+    info?: string;
+}

--- a/resources/js/pages/manage/admin/tags/create.tsx
+++ b/resources/js/pages/manage/admin/tags/create.tsx
@@ -1,0 +1,116 @@
+import { Head, Link } from '@inertiajs/react';
+import { AlertTriangle, ArrowLeft } from 'lucide-react';
+import { useEffect, useMemo } from 'react';
+
+import TagForm, { type TagContextOption, type TagFormSubmitHandler } from '@/components/manage/tags/tag-form';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import ToastContainer from '@/components/ui/toast-container';
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { useToast } from '@/hooks/use-toast';
+import { useTranslator } from '@/hooks/use-translator';
+import type { BreadcrumbItem } from '@/types';
+
+interface TagsCreatePageProps {
+    contextOptions: TagContextOption[];
+    tableReady: boolean;
+}
+
+export default function TagsCreatePage({ contextOptions, tableReady }: TagsCreatePageProps) {
+    const { t } = useTranslator('manage');
+    const { toasts, dismissToast, showError, showWarning } = useToast();
+
+    const breadcrumbs = useMemo<BreadcrumbItem[]>(
+        () => [
+            { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+            { title: t('layout.breadcrumbs.tags', '標籤管理'), href: '/manage/tags' },
+            { title: t('layout.breadcrumbs.tags_create', '新增標籤'), href: '/manage/tags/create' },
+        ],
+        [t],
+    );
+
+    const pageTitle = t('tags.create.title', '新增標籤');
+    const pageDescription = t('tags.create.description', '建立新的標籤以供公告或其他模組使用。');
+    const backToIndex = t('tags.create.back_to_index', '返回標籤列表');
+
+    // 頁面載入時檢查資料表狀態，若未就緒則立即提醒管理者先完成遷移。
+    useEffect(() => {
+        if (!tableReady) {
+            showWarning(
+                t('tags.index.toast.table_not_ready.title', '標籤資料表尚未建立'),
+                t('tags.index.toast.table_not_ready.description', '請先執行資料庫遷移後再進行標籤管理。'),
+            );
+        }
+    }, [tableReady, showWarning, t]);
+
+    // 送出表單時再次驗證資料表狀態，避免在遷移未完成前誤送資料。
+    const handleSubmit: TagFormSubmitHandler = (form) => {
+        if (!tableReady) {
+            showWarning(
+                t('tags.index.toast.table_not_ready.title', '標籤資料表尚未建立'),
+                t('tags.index.toast.table_not_ready.description', '請先執行資料庫遷移後再進行標籤管理。'),
+            );
+            return;
+        }
+
+        form.post('/manage/tags', {
+            preserveScroll: true,
+            onError: (errors) => {
+                const aggregated = Object.values(errors ?? {})
+                    .flat()
+                    .map((message) => String(message))
+                    .filter((message) => message.trim().length > 0);
+
+                const fallbackMessage = t('tags.create.toast.error.description', '建立標籤時發生錯誤，請確認欄位內容。');
+
+                showError(t('tags.create.toast.error.title', '建立失敗'), aggregated[0] ?? fallbackMessage);
+            },
+        });
+    };
+
+    return (
+        <ManageLayout role="admin" breadcrumbs={breadcrumbs}>
+            <Head title={pageTitle} />
+
+            <ToastContainer toasts={toasts} onDismiss={dismissToast} position="bottom-right" />
+
+            <section className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+                <Card className="border border-slate-200 bg-white shadow-sm">
+                    <CardContent className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="space-y-2">
+                            <h1 className="text-3xl font-semibold text-slate-900">{pageTitle}</h1>
+                            <p className="text-sm text-slate-600">{pageDescription}</p>
+                        </div>
+                        <Button asChild variant="outline" className="rounded-full">
+                            <Link href="/manage/tags" className="inline-flex items-center gap-2" aria-label={backToIndex}>
+                                <ArrowLeft className="h-4 w-4" />
+                                {backToIndex}
+                            </Link>
+                        </Button>
+                    </CardContent>
+                </Card>
+
+                {!tableReady && (
+                    <Alert className="border-amber-200 bg-amber-50 text-amber-900">
+                        <AlertTriangle className="h-4 w-4" />
+                        <AlertTitle>{t('tags.create.alert.migration_needed.title', '目前無法建立標籤')}</AlertTitle>
+                        <AlertDescription>
+                            {t(
+                                'tags.create.alert.migration_needed.description',
+                                '尚未建立標籤資料表，請先執行 `php artisan migrate` 後再重試。',
+                            )}
+                        </AlertDescription>
+                    </Alert>
+                )}
+
+                <TagForm
+                    contextOptions={contextOptions}
+                    submitLabel={t('tags.create.submit', '建立標籤')}
+                    cancelUrl="/manage/tags"
+                    onSubmit={handleSubmit}
+                />
+            </section>
+        </ManageLayout>
+    );
+}

--- a/resources/js/pages/manage/admin/tags/edit.tsx
+++ b/resources/js/pages/manage/admin/tags/edit.tsx
@@ -1,0 +1,89 @@
+import { Head, Link } from '@inertiajs/react';
+import { ArrowLeft } from 'lucide-react';
+import { useMemo } from 'react';
+
+import TagForm, { type TagContextOption, type TagFormSubmitHandler, type TagResource } from '@/components/manage/tags/tag-form';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import ToastContainer from '@/components/ui/toast-container';
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { useToast } from '@/hooks/use-toast';
+import { useTranslator } from '@/hooks/use-translator';
+import type { BreadcrumbItem } from '@/types';
+
+interface EditableTag extends TagResource {
+    id: number;
+}
+
+interface TagsEditPageProps {
+    tag: EditableTag;
+    contextOptions: TagContextOption[];
+}
+
+export default function TagsEditPage({ tag, contextOptions }: TagsEditPageProps) {
+    const { t } = useTranslator('manage');
+    const { toasts, dismissToast, showError } = useToast();
+
+    const breadcrumbs = useMemo<BreadcrumbItem[]>(
+        () => [
+            { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+            { title: t('layout.breadcrumbs.tags', '標籤管理'), href: '/manage/tags' },
+            { title: t('layout.breadcrumbs.tags_edit', '編輯標籤'), href: `/manage/tags/${tag.id}/edit` },
+        ],
+        [t, tag.id],
+    );
+
+    const pageTitle = t('tags.edit.title', '編輯標籤');
+    const pageDescription = t('tags.edit.description', '調整標籤資訊以保持分類一致性。');
+    const backToIndex = t('tags.edit.back_to_index', '返回標籤列表');
+
+    // 更新時只顯示錯誤 Toast，成功會透過重新導向的列表頁顯示統一提示。
+    const handleSubmit: TagFormSubmitHandler = (form) => {
+        form.put(`/manage/tags/${tag.id}`, {
+            preserveScroll: true,
+            onError: (errors) => {
+                const aggregated = Object.values(errors ?? {})
+                    .flat()
+                    .map((message) => String(message))
+                    .filter((message) => message.trim().length > 0);
+
+                const fallbackMessage = t('tags.edit.toast.error.description', '更新標籤時發生錯誤，請確認欄位內容。');
+
+                showError(t('tags.edit.toast.error.title', '更新失敗'), aggregated[0] ?? fallbackMessage);
+            },
+        });
+    };
+
+    return (
+        <ManageLayout role="admin" breadcrumbs={breadcrumbs}>
+            <Head title={pageTitle} />
+
+            <ToastContainer toasts={toasts} onDismiss={dismissToast} position="bottom-right" />
+
+            <section className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+                <Card className="border border-slate-200 bg-white shadow-sm">
+                    <CardContent className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="space-y-2">
+                            <h1 className="text-3xl font-semibold text-slate-900">{pageTitle}</h1>
+                            <p className="text-sm text-slate-600">{pageDescription}</p>
+                        </div>
+                        <Button asChild variant="outline" className="rounded-full">
+                            <Link href="/manage/tags" className="inline-flex items-center gap-2" aria-label={backToIndex}>
+                                <ArrowLeft className="h-4 w-4" />
+                                {backToIndex}
+                            </Link>
+                        </Button>
+                    </CardContent>
+                </Card>
+
+                <TagForm
+                    tag={tag}
+                    contextOptions={contextOptions}
+                    submitLabel={t('tags.edit.submit', '儲存變更')}
+                    cancelUrl="/manage/tags"
+                    onSubmit={handleSubmit}
+                />
+            </section>
+        </ManageLayout>
+    );
+}

--- a/resources/js/pages/manage/admin/tags/index.tsx
+++ b/resources/js/pages/manage/admin/tags/index.tsx
@@ -1,0 +1,185 @@
+import { Head, router, usePage } from '@inertiajs/react';
+import { AlertTriangle, Plus, Tag as TagIcon } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import TagTable from '@/components/manage/tags/tag-table';
+import type { TagContextOption } from '@/components/manage/tags/tag-form';
+import type { TagFlashMessages, TagListItem } from '@/components/manage/tags/tag-types';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import ToastContainer from '@/components/ui/toast-container';
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { useToast } from '@/hooks/use-toast';
+import { useTranslator } from '@/hooks/use-translator';
+import type { BreadcrumbItem, SharedData } from '@/types';
+
+interface TagsIndexPageProps {
+    contextOptions: TagContextOption[];
+    tags: TagListItem[];
+    tableReady: boolean;
+}
+
+type PageProps = SharedData & { flash?: TagFlashMessages };
+
+export default function TagsIndexPage({ contextOptions, tags, tableReady }: TagsIndexPageProps) {
+    const page = usePage<PageProps>();
+    const flash = page.props.flash ?? {};
+
+    const { t } = useTranslator('manage');
+    const { toasts, dismissToast, showSuccess, showError, showInfo, showWarning } = useToast();
+
+    // 透過 ref 紀錄是否已由前端顯示 Toast，避免重複顯示後端 flash 訊息。
+    const skipFlashToastRef = useRef(false);
+    const previousFlashRef = useRef<TagFlashMessages>({});
+
+    const breadcrumbs = useMemo<BreadcrumbItem[]>(
+        () => [
+            { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+            { title: t('layout.breadcrumbs.tags', '標籤管理'), href: '/manage/tags' },
+        ],
+        [t],
+    );
+
+    const pageTitle = t('tags.index.title', '標籤管理');
+    const pageDescription = t(
+        'tags.index.description',
+        '維護公告、師資等各模組共用的標籤，協助建立一致的分類與篩選經驗。',
+    );
+
+    const createLabel = t('tags.index.actions.create', '新增標籤');
+
+    // 若資料表尚未建立，於初次載入時即提醒使用者處理遷移。
+    useEffect(() => {
+        if (!tableReady) {
+            showWarning(
+                t('tags.index.toast.table_not_ready.title', '標籤資料表尚未建立'),
+                t('tags.index.toast.table_not_ready.description', '請先執行資料庫遷移後再進行標籤管理。'),
+            );
+        }
+    }, [tableReady, showWarning, t]);
+
+    // 刪除流程需二次確認，並在成功或失敗時即時提示使用者。
+    const handleDelete = useCallback(
+        (tag: TagListItem) => {
+            if (!tableReady) {
+                showWarning(
+                    t('tags.index.toast.table_not_ready.title', '標籤資料表尚未建立'),
+                    t('tags.index.toast.table_not_ready.description', '請先執行資料庫遷移後再進行標籤管理。'),
+                );
+                return;
+            }
+
+            const confirmed = window.confirm(
+                t('tags.index.confirm.delete', '確定要刪除標籤「:name」嗎？此操作無法復原。', { name: tag.name }),
+            );
+
+            if (!confirmed) {
+                return;
+            }
+
+            router.delete(`/manage/tags/${tag.id}`, {
+                preserveScroll: true,
+                onSuccess: () => {
+                    skipFlashToastRef.current = true;
+                    showSuccess(
+                        t('tags.index.toast.delete_success.title', '刪除成功'),
+                        t('tags.index.toast.delete_success.description', '已刪除標籤「:name」。', { name: tag.name }),
+                    );
+                },
+                onError: (errors) => {
+                    skipFlashToastRef.current = true;
+                    const aggregated = Object.values(errors ?? {})
+                        .flat()
+                        .map((message) => String(message))
+                        .filter((message) => message.trim().length > 0);
+
+                    const fallbackMessage = t(
+                        'tags.index.toast.delete_error.description',
+                        '刪除標籤時發生錯誤，請稍後再試。',
+                    );
+
+                    showError(
+                        t('tags.index.toast.delete_error.title', '刪除失敗'),
+                        aggregated[0] ?? fallbackMessage,
+                    );
+                },
+            });
+        },
+        [tableReady, t, showWarning, showSuccess, showError],
+    );
+
+    useEffect(() => {
+        if (skipFlashToastRef.current) {
+            previousFlashRef.current = flash;
+            skipFlashToastRef.current = false;
+            return;
+        }
+
+        if (flash.success && flash.success !== previousFlashRef.current.success) {
+            showSuccess(t('tags.index.toast.flash_success.title', '操作成功'), flash.success);
+        }
+
+        if (flash.error && flash.error !== previousFlashRef.current.error) {
+            showError(t('tags.index.toast.flash_error.title', '操作失敗'), flash.error);
+        }
+
+        if (flash.info && flash.info !== previousFlashRef.current.info) {
+            showInfo(t('tags.index.toast.flash_info.title', '系統訊息'), flash.info);
+        }
+
+        previousFlashRef.current = flash;
+    }, [flash, showSuccess, showError, showInfo, t]);
+
+    return (
+        <ManageLayout role="admin" breadcrumbs={breadcrumbs}>
+            <Head title={pageTitle} />
+
+            <ToastContainer toasts={toasts} onDismiss={dismissToast} position="bottom-right" />
+
+            <section className="space-y-6">
+                <ManagePageHeader
+                    badge={{ icon: <TagIcon className="h-4 w-4" />, label: t('tags.index.badge', '標籤總覽') }}
+                    title={pageTitle}
+                    description={pageDescription}
+                    actions={
+                        <Button
+                            type="button"
+                            className="rounded-full px-5"
+                            disabled={!tableReady}
+                            onClick={() => {
+                                if (!tableReady) {
+                                    showWarning(
+                                        t('tags.index.toast.table_not_ready.title', '標籤資料表尚未建立'),
+                                        t('tags.index.toast.table_not_ready.description', '請先執行資料庫遷移後再進行標籤管理。'),
+                                    );
+                                    return;
+                                }
+
+                                router.visit('/manage/tags/create');
+                            }}
+                        >
+                            <Plus className="mr-2 h-4 w-4" />
+                            {createLabel}
+                        </Button>
+                    }
+                />
+
+                {!tableReady && (
+                    <Alert className="border-amber-200 bg-amber-50 text-amber-900">
+                        <AlertTriangle className="h-4 w-4" />
+                        <AlertTitle>{t('tags.index.alert.migration_needed.title', '請先執行資料庫遷移')}</AlertTitle>
+                        <AlertDescription>
+                            {t(
+                                'tags.index.alert.migration_needed.description',
+                                '系統偵測到標籤資料表尚未建立，請先執行 `php artisan migrate` 後重新整理此頁面。',
+                            )}
+                        </AlertDescription>
+                    </Alert>
+                )}
+
+                <TagTable tags={tags} contextOptions={contextOptions} onDelete={handleDelete} />
+            </section>
+        </ManageLayout>
+    );
+}

--- a/resources/js/pages/manage/admin/tags/show.tsx
+++ b/resources/js/pages/manage/admin/tags/show.tsx
@@ -1,0 +1,95 @@
+import { Head, Link, usePage } from '@inertiajs/react';
+import { ArrowLeft, PenLine, Tag as TagIcon } from 'lucide-react';
+import { useEffect, useMemo, useRef } from 'react';
+
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import TagDetailCard from '@/components/manage/tags/tag-detail-card';
+import type { TagDetail, TagFlashMessages } from '@/components/manage/tags/tag-types';
+import { Button } from '@/components/ui/button';
+import ToastContainer from '@/components/ui/toast-container';
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { useToast } from '@/hooks/use-toast';
+import { useTranslator } from '@/hooks/use-translator';
+import type { BreadcrumbItem, SharedData } from '@/types';
+
+interface TagShowPageProps {
+    tag: TagDetail;
+}
+
+type PageProps = SharedData & { flash?: TagFlashMessages };
+
+export default function TagShowPage({ tag }: TagShowPageProps) {
+    const page = usePage<PageProps>();
+    const flash = page.props.flash ?? {};
+
+    const { t } = useTranslator('manage');
+    const { toasts, dismissToast, showSuccess, showError, showInfo } = useToast();
+
+    const previousFlashRef = useRef<TagFlashMessages>({});
+
+    const breadcrumbs = useMemo<BreadcrumbItem[]>(
+        () => [
+            { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+            { title: t('layout.breadcrumbs.tags', '標籤管理'), href: '/manage/tags' },
+            { title: t('layout.breadcrumbs.tags_show', '標籤詳情'), href: `/manage/tags/${tag.id}` },
+        ],
+        [t, tag.id],
+    );
+
+    const pageTitle = t('tags.show.title', '標籤詳情');
+    const pageDescription = t(
+        'tags.show.description',
+        '檢視標籤的詳細設定與建立時間，協助了解分類使用狀況。',
+    );
+
+    // 若後端帶有 flash 訊息，統一在此轉換為 Toast，避免資訊被忽略。
+    useEffect(() => {
+        if (flash.success && flash.success !== previousFlashRef.current.success) {
+            showSuccess(t('tags.index.toast.flash_success.title', '操作成功'), flash.success);
+        }
+
+        if (flash.error && flash.error !== previousFlashRef.current.error) {
+            showError(t('tags.index.toast.flash_error.title', '操作失敗'), flash.error);
+        }
+
+        if (flash.info && flash.info !== previousFlashRef.current.info) {
+            showInfo(t('tags.index.toast.flash_info.title', '系統訊息'), flash.info);
+        }
+
+        previousFlashRef.current = flash;
+    }, [flash, showSuccess, showError, showInfo, t]);
+
+    return (
+        <ManageLayout role="admin" breadcrumbs={breadcrumbs}>
+            <Head title={pageTitle} />
+
+            <ToastContainer toasts={toasts} onDismiss={dismissToast} position="bottom-right" />
+
+            <section className="space-y-6">
+                <ManagePageHeader
+                    badge={{ icon: <TagIcon className="h-4 w-4" />, label: tag.context_label ?? tag.context }}
+                    title={pageTitle}
+                    description={pageDescription}
+                    actions={
+                        <div className="flex flex-col gap-2 sm:flex-row">
+                            <Button asChild variant="outline" className="rounded-full">
+                                <Link href="/manage/tags" className="inline-flex items-center gap-2">
+                                    <ArrowLeft className="h-4 w-4" />
+                                    {t('tags.show.actions.back', '返回列表')}
+                                </Link>
+                            </Button>
+                            <Button asChild className="rounded-full">
+                                <Link href={`/manage/tags/${tag.id}/edit`} className="inline-flex items-center gap-2">
+                                    <PenLine className="h-4 w-4" />
+                                    {t('tags.show.actions.edit', '編輯標籤')}
+                                </Link>
+                            </Button>
+                        </div>
+                    }
+                />
+
+                <TagDetailCard tag={tag} />
+            </section>
+        </ManageLayout>
+    );
+}


### PR DESCRIPTION
## Summary
- add shared tag list/detail components and typed resources for manage UI reuse
- implement admin tag index with toast handling, migration warning, and grouped table actions
- create dedicated tag create/edit/show pages that reuse TagForm with defensive checks and alerts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d587d84c908323a22f60f5db0d944b