### PR TITLE
調整語言切換器的精簡模式觸發寬度

### DIFF
--- a/resources/js/components/language-switcher.tsx
+++ b/resources/js/components/language-switcher.tsx
@@ -28,7 +28,8 @@ export default function LanguageSwitcher({
             return;
         }
 
-        const mediaQuery = window.matchMedia('(max-width: 420px)');
+        // 適度提前在中小尺寸畫面就切換為單一按鈕，避免繁體字造成的排版擁擠
+        const mediaQuery = window.matchMedia('(max-width: 520px)');
 
         const updateCompactMode = (event: MediaQueryList | MediaQueryListEvent) => {
             setIsCompact(event.matches);


### PR DESCRIPTION
## Summary
- 將語言切換器偵測的畫面寬度從 420px 放寬至 520px
- 新增中文註解，說明提前切換為單一按鈕的目的

## Testing
- 未執行測試（前端樣式調整）

------
https://chatgpt.com/codex/tasks/task_e_68da56ff4b0c832387537256a72909de