### PR TITLE
Adjust profile settings text and tab styling

### DIFF
--- a/resources/js/components/heading-small.tsx
+++ b/resources/js/components/heading-small.tsx
@@ -2,7 +2,7 @@ export default function HeadingSmall({ title, description }: { title: string; de
     return (
         <header>
             <h3 className="mb-0.5 text-base font-medium">{title}</h3>
-            {description && <p className="text-sm text-muted-foreground">{description}</p>}
+            {description && <p className="text-sm text-foreground">{description}</p>}
         </header>
     );
 }

--- a/resources/js/layouts/manage/settings-layout.tsx
+++ b/resources/js/layouts/manage/settings-layout.tsx
@@ -51,7 +51,7 @@ export default function ManageSettingsLayout({ children, active }: ManageSetting
                                     href={item.href}
                                     prefetch
                                     className={cn(
-                                        'flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-colors',
+                                        'flex items-center gap-2 rounded-2xl px-4 py-2 text-sm font-medium transition-colors',
                                         active === item.key
                                             ? 'bg-[#151f54] text-white shadow-sm'
                                             : 'text-neutral-600 hover:bg-neutral-100 hover:text-neutral-900'


### PR DESCRIPTION
## Summary
- darken the profile settings descriptions to use the primary foreground color
- align the settings navigation tab radius with its container for consistent corners

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da6113dd6c83238a446e358f18591c