### PR TITLE
Refine academic management roles

### DIFF
--- a/lang/en/manage.php
+++ b/lang/en/manage.php
@@ -46,7 +46,7 @@ return [
             'staff' => 'Faculty & Staff',
             'labs' => 'Laboratories',
             'classrooms' => 'Classrooms',
-            'academics' => 'Courses & Programs',
+            'academics' => 'Program management',
             'users' => 'Users',
             'messages' => 'Messages',
             'attachments' => 'Attachments',
@@ -54,8 +54,8 @@ return [
         'teacher' => [
             'dashboard' => 'Teaching Home',
             'posts' => 'Announcements',
-            'labs' => 'Research',
-            'academics' => 'Program Management',
+            'labs' => 'Laboratories',
+            'projects' => 'Research projects',
             'profile' => 'Profile Settings',
             'guide' => 'Teaching Guide',
             'nav_label' => 'Teaching',
@@ -259,19 +259,19 @@ return [
         ],
         'teacher' => [
             'title' => 'Teaching workspace',
-            'description' => 'Access announcements, research updates, and course tools in one place.',
+            'description' => 'Access announcements, lab updates, and research tools in one place.',
             'actions' => [
                 'posts' => [
                     'label' => 'Announcements',
                     'description' => 'Publish and maintain department updates.',
                 ],
                 'labs' => [
-                    'label' => 'Research overview',
+                    'label' => 'Laboratory management',
                     'description' => 'Update lab profiles and research highlights.',
                 ],
-                'academics' => [
-                    'label' => 'Program Management',
-                    'description' => 'Manage academic programs and documents.',
+                'projects' => [
+                    'label' => 'Research projects',
+                    'description' => 'Manage research plans and published results.',
                 ],
                 'profile' => [
                     'label' => 'Profile settings',

--- a/lang/zh-TW/manage.php
+++ b/lang/zh-TW/manage.php
@@ -46,7 +46,7 @@ return [
             'staff' => '師資與職員',
             'labs' => '實驗室管理',
             'classrooms' => '教室管理',
-            'academics' => '課程與學程',
+            'academics' => '學制管理',
             'users' => '使用者管理',
             'messages' => '聯絡訊息',
             'attachments' => '附件管理',
@@ -54,8 +54,8 @@ return [
         'teacher' => [
             'dashboard' => '教學首頁',
             'posts' => '公告管理',
-            'labs' => '研究管理',
-            'academics' => '學程管理',
+            'labs' => '實驗室管理',
+            'projects' => '研究專案',
             'profile' => '個人設定',
             'guide' => '教學資源指南',
             'nav_label' => '教學管理',
@@ -259,19 +259,19 @@ return [
         ],
         'teacher' => [
             'title' => '教學管理首頁',
-            'description' => '快速掌握公告、研究與課程工具。',
+            'description' => '快速掌握公告、實驗室與研究工具。',
             'actions' => [
                 'posts' => [
                     'label' => '公告管理',
                     'description' => '發布與維護系上公告與資訊。',
                 ],
                 'labs' => [
-                    'label' => '研究管理',
+                    'label' => '實驗室管理',
                     'description' => '更新實驗室介紹與研究成果。',
                 ],
-                'academics' => [
-                    'label' => '學程管理',
-                    'description' => '管理學程架構與相關文件。',
+                'projects' => [
+                    'label' => '研究專案',
+                    'description' => '維護研究計畫與成果資訊。',
                 ],
                 'profile' => [
                     'label' => '個人設定',

--- a/resources/js/components/manage/dashboard/manage-quick-actions.tsx
+++ b/resources/js/components/manage/dashboard/manage-quick-actions.tsx
@@ -1,9 +1,8 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import RoleGuard, { useCurrentRole, useRolePermission } from '@/components/manage/guards/role-guard';
-import { PermissionGuard, usePermission, useRoleInfo } from '@/components/manage/utils/permission-utils';
+import RoleGuard from '@/components/manage/guards/role-guard';
+import { usePermission, useRoleInfo } from '@/components/manage/utils/permission-utils';
+import { QuickActionSection, type QuickActionItem } from '@/components/manage/dashboard/quick-action-section';
 import { useTranslator } from '@/hooks/use-translator';
-import { Link } from '@inertiajs/react';
 import {
     Users,
     Megaphone,
@@ -12,7 +11,9 @@ import {
     Settings,
     FileText,
     Mail,
-    UserCheck
+    UserCheck,
+    GraduationCap,
+    NotebookPen,
 } from 'lucide-react';
 
 /**
@@ -28,6 +29,88 @@ export default function ManageQuickActions() {
     const canManagePosts = usePermission('MANAGE_POSTS');
     const canManageLabs = usePermission('MANAGE_LABS');
     const canManageClassrooms = usePermission('MANAGE_CLASSROOMS');
+    const canManageAcademics = usePermission('MANAGE_ACADEMICS');
+    const canManageProjects = usePermission('MANAGE_PROJECTS');
+
+    const adminActions: QuickActionItem[] = [
+        {
+            label: t('sidebar.admin.users'),
+            icon: Users,
+            href: '/manage/users',
+            permission: 'MANAGE_USERS',
+        },
+        {
+            label: t('sidebar.admin.staff'),
+            icon: UserCheck,
+            href: '/manage/staff',
+            permission: 'MANAGE_STAFF',
+        },
+        {
+            label: t('sidebar.admin.classrooms'),
+            icon: School,
+            href: '/manage/classrooms',
+            permission: 'MANAGE_CLASSROOMS',
+        },
+        {
+            label: t('sidebar.admin.messages'),
+            icon: Mail,
+            href: '/manage/contact-messages',
+            permission: 'MANAGE_CONTACT_MESSAGES',
+        },
+        {
+            label: t('sidebar.admin.attachments'),
+            icon: FileText,
+            href: '/manage/attachments',
+            permission: 'MANAGE_ATTACHMENTS',
+        },
+    ];
+
+    const teachingActions: QuickActionItem[] = [
+        {
+            label: role === 'admin' ? t('sidebar.admin.posts') : t('sidebar.teacher.posts'),
+            icon: Megaphone,
+            href: (currentRole) => (currentRole === 'admin' ? '/manage/posts' : '/manage/teacher/posts'),
+            permission: 'MANAGE_POSTS',
+        },
+        {
+            label: role === 'admin' ? t('sidebar.admin.labs') : t('sidebar.teacher.labs'),
+            icon: Beaker,
+            href: (currentRole) => (currentRole === 'admin' ? '/manage/labs' : '/manage/teacher/labs'),
+            permission: 'MANAGE_LABS',
+        },
+        ...(role === 'admin'
+            ? [
+                  {
+                      label: t('sidebar.admin.academics'),
+                      icon: GraduationCap,
+                      href: '/manage/academics',
+                      permission: 'MANAGE_ACADEMICS',
+                  } satisfies QuickActionItem,
+              ]
+            : [
+                  {
+                      label: t('sidebar.teacher.projects'),
+                      icon: NotebookPen,
+                      href: '/manage/projects',
+                      permission: 'MANAGE_PROJECTS',
+                  } satisfies QuickActionItem,
+              ]),
+    ];
+
+    const personalActions: QuickActionItem[] = [
+        {
+            label: t('sidebar.user.profile'),
+            icon: Settings,
+            href: '/manage/settings/profile',
+            permission: 'MANAGE_PROFILE',
+        },
+        {
+            label: t('sidebar.user.security'),
+            icon: Settings,
+            href: '/manage/settings/password',
+            permission: 'MANAGE_PASSWORD',
+        },
+    ];
 
     return (
         <div className="space-y-6">
@@ -46,140 +129,31 @@ export default function ManageQuickActions() {
 
             {/* 管理員專用功能 */}
             <RoleGuard allowedRoles={['admin']}>
-                <Card>
-                    <CardHeader>
-                        <CardTitle>管理功能</CardTitle>
-                        <CardDescription>
-                            系統管理與維護功能
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                            {/* 使用者管理 */}
-                            <PermissionGuard permission="MANAGE_USERS">
-                                <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
-                                    <Link href="/manage/users">
-                                        <Users className="h-6 w-6" />
-                                        <span>{t('sidebar.admin.users')}</span>
-                                    </Link>
-                                </Button>
-                            </PermissionGuard>
-
-                            {/* 師資管理 */}
-                            <PermissionGuard permission="MANAGE_STAFF">
-                                <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
-                                    <Link href="/manage/staff">
-                                        <UserCheck className="h-6 w-6" />
-                                        <span>{t('sidebar.admin.staff')}</span>
-                                    </Link>
-                                </Button>
-                            </PermissionGuard>
-
-                            {/* 教室管理 */}
-                            <PermissionGuard permission="MANAGE_CLASSROOMS">
-                                <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
-                                    <Link href="/manage/classrooms">
-                                        <School className="h-6 w-6" />
-                                        <span>{t('sidebar.admin.classrooms')}</span>
-                                    </Link>
-                                </Button>
-                            </PermissionGuard>
-
-                            {/* 聯絡訊息 */}
-                            <PermissionGuard permission="MANAGE_CONTACT_MESSAGES">
-                                <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
-                                    <Link href="/manage/contact-messages">
-                                        <Mail className="h-6 w-6" />
-                                        <span>{t('sidebar.admin.messages')}</span>
-                                    </Link>
-                                </Button>
-                            </PermissionGuard>
-
-                            {/* 附件管理 */}
-                            <PermissionGuard permission="MANAGE_ATTACHMENTS">
-                                <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
-                                    <Link href="/manage/attachments">
-                                        <FileText className="h-6 w-6" />
-                                        <span>{t('sidebar.admin.attachments')}</span>
-                                    </Link>
-                                </Button>
-                            </PermissionGuard>
-                        </div>
-                    </CardContent>
-                </Card>
+                <QuickActionSection
+                    role={role}
+                    title="管理功能"
+                    description="系統管理與維護功能"
+                    actions={adminActions}
+                />
             </RoleGuard>
 
             {/* 教師和管理員共用功能 */}
             <RoleGuard allowedRoles={['admin', 'teacher']}>
-                <Card>
-                    <CardHeader>
-                        <CardTitle>教學管理</CardTitle>
-                        <CardDescription>
-                            內容與學術資源管理
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                            {/* 公告管理 */}
-                            <PermissionGuard permission="MANAGE_POSTS">
-                                <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
-                                    <Link href="/manage/posts">
-                                        <Megaphone className="h-6 w-6" />
-                                        <span>{t('sidebar.teacher.posts')}</span>
-                                    </Link>
-                                </Button>
-                            </PermissionGuard>
-
-                            {/* 實驗室管理 */}
-                            <PermissionGuard permission="MANAGE_LABS">
-                                <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
-                                    <Link href={role === 'admin' ? '/manage/labs' : '/manage/teacher/labs'}>
-                                        <Beaker className="h-6 w-6" />
-                                        <span>{t('sidebar.teacher.labs')}</span>
-                                    </Link>
-                                </Button>
-                            </PermissionGuard>
-
-                            {/* 學程管理 */}
-                            <PermissionGuard permission="MANAGE_ACADEMICS">
-                                <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
-                                    <Link href="/manage/academics">
-                                        <School className="h-6 w-6" />
-                                        <span>{t('sidebar.admin.academics')}</span>
-                                    </Link>
-                                </Button>
-                            </PermissionGuard>
-                        </div>
-                    </CardContent>
-                </Card>
+                <QuickActionSection
+                    role={role}
+                    title="教學管理"
+                    description="內容與學術資源管理"
+                    actions={teachingActions}
+                />
             </RoleGuard>
 
             {/* 個人設定（所有角色共用） */}
-            <Card>
-                <CardHeader>
-                    <CardTitle>個人設定</CardTitle>
-                    <CardDescription>
-                        帳戶與安全設定管理
-                    </CardDescription>
-                </CardHeader>
-                <CardContent>
-                    <div className="grid gap-4 md:grid-cols-2">
-                        <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
-                            <Link href="/manage/settings/profile">
-                                <Settings className="h-6 w-6" />
-                                <span>{t('sidebar.user.profile')}</span>
-                            </Link>
-                        </Button>
-
-                        <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
-                            <Link href="/manage/settings/password">
-                                <Settings className="h-6 w-6" />
-                                <span>{t('sidebar.user.security')}</span>
-                            </Link>
-                        </Button>
-                    </div>
-                </CardContent>
-            </Card>
+            <QuickActionSection
+                role={role}
+                title="個人設定"
+                description="帳戶與安全設定管理"
+                actions={personalActions}
+            />
 
             {/* 除錯資訊（僅開發環境顯示） */}
             {process.env.NODE_ENV === 'development' && (
@@ -193,6 +167,8 @@ export default function ManageQuickActions() {
                         <p>可管理公告: {canManagePosts ? '是' : '否'}</p>
                         <p>可管理實驗室: {canManageLabs ? '是' : '否'}</p>
                         <p>可管理教室: {canManageClassrooms ? '是' : '否'}</p>
+                        <p>可管理學制: {canManageAcademics ? '是' : '否'}</p>
+                        <p>可管理研究專案: {canManageProjects ? '是' : '否'}</p>
                     </CardContent>
                 </Card>
             )}

--- a/resources/js/components/manage/dashboard/quick-action-section.tsx
+++ b/resources/js/components/manage/dashboard/quick-action-section.tsx
@@ -1,0 +1,81 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { PermissionGuard, type PermissionKey } from '@/components/manage/utils/permission-utils';
+import type { ManageRole } from '@/components/manage/manage-brand';
+import { Link } from '@inertiajs/react';
+import type { LucideIcon } from 'lucide-react';
+
+/**
+ * 快速操作項目設定
+ * 以資料結構方式描述按鈕與權限需求
+ */
+export interface QuickActionItem {
+    /** 按鈕標籤文字 */
+    label: string;
+    /** 對應的圖示元件 */
+    icon: LucideIcon;
+    /** 導向連結，可根據角色動態決定 */
+    href: string | ((role: ManageRole) => string);
+    /**
+     * 權限鍵值，若未提供則不做權限檢查
+     * 僅當使用者擁有權限時才會顯示按鈕
+     */
+    permission?: PermissionKey;
+}
+
+interface QuickActionSectionProps {
+    /** 卡片標題 */
+    title: string;
+    /** 卡片描述 */
+    description: string;
+    /** 當前登入角色，用於判斷連結 */
+    role: ManageRole;
+    /** 快速操作項目列表 */
+    actions: QuickActionItem[];
+}
+
+/**
+ * 快速操作按鈕
+ * 依照權限與角色動態顯示
+ */
+function QuickActionButton({ role, action }: { role: ManageRole; action: QuickActionItem }) {
+    const { icon: Icon, label, permission } = action;
+    const href = typeof action.href === 'function' ? action.href(role) : action.href;
+
+    const button = (
+        <Button asChild variant="outline" className="h-auto flex-col gap-2 p-4">
+            <Link href={href}>
+                <Icon className="h-6 w-6" />
+                <span>{label}</span>
+            </Link>
+        </Button>
+    );
+
+    if (!permission) {
+        return button;
+    }
+
+    return <PermissionGuard permission={permission}>{button}</PermissionGuard>;
+}
+
+/**
+ * 快速操作卡片
+ * 接受一組操作項目並統一渲染版型
+ */
+export function QuickActionSection({ title, description, role, actions }: QuickActionSectionProps) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>{title}</CardTitle>
+                <CardDescription>{description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                    {actions.map((action) => (
+                        <QuickActionButton key={action.label} role={role} action={action} />
+                    ))}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/manage/sidebar/manage-sidebar.tsx
+++ b/resources/js/components/manage/sidebar/manage-sidebar.tsx
@@ -99,27 +99,27 @@ export default function ManageSidebar({ role: roleOverride }: ManageSidebarProps
         {
             title: t('sidebar.teacher.dashboard'),
             href: '/manage/dashboard',
-            icon: LayoutGrid
+            icon: LayoutGrid,
         },
         {
             title: t('sidebar.teacher.posts'),
             href: '/manage/teacher/posts',
-            icon: Megaphone
+            icon: Megaphone,
         },
         {
             title: t('sidebar.teacher.labs'),
             href: '/manage/teacher/labs',
-            icon: Beaker
+            icon: Beaker,
         },
         {
-            title: t('sidebar.admin.academics'),
-            href: '/manage/academics',
-            icon: NotebookPen
+            title: t('sidebar.teacher.projects'),
+            href: '/manage/projects',
+            icon: NotebookPen,
         },
         {
             title: t('sidebar.teacher.profile'),
             href: '/manage/settings/profile',
-            icon: Settings
+            icon: Settings,
         },
     ], [t]);
 

--- a/resources/js/components/manage/utils/permission-utils.tsx
+++ b/resources/js/components/manage/utils/permission-utils.tsx
@@ -22,9 +22,9 @@ export const MANAGE_PERMISSIONS = {
     // 學術管理
     MANAGE_LABS: ['admin', 'teacher'] as ManageRole[],
     MANAGE_CLASSROOMS: ['admin'] as ManageRole[],
-    MANAGE_ACADEMICS: ['admin', 'teacher'] as ManageRole[],
+    MANAGE_ACADEMICS: ['admin'] as ManageRole[],
     MANAGE_PROGRAMS: ['admin'] as ManageRole[],
-    MANAGE_PROJECTS: ['admin'] as ManageRole[],
+    MANAGE_PROJECTS: ['admin', 'teacher'] as ManageRole[],
     MANAGE_PUBLICATIONS: ['admin'] as ManageRole[],
 
     // 個人設定

--- a/resources/js/pages/manage/academics/index.tsx
+++ b/resources/js/pages/manage/academics/index.tsx
@@ -5,8 +5,8 @@ import { useTranslator } from '@/hooks/use-translator';
 import type { BreadcrumbItem } from '@/types';
 
 /**
- * 學術課程與學程管理頁面
- * 提供課程與學程資料的檢視和管理功能
+ * 學制管理頁面
+ * 提供學制與修業資訊的檢視和管理功能
  */
 export default function AcademicsIndex() {
     const { t } = useTranslator('manage');
@@ -22,8 +22,8 @@ export default function AcademicsIndex() {
 
             <ManagePageHeader
                 title={t('sidebar.admin.academics')}
-                description="管理系所課程與學程資訊"
-                badge={{ label: "學術管理" }}
+                description="管理學制架構與修業規定"
+                badge={{ label: "學制管理" }}
             />
 
             <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
@@ -33,7 +33,7 @@ export default function AcademicsIndex() {
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                         </svg>
                     </div>
-                    <h3 className="mt-2 text-sm font-medium text-gray-900">學術管理功能開發中</h3>
+                    <h3 className="mt-2 text-sm font-medium text-gray-900">學制管理功能開發中</h3>
                     <p className="mt-1 text-sm text-gray-500">
                         此功能正在開發中，敬請期待
                     </p>

--- a/resources/js/pages/manage/dashboard.tsx
+++ b/resources/js/pages/manage/dashboard.tsx
@@ -203,9 +203,9 @@ export default function Dashboard() {
                     icon: NotebookPen,
                 },
                 {
-                    href: '/manage/academics',
-                    label: t('dashboard.admin.actions.academics.label'),
-                    description: t('dashboard.admin.actions.academics.description'),
+                    href: '/manage/projects',
+                    label: t('dashboard.teacher.actions.projects.label'),
+                    description: t('dashboard.teacher.actions.projects.description'),
                     icon: BookOpen,
                 },
                 {

--- a/routes/manage.php
+++ b/routes/manage.php
@@ -66,9 +66,11 @@ Route::middleware(['auth', 'role:admin|teacher'])
         Route::resource('projects', AdminProjectController::class);
         Route::resource('publications', AdminPublicationController::class);
 
-        // 課程修業管理
-        Route::get('academics', [AdminAcademicController::class, 'index'])->name('academics.index');
-        Route::resource('programs', AdminProgramController::class);
+        // 學制管理僅限管理員使用
+        Route::middleware('role:admin')->group(function () {
+            Route::get('academics', [AdminAcademicController::class, 'index'])->name('academics.index');
+            Route::resource('programs', AdminProgramController::class);
+        });
 
         // 聯絡我們管理
         Route::resource('contact-messages', AdminContactMessageController::class);


### PR DESCRIPTION
## Summary
- rename the admin academic tools to program management and restrict them to administrators
- componentize the dashboard quick actions and adjust teacher navigation to focus on labs and research projects
- refresh translations and placeholders to reflect the new academic management naming

## Testing
- npm run test -- --runInBand --watch=false *(fails: jest cannot resolve aliased UI components)*

------
https://chatgpt.com/codex/tasks/task_e_68da73b530b48323a536618fc3033def