### PR TITLE
Fix date picker locale for English admin filters

### DIFF
--- a/resources/js/components/manage/post/post-filter-form.tsx
+++ b/resources/js/components/manage/post/post-filter-form.tsx
@@ -37,7 +37,8 @@ export function PostFilterForm({
 }: PostFilterFormProps) {
     // 依語系提供對應預設文案，避免英文介面顯示中文字。
     const fallbackText = (zh: string, en: string) => (fallbackLanguage === 'zh' ? zh : en);
-    const dateInputLocale = fallbackLanguage === 'zh' ? 'zh-Hant-TW' : 'en';
+    // 以對應語系設定日期輸入的語言，確保英文介面不會顯示中文的年/月/日字樣。
+    const dateInputLocale = fallbackLanguage === 'zh' ? 'zh-Hant-TW' : 'en-CA';
 
     return (
         <Card className="border border-slate-200 bg-white shadow-sm">

--- a/resources/js/components/manage/users/user-filter-form.tsx
+++ b/resources/js/components/manage/users/user-filter-form.tsx
@@ -37,6 +37,8 @@ export function UserFilterForm({
 }: UserFilterFormProps) {
     // 依語系提供預設字串，確保中英文介面都有合適提示。
     const fallbackText = (zh: string, en: string) => (fallbackLanguage === 'zh' ? zh : en);
+    // 依語系設定日期輸入語言，避免英文介面顯示中文的年/月/日。
+    const dateInputLocale = fallbackLanguage === 'zh' ? 'zh-Hant-TW' : 'en-CA';
 
     return (
         <Card className="border border-slate-200 bg-white shadow-sm">
@@ -108,6 +110,7 @@ export function UserFilterForm({
                             type="date"
                             value={filterState.created_from}
                             onChange={(event) => onChange('created_from', event.target.value)}
+                            lang={dateInputLocale}
                         />
                     </div>
 
@@ -120,6 +123,7 @@ export function UserFilterForm({
                             type="date"
                             value={filterState.created_to}
                             onChange={(event) => onChange('created_to', event.target.value)}
+                            lang={dateInputLocale}
                         />
                     </div>
 


### PR DESCRIPTION
## Summary
- update the post and user filter forms to choose the proper locale for date inputs
- ensure the English interface uses a western locale so the placeholder no longer shows Chinese characters

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da7b065a2c8323bae6c14a634f5d37