### PR TITLE
Add employment tracking to staff and teacher profiles

### DIFF
--- a/app/Models/Staff.php
+++ b/app/Models/Staff.php
@@ -2,20 +2,39 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Builder;
 
 class Staff extends Model
 {
     use HasFactory, SoftDeletes;
 
     protected $fillable = [
-        'email','phone','photo_url','name','name_en','position','position_en','bio','bio_en','sort_order','visible',
+        'email',
+        'phone',
+        'photo_url',
+        'name',
+        'name_en',
+        'position',
+        'position_en',
+        'bio',
+        'bio_en',
+        'sort_order',
+        'visible',
+        'user_id',
+        'employment_status',
+        'employment_started_at',
+        'employment_ended_at',
     ];
 
     protected $casts = [
         'visible' => 'boolean',
+        'employment_started_at' => 'datetime',
+        'employment_ended_at' => 'datetime',
     ];
 
     protected $attributes = [
@@ -162,6 +181,38 @@ class Staff extends Model
     public function classrooms()
     {
         return $this->belongsToMany(Classroom::class, 'classroom_staff');
+    }
+
+    /**
+     * 與使用者帳號的關聯。
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * 若教職員身兼教師，可透過 user_id 對應教師檔案。
+     */
+    public function teacherProfile(): HasOne
+    {
+        return $this->hasOne(Teacher::class, 'user_id', 'user_id');
+    }
+
+    /**
+     * 範圍：只取得目前在職的職員。
+     */
+    public function scopeCurrentlyEmployed(Builder $query): Builder
+    {
+        return $query->where('employment_status', 'active');
+    }
+
+    /**
+     * 範圍：取得已離開或暫時不在職的職員。
+     */
+    public function scopeFormerlyEmployed(Builder $query): Builder
+    {
+        return $query->whereIn('employment_status', ['inactive', 'retired', 'left']);
     }
 }
 

--- a/database/factories/TeacherFactory.php
+++ b/database/factories/TeacherFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Teacher;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Teacher>
@@ -11,12 +12,14 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 class TeacherFactory extends Factory
 {
     /**
-     * Define the model's default state.
+     * 定義模型預設狀態。
      *
      * @return array<string, mixed>
      */
     public function definition(): array
     {
+        $startedAt = Carbon::instance($this->faker->dateTimeBetween('-10 years', 'now'));
+
         return [
             'office' => $this->faker->optional()->regexify('Room [0-9]{3}'),
             'phone' => $this->faker->optional()->phoneNumber(),
@@ -34,44 +37,51 @@ class TeacherFactory extends Factory
                 'Mobile Development',
                 'Database Systems',
                 'Network Administration',
-                'Information Systems'
+                'Information Systems',
             ]),
             'expertise_en' => $this->faker->optional()->randomElement([
                 'Computer Science',
                 'Software Engineering',
-                'Data Science'
+                'Data Science',
             ]),
             'bio' => $this->faker->optional()->paragraph(3),
             'bio_en' => $this->faker->optional()->paragraph(3),
             'education' => $this->faker->optional()->paragraph(2),
             'education_en' => $this->faker->optional()->paragraph(2),
             'sort_order' => $this->faker->numberBetween(0, 100),
-            'visible' => $this->faker->randomElement([true, true, true, false]), // 75% visible
+            'visible' => $this->faker->randomElement([true, true, true, false]),
+            'user_id' => null,
+            'employment_status' => 'active',
+            'employment_started_at' => $startedAt,
+            'employment_ended_at' => null,
         ];
     }
 
     /**
-     * Indicate that the teacher is active.
+     * 標記教師為顯示狀態。
      */
     public function active(): static
     {
         return $this->state(fn (array $attributes) => [
             'visible' => true,
+            'employment_status' => 'active',
+            'employment_ended_at' => null,
         ]);
     }
 
     /**
-     * Indicate that the teacher is inactive.
+     * 標記教師為隱藏狀態。
      */
     public function inactive(): static
     {
         return $this->state(fn (array $attributes) => [
             'visible' => false,
+            'employment_status' => 'inactive',
         ]);
     }
 
     /**
-     * Create a teacher with a specific specialty (mapped to expertise).
+     * 指定專長領域。
      */
     public function withSpecialty(string $specialty): static
     {
@@ -81,7 +91,7 @@ class TeacherFactory extends Factory
     }
 
     /**
-     * Create a teacher with complete information.
+     * 產生完整教師資料。
      */
     public function complete(): static
     {
@@ -95,18 +105,38 @@ class TeacherFactory extends Factory
             'expertise' => $this->faker->randomElement([
                 'Computer Science',
                 'Software Engineering',
-                'Data Science'
+                'Data Science',
             ]),
             'expertise_en' => $this->faker->randomElement([
                 'Computer Science',
                 'Software Engineering',
-                'Data Science'
+                'Data Science',
             ]),
             'bio' => $this->faker->paragraph(3),
             'bio_en' => $this->faker->paragraph(3),
             'education' => $this->faker->paragraph(2),
             'education_en' => $this->faker->paragraph(2),
             'visible' => true,
+            'employment_status' => 'active',
+            'employment_ended_at' => null,
         ]);
+    }
+
+    /**
+     * 標記教師為退休或離職。
+     */
+    public function former(string $status = 'retired'): static
+    {
+        return $this->state(function (array $attributes) use ($status) {
+            $endedAt = Carbon::instance($this->faker->dateTimeBetween('-2 years', 'now'));
+
+            return [
+                'employment_status' => $status,
+                'employment_ended_at' => $endedAt,
+                'employment_started_at' => Carbon::instance(
+                    $this->faker->dateTimeBetween('-20 years', $endedAt->copy()->subMonths(6))
+                ),
+            ];
+        });
     }
 }

--- a/database/migrations/2025_09_13_100100_create_teachers_and_staff_tables.php
+++ b/database/migrations/2025_09_13_100100_create_teachers_and_staff_tables.php
@@ -22,6 +22,9 @@ return new class extends Migration
             $table->string('title_en');
             $table->longText('bio')->nullable();
             $table->longText('bio_en')->nullable();
+            $table->enum('employment_status', ['active', 'inactive', 'retired', 'left'])->default('active')->index();
+            $table->timestamp('employment_started_at')->nullable();
+            $table->timestamp('employment_ended_at')->nullable();
             $table->text('expertise')->nullable();
             $table->text('expertise_en')->nullable();
             $table->text('education')->nullable();
@@ -30,6 +33,8 @@ return new class extends Migration
             $table->boolean('visible')->default(true)->index();
             $table->softDeletes();
             $table->timestamps();
+
+            $table->unique('user_id');
         });
 
         Schema::create('teacher_links', function (Blueprint $table) {
@@ -44,6 +49,7 @@ return new class extends Migration
 
         Schema::create('staff', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
             $table->string('email')->nullable();
             $table->string('phone')->nullable();
             $table->string('photo_url')->nullable();
@@ -53,10 +59,15 @@ return new class extends Migration
             $table->string('position_en');
             $table->longText('bio')->nullable();
             $table->longText('bio_en')->nullable();
+            $table->enum('employment_status', ['active', 'inactive', 'retired', 'left'])->default('active')->index();
+            $table->timestamp('employment_started_at')->nullable();
+            $table->timestamp('employment_ended_at')->nullable();
             $table->integer('sort_order')->default(0);
             $table->boolean('visible')->default(true);
             $table->softDeletes();
             $table->timestamps();
+
+            $table->unique('user_id');
         });
     }
 

--- a/tests/Feature/Manage/StaffTeacherEmploymentStatusTest.php
+++ b/tests/Feature/Manage/StaffTeacherEmploymentStatusTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Manage;
+
+use App\Models\Staff;
+use App\Models\Teacher;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StaffTeacherEmploymentStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_helpers_and_relationships_reflect_employment_status(): void
+    {
+        $user = User::factory()->create();
+
+        $staff = Staff::factory()->create([
+            'user_id' => $user->id,
+            'email' => $user->email,
+            'employment_status' => 'active',
+            'employment_started_at' => now()->subYears(2),
+        ]);
+
+        $teacher = Teacher::factory()->create([
+            'user_id' => $user->id,
+            'email' => $user->email,
+            'employment_status' => 'active',
+            'employment_started_at' => now()->subYears(3),
+        ]);
+
+        $user->load(['teacher', 'staff']);
+
+        $this->assertTrue($user->hasActiveStaffProfile());
+        $this->assertTrue($user->hasActiveTeacherProfile());
+        $this->assertTrue($teacher->fresh()->staffProfile?->is($staff));
+        $this->assertTrue($staff->fresh()->teacherProfile?->is($teacher));
+
+        $teacher->update([
+            'employment_status' => 'retired',
+            'employment_ended_at' => now()->subMonth(),
+        ]);
+
+        $user->unsetRelation('teacher');
+        $this->assertFalse($user->fresh()->hasActiveTeacherProfile());
+    }
+
+    public function test_scopes_filter_current_and_former_records(): void
+    {
+        Staff::factory()->count(2)->create([
+            'employment_status' => 'active',
+            'employment_ended_at' => null,
+        ]);
+        Staff::factory()->former('left')->create();
+
+        $this->assertCount(2, Staff::currentlyEmployed()->get());
+        $this->assertCount(1, Staff::formerlyEmployed()->get());
+
+        Teacher::factory()->count(3)->create([
+            'employment_status' => 'active',
+            'employment_ended_at' => null,
+        ]);
+        Teacher::factory()->former('inactive')->create();
+
+        $this->assertCount(3, Teacher::currentlyEmployed()->get());
+        $this->assertCount(1, Teacher::formerlyEmployed()->get());
+    }
+}


### PR DESCRIPTION
## Summary
- embed the employment metadata and user associations directly into the original staff and teacher table migration
- extend staff, teacher, and user models with fillable/cast updates, relationships, and helpers for employment status checks
- update staff/teacher factories and add a regression test covering the new scopes and user convenience methods

## Testing
- php artisan test --filter StaffTeacherEmploymentStatusTest

------
https://chatgpt.com/codex/tasks/task_e_68da84a1abd48323875e7a26d68d7277