### PR TITLE
fix: load user relations in teacher manage pages

### DIFF
--- a/app/Http/Controllers/Manage/Admin/StaffController.php
+++ b/app/Http/Controllers/Manage/Admin/StaffController.php
@@ -6,9 +6,11 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Manage\Admin\StoreStaffRequest;
 use App\Http\Requests\Manage\Admin\UpdateStaffRequest;
 use App\Http\Resources\StaffResource;
+use App\Http\Resources\TeacherResource;
 use App\Models\Staff;
 use App\Models\Teacher;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Inertia\Inertia;
 
 class StaffController extends Controller
@@ -19,115 +21,137 @@ class StaffController extends Controller
         $this->authorizeResource(Staff::class, 'staff');
     }
 
-    // 列出所有職員
+    // 列出所有職員與教師，提供統一的資料結構與篩選功能
     public function index(Request $request)
     {
         $activeTab = $request->query('tab');
         if (! in_array($activeTab, ['teachers', 'staff'], true)) {
-            $activeTab = 'teachers';
+            $activeTab = 'staff';
         }
 
-        $staff = Staff::orderBy('sort_order')
-            ->orderBy('name')
-            ->get()
-            ->map(function (Staff $member) {
-                return [
-                    'id' => $member->id,
-                    'name' => $member->name,
-                    'name_en' => $member->name_en,
-                    'position' => $member->position,
-                    'position_en' => $member->position_en,
-                    'email' => $member->email,
-                    'phone' => $member->phone,
-                    'photo_url' => $member->photo_url,
-                    'bio' => $member->bio,
-                    'bio_en' => $member->bio_en,
-                    'sort_order' => $member->sort_order,
-                    'visible' => $member->visible,
-                ];
-            });
+        $search = trim((string) $request->query('search', ''));
+        $statusFilter = $request->query('status');
+        $visibleFilter = $request->query('visible');
 
-        $trashedStaff = Staff::onlyTrashed()
-            ->orderByDesc('deleted_at')
-            ->orderBy('name')
-            ->get()
-            ->map(function (Staff $member) {
-                return [
-                    'id' => $member->id,
-                    'name' => $member->name,
-                    'name_en' => $member->name_en,
-                    'position' => $member->position,
-                    'position_en' => $member->position_en,
-                    'email' => $member->email,
-                    'phone' => $member->phone,
-                    'deleted_at' => $member->deleted_at,
-                ];
-            });
+        $perPage = (int) $request->input('per_page', 15);
+        $perPage = max(1, min(200, $perPage));
 
-        $teachersPerPage = (int) $request->input('per_page', 15);
-        if ($teachersPerPage < 1) {
-            $teachersPerPage = 15;
-        }
+        $statusWhitelist = ['active', 'inactive', 'retired', 'left'];
+        $visibilityResolver = function ($value) {
+            if ($value === null || $value === '') {
+                return null;
+            }
 
-        if ($teachersPerPage > 200) {
-            $teachersPerPage = 200;
-        }
+            $normalized = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
 
-        $teachers = Teacher::with([
-                'labs:id,name,name_en',
-            ])
+            return $normalized;
+        };
+
+        $staffQuery = Staff::query()
+            ->with(['user'])
+            ->when($search !== '', fn ($query) => $query->search($search))
+            ->when(
+                $statusFilter && in_array($statusFilter, $statusWhitelist, true),
+                fn ($query) => $query->where('employment_status', $statusFilter)
+            )
+            ->when(
+                $visibilityResolver($visibleFilter) !== null,
+                fn ($query) => $query->where('visible', $visibilityResolver($visibleFilter))
+            )
             ->orderBy('sort_order')
-            ->orderBy('name')
-            ->paginate($teachersPerPage);
+            ->orderBy('name');
 
-        $teachers->getCollection()->transform(function (Teacher $teacher) {
-            return [
-                'id' => $teacher->id,
-                'name' => $teacher->name,
-                'name_en' => $teacher->name_en,
-                'title' => $teacher->title,
-                'title_en' => $teacher->title_en,
-                'email' => $teacher->email,
-                'phone' => $teacher->phone,
-                'office' => $teacher->office,
-                'job_title' => $teacher->job_title,
-                'photo_url' => $teacher->photo_url,
-                'bio' => $teacher->bio,
-                'bio_en' => $teacher->bio_en,
-                'expertise' => $teacher->expertise,
-                'expertise_en' => $teacher->expertise_en,
-                'education' => $teacher->education,
-                'education_en' => $teacher->education_en,
-                'sort_order' => $teacher->sort_order,
-                'visible' => $teacher->visible,
-                'labs' => $teacher->labs->map(function ($lab) {
-                    return [
-                        'id' => $lab->id,
-                        'name' => $lab->name,
-                        'name_en' => $lab->name_en,
-                    ];
-                })->all(),
-            ];
-        });
+        $staffActive = StaffResource::collection(
+            (clone $staffQuery)->get()
+        )->toArray($request);
 
-        $teachers->withQueryString();
+        $staffTrashed = StaffResource::collection(
+            (clone $staffQuery)->onlyTrashed()->get()
+        )->toArray($request);
+
+        $teacherQuery = Teacher::query()
+            ->with(['user', 'labs:id,code,name,name_en'])
+            ->when($search !== '', fn ($query) => $query->search($search))
+            ->when(
+                $statusFilter && in_array($statusFilter, $statusWhitelist, true),
+                fn ($query) => $query->where('employment_status', $statusFilter)
+            )
+            ->when(
+                $visibilityResolver($visibleFilter) !== null,
+                fn ($query) => $query->where('visible', $visibilityResolver($visibleFilter))
+            )
+            ->orderBy('sort_order')
+            ->orderBy('name');
+
+        $teacherPaginator = (clone $teacherQuery)->paginate($perPage)->appends($request->query());
+
+        $teacherData = TeacherResource::collection(
+            $teacherPaginator->getCollection()
+        )->toArray($request);
+
+        $teacherTrashed = TeacherResource::collection(
+            (clone $teacherQuery)->onlyTrashed()->get()
+        )->toArray($request);
+
+        $teacherLinks = collect($teacherPaginator->linkCollection())->map(function ($link) {
+            return Arr::only($link, ['url', 'label', 'active']);
+        })->values()->toArray();
 
         return Inertia::render('manage/staff/index', [
             'initialTab' => $activeTab,
             'staff' => [
-                'active' => $staff,
-                'trashed' => $trashedStaff,
+                'active' => $staffActive,
+                'trashed' => $staffTrashed,
             ],
-            'teachers' => $teachers,
-            'perPage' => $teachersPerPage,
+            'teachers' => [
+                'data' => $teacherData,
+                'trashed' => $teacherTrashed,
+                'meta' => [
+                    'current_page' => $teacherPaginator->currentPage(),
+                    'last_page' => $teacherPaginator->lastPage(),
+                    'per_page' => $teacherPaginator->perPage(),
+                    'total' => $teacherPaginator->total(),
+                    'from' => $teacherPaginator->firstItem() ?? 0,
+                    'to' => $teacherPaginator->lastItem() ?? 0,
+                ],
+                'links' => $teacherLinks,
+            ],
+            'filters' => [
+                'search' => $search,
+                'status' => $statusFilter,
+                'visible' => $visibleFilter,
+                'per_page' => $teacherPaginator->perPage(),
+            ],
             'perPageOptions' => [15, 30, 50, 100, 200],
+            'employmentStatusOptions' => [
+                ['value' => '', 'label' => '全部狀態'],
+                ['value' => 'active', 'label' => '在職'],
+                ['value' => 'inactive', 'label' => '暫離'],
+                ['value' => 'retired', 'label' => '退休'],
+                ['value' => 'left', 'label' => '離職'],
+            ],
+            'visibilityOptions' => [
+                ['value' => '', 'label' => '顯示全部'],
+                ['value' => '1', 'label' => '僅顯示前台'],
+                ['value' => '0', 'label' => '僅顯示隱藏'],
+            ],
         ]);
     }
 
     // 顯示新增職員表單
     public function create()
     {
-        return Inertia::render('manage/staff/create');
+        return Inertia::render('manage/staff/create', [
+            'staff' => null,
+        ]);
+    }
+
+    // 顯示職員詳細資料
+    public function show(Staff $staff)
+    {
+        return Inertia::render('manage/staff/show', [
+            'staff' => (new StaffResource($staff->load(['user'])))->resolve(),
+        ]);
     }
 
     // 儲存新的職員
@@ -150,14 +174,14 @@ class StaffController extends Controller
         $staff->classrooms()->sync($classroomIds);
 
         return redirect()->route('manage.staff.index')
-            ->with('success', __('manage.success.created', ['item' => __('manage.staff.title')]));
+            ->with('success', __('manage.success.created', ['item' => __('manage.staff.index.title')]));
     }
 
     // 顯示編輯表單
     public function edit(Staff $staff)
     {
         return Inertia::render('manage/staff/edit', [
-            'staff' => new StaffResource($staff),
+            'staff' => (new StaffResource($staff->load(['user'])))->resolve(),
         ]);
     }
 
@@ -180,7 +204,7 @@ class StaffController extends Controller
         $staff->classrooms()->sync($classroomIds);
 
         return redirect()->route('manage.staff.index')
-            ->with('success', __('manage.success.updated', ['item' => __('manage.staff.title')]));
+            ->with('success', __('manage.success.updated', ['item' => __('manage.staff.index.title')]));
     }
 
     // 刪除職員
@@ -188,7 +212,50 @@ class StaffController extends Controller
     {
         $staff->delete();
         return redirect()->route('manage.staff.index')
-            ->with('success', __('manage.success.deleted', ['item' => __('manage.staff.title')]));
+            ->with('success', __('manage.success.deleted', ['item' => __('manage.staff.index.title')]));
+    }
+
+    // 切換職員的在職狀態
+    public function toggleStatus(Request $request, Staff $staff)
+    {
+        $this->authorize('update', $staff);
+
+        $status = $request->input('status');
+        $allowed = ['active', 'inactive', 'retired', 'left'];
+
+        if ($status && ! in_array($status, $allowed, true)) {
+            return back()->withErrors([
+                'status' => '無效的在職狀態。',
+            ]);
+        }
+
+        $nextStatus = $status ?: ($staff->employment_status === 'active' ? 'inactive' : 'active');
+        $staff->employment_status = $nextStatus;
+
+        if ($request->boolean('sync_visibility', true)) {
+            if ($nextStatus === 'active' && $request->boolean('restore_visibility', true)) {
+                $staff->visible = true;
+            }
+
+            if ($nextStatus !== 'active' && $request->boolean('hide_inactive', true)) {
+                $staff->visible = false;
+            }
+        }
+
+        $staff->save();
+
+        return back()->with('success', __('manage.success.updated', ['item' => __('manage.staff.index.title')]));
+    }
+
+    // 切換職員的前台顯示狀態
+    public function toggleVisibility(Staff $staff)
+    {
+        $this->authorize('update', $staff);
+
+        $staff->visible = ! $staff->visible;
+        $staff->save();
+
+        return back()->with('success', __('manage.success.updated', ['item' => __('manage.staff.index.title')]));
     }
 
     public function restore(int $staff)
@@ -198,7 +265,8 @@ class StaffController extends Controller
 
         $record->restore();
 
-        return redirect()->route('manage.staff.index')->with('success', '職員已復原');
+        return redirect()->route('manage.staff.index')
+            ->with('success', __('manage.success.updated', ['item' => __('manage.staff.index.title')]));
     }
 
     public function forceDelete(int $staff)
@@ -208,6 +276,7 @@ class StaffController extends Controller
 
         $record->forceDelete();
 
-        return redirect()->route('manage.staff.index')->with('success', '職員已永久刪除');
+        return redirect()->route('manage.staff.index')
+            ->with('success', __('manage.success.deleted', ['item' => __('manage.staff.index.title')]));
     }
 }

--- a/app/Http/Controllers/Manage/Admin/TeacherController.php
+++ b/app/Http/Controllers/Manage/Admin/TeacherController.php
@@ -46,7 +46,7 @@ class TeacherController extends Controller
         $teacher = Teacher::create($validated);
 
         return redirect()->route('manage.staff.index', ['tab' => 'teachers'])
-            ->with('success', __('manage.success.created', ['item' => __('manage.teacher.title')]));
+            ->with('success', __('manage.success.created', ['item' => __('manage.staff.teachers.title')]));
     }
 
     /**
@@ -55,7 +55,14 @@ class TeacherController extends Controller
     public function show(Teacher $teacher)
     {
         return Inertia::render('manage/teachers/show', [
-            'teacher' => new TeacherResource($teacher->load(['links', 'projects', 'publications'])),
+            // 一次載入相關關聯，確保資源可以輸出完整資訊
+            'teacher' => new TeacherResource($teacher->load([
+                'user',
+                'links',
+                'projects',
+                'publications',
+                'labs:id,code,name,name_en',
+            ])),
         ]);
     }
 
@@ -65,7 +72,11 @@ class TeacherController extends Controller
     public function edit(Teacher $teacher)
     {
         return Inertia::render('manage/teachers/edit', [
-            'teacher' => new TeacherResource($teacher->load(['links'])),
+            'teacher' => new TeacherResource($teacher->load([
+                'user',
+                'links',
+                'labs:id,code,name,name_en',
+            ])),
         ]);
     }
 
@@ -83,7 +94,7 @@ class TeacherController extends Controller
         $teacher->update($validated);
 
         return redirect()->route('manage.staff.index', ['tab' => 'teachers'])
-            ->with('success', __('manage.success.updated', ['item' => __('manage.teacher.title')]));
+            ->with('success', __('manage.success.updated', ['item' => __('manage.staff.teachers.title')]));
     }
 
     /**
@@ -94,6 +105,73 @@ class TeacherController extends Controller
         $teacher->delete();
 
         return redirect()->route('manage.staff.index', ['tab' => 'teachers'])
-            ->with('success', __('manage.success.deleted', ['item' => __('manage.teacher.title')]));
+            ->with('success', __('manage.success.deleted', ['item' => __('manage.staff.teachers.title')]));
+    }
+
+    // 切換教師的在職狀態
+    public function toggleStatus(Request $request, Teacher $teacher)
+    {
+        $this->authorize('update', $teacher);
+
+        $status = $request->input('status');
+        $allowed = ['active', 'inactive', 'retired', 'left'];
+
+        if ($status && ! in_array($status, $allowed, true)) {
+            return back()->withErrors([
+                'status' => '無效的在職狀態。',
+            ]);
+        }
+
+        $nextStatus = $status ?: ($teacher->employment_status === 'active' ? 'inactive' : 'active');
+        $teacher->employment_status = $nextStatus;
+
+        if ($request->boolean('sync_visibility', true)) {
+            if ($nextStatus === 'active' && $request->boolean('restore_visibility', true)) {
+                $teacher->visible = true;
+            }
+
+            if ($nextStatus !== 'active' && $request->boolean('hide_inactive', true)) {
+                $teacher->visible = false;
+            }
+        }
+
+        $teacher->save();
+
+        return back()->with('success', __('manage.success.updated', ['item' => __('manage.staff.teachers.title')]));
+    }
+
+    // 切換教師的前台顯示狀態
+    public function toggleVisibility(Teacher $teacher)
+    {
+        $this->authorize('update', $teacher);
+
+        $teacher->visible = ! $teacher->visible;
+        $teacher->save();
+
+        return back()->with('success', __('manage.success.updated', ['item' => __('manage.staff.teachers.title')]));
+    }
+
+    // 還原被軟刪除的教師資料
+    public function restore(int $teacher)
+    {
+        $record = Teacher::onlyTrashed()->findOrFail($teacher);
+        $this->authorize('restore', $record);
+
+        $record->restore();
+
+        return redirect()->route('manage.staff.index', ['tab' => 'teachers'])
+            ->with('success', __('manage.success.updated', ['item' => __('manage.staff.teachers.title')]));
+    }
+
+    // 永久刪除教師資料
+    public function forceDelete(int $teacher)
+    {
+        $record = Teacher::onlyTrashed()->findOrFail($teacher);
+        $this->authorize('forceDelete', $record);
+
+        $record->forceDelete();
+
+        return redirect()->route('manage.staff.index', ['tab' => 'teachers'])
+            ->with('success', __('manage.success.deleted', ['item' => __('manage.staff.teachers.title')]));
     }
 }

--- a/app/Http/Resources/StaffResource.php
+++ b/app/Http/Resources/StaffResource.php
@@ -4,30 +4,56 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class StaffResource extends JsonResource
 {
     /**
-     * Transform the resource into an array.
+     * 將職員資料轉換為統一結構，供 Inertia 前端使用。
      *
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array
     {
+        $photoPath = $this->photo_url ?? null;
+        $photoUrl = null;
+
+        if ($photoPath) {
+            if (Str::startsWith($photoPath, ['http://', 'https://', '/'])) {
+                $photoUrl = $photoPath;
+            } elseif (Storage::disk('public')->exists($photoPath)) {
+                $photoUrl = Storage::disk('public')->url($photoPath);
+            } else {
+                $photoUrl = asset($photoPath);
+            }
+        }
+
         return [
             'id' => $this->id,
-            'name' => $this->name, // JSON object with localized content
-            'position' => $this->position, // JSON object with localized content
+            'name' => $this->name,
+            'position' => $this->position,
             'email' => $this->email,
             'phone' => $this->phone,
             'office' => $this->office,
-            'bio' => $this->bio, // JSON object with localized content
-            'avatar' => $this->avatar,
-            'avatar_url' => $this->avatar ? asset('storage/' . $this->avatar) : null,
-            'visible' => $this->visible,
+            'bio' => $this->bio,
+            'avatar_url' => $photoUrl,
+            'visible' => (bool) $this->visible,
             'sort_order' => $this->sort_order,
-            'created_at' => $this->created_at,
-            'updated_at' => $this->updated_at,
+            'employment_status' => $this->employment_status,
+            'employment_started_at' => $this->employment_started_at?->toDateString(),
+            'employment_ended_at' => $this->employment_ended_at?->toDateString(),
+            'deleted_at' => $this->deleted_at?->toDateTimeString(),
+            'created_at' => $this->created_at?->toDateTimeString(),
+            'updated_at' => $this->updated_at?->toDateTimeString(),
+            'user' => $this->whenLoaded('user', function ($user) {
+                return [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'role' => $user->role,
+                ];
+            }),
         ];
     }
 }

--- a/app/Http/Resources/TeacherResource.php
+++ b/app/Http/Resources/TeacherResource.php
@@ -4,42 +4,77 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class TeacherResource extends JsonResource
 {
     /**
-     * Transform the resource into an array.
+     * 將教師資料轉換為統一結構，供 Inertia 前端使用。
      *
      * @return array<string, mixed>
      */
     public function toArray($request): array
     {
+        $photoPath = $this->photo_url ?? null;
+        $photoUrl = null;
+
+        if ($photoPath) {
+            if (Str::startsWith($photoPath, ['http://', 'https://', '/'])) {
+                $photoUrl = $photoPath;
+            } elseif (Storage::disk('public')->exists($photoPath)) {
+                $photoUrl = Storage::disk('public')->url($photoPath);
+            } else {
+                $photoUrl = asset($photoPath);
+            }
+        }
+
         return [
             'id' => $this->id,
+            'name' => $this->name,
+            'title' => $this->title,
             'email' => $this->email,
             'phone' => $this->phone,
             'office' => $this->office,
             'job_title' => $this->job_title,
-            'avatar_url' => $this->avatar,
-            'name' => $this->name,
-            'title' => $this->title,
             'bio' => $this->bio,
             'expertise' => $this->expertise,
             'education' => $this->education,
+            'avatar_url' => $photoUrl,
+            'visible' => (bool) $this->visible,
             'sort_order' => $this->sort_order,
-            'visible' => $this->visible,
-            'created_at' => $this->created_at,
-            'updated_at' => $this->updated_at,
-
-            // Conditional relationships
+            'employment_status' => $this->employment_status,
+            'employment_started_at' => $this->employment_started_at?->toDateString(),
+            'employment_ended_at' => $this->employment_ended_at?->toDateString(),
+            'deleted_at' => $this->deleted_at?->toDateTimeString(),
+            'created_at' => $this->created_at?->toDateTimeString(),
+            'updated_at' => $this->updated_at?->toDateTimeString(),
+            'user' => $this->whenLoaded('user', function ($user) {
+                return [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'role' => $user->role,
+                ];
+            }),
+            'labs' => $this->whenLoaded('labs', function () {
+                return $this->labs->map(function ($lab) {
+                    return [
+                        'id' => $lab->id,
+                        'code' => $lab->code,
+                        'name' => [
+                            'zh-TW' => $lab->name,
+                            'en' => $lab->name_en,
+                        ],
+                    ];
+                })->values();
+            }),
             $this->mergeWhen($this->relationLoaded('links'), [
                 'links' => $this->whenLoaded('links'),
             ]),
-
             $this->mergeWhen($this->relationLoaded('publications'), [
                 'publications' => $this->whenLoaded('publications'),
             ]),
-
             $this->mergeWhen($this->relationLoaded('projects'), [
                 'projects' => $this->whenLoaded('projects'),
             ]),

--- a/app/Policies/TeacherPolicy.php
+++ b/app/Policies/TeacherPolicy.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Teacher;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TeacherPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return in_array($user->role, ['admin', 'teacher'], true);
+    }
+
+    public function view(User $user, Teacher $teacher): bool
+    {
+        return in_array($user->role, ['admin', 'teacher'], true);
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    public function update(User $user, Teacher $teacher): bool
+    {
+        if ($user->role === 'admin') {
+            return true;
+        }
+
+        if ($user->role === 'teacher') {
+            return (int) $teacher->getAttribute('user_id') === $user->id;
+        }
+
+        return false;
+    }
+
+    public function delete(User $user, Teacher $teacher): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    public function restore(User $user, Teacher $teacher): bool
+    {
+        return $user->role === 'admin';
+    }
+
+    public function forceDelete(User $user, Teacher $teacher): bool
+    {
+        return $user->role === 'admin';
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -7,6 +7,7 @@ use App\Models\Classroom;
 use App\Models\Lab;
 use App\Models\Post;
 use App\Models\Publication;
+use App\Models\Teacher;
 use App\Models\Staff;
 use App\Models\Tag;
 use App\Models\User;
@@ -17,6 +18,7 @@ use App\Policies\PostPolicy;
 use App\Policies\PublicationPolicy;
 use App\Policies\StaffPolicy;
 use App\Policies\TagPolicy;
+use App\Policies\TeacherPolicy;
 use App\Policies\UserPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
@@ -40,6 +42,8 @@ class AuthServiceProvider extends ServiceProvider
         Publication::class => PublicationPolicy::class,
         // 標籤授權政策
         Tag::class => TagPolicy::class,
+        // 教師授權政策
+        Teacher::class => TeacherPolicy::class,
     ];
 
     public function boot(): void

--- a/resources/js/pages/manage/staff/create.tsx
+++ b/resources/js/pages/manage/staff/create.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from 'react';
+import { Head, router } from '@inertiajs/react';
+
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import { StaffForm } from '@/components/manage/staff/StaffForm';
+
+import { useTranslator } from '@/hooks/use-translator';
+
+import type { BreadcrumbItem } from '@/types';
+import type { StaffCreateProps, StaffFormData } from '@/types/staff';
+
+export default function StaffCreate(_: StaffCreateProps) {
+    const { t } = useTranslator('manage');
+
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+        { title: t('sidebar.admin.staff', '師資與職員'), href: '/manage/staff' },
+        { title: t('staff.form.staff.title_create', '新增職員'), href: '/manage/staff/create' },
+    ];
+
+    const handleSubmit = (data: StaffFormData) => {
+        router.post('/manage/staff', data, {
+            preserveScroll: true,
+        });
+    };
+
+    return (
+        <ManageLayout breadcrumbs={breadcrumbs}>
+            <Head title={t('staff.form.staff.title_create', '新增職員')} />
+
+            <ManagePageHeader
+                title={t('staff.form.staff.title_create', '新增職員')}
+                description={t('staff.index.description', '管理系所教師與職員資料，維護個人檔案與聯絡資訊。')}
+                badge={{ label: t('staff.index.tabs.staff', '職員管理') }}
+            />
+
+            <div className="mt-6">
+                <StaffForm onSubmit={handleSubmit} submitLabel={t('staff.form.actions.save', '儲存')} />
+            </div>
+        </ManageLayout>
+    );
+}
+
+StaffCreate.layout = (page: ReactElement) => page;

--- a/resources/js/pages/manage/staff/edit.tsx
+++ b/resources/js/pages/manage/staff/edit.tsx
@@ -1,0 +1,63 @@
+import type { ReactElement } from 'react';
+import { Head, router } from '@inertiajs/react';
+
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import { StaffForm } from '@/components/manage/staff/StaffForm';
+
+import { useTranslator } from '@/hooks/use-translator';
+
+import type { BreadcrumbItem } from '@/types';
+import type { StaffEditProps, StaffFormData } from '@/types/staff';
+
+const resolveStaffDisplayName = (name: StaffEditProps['staff']['name']): string => {
+    const zh = name?.['zh-TW']?.trim();
+    const en = name?.en?.trim();
+
+    if (zh && en) {
+        return `${zh} / ${en}`;
+    }
+
+    return zh ?? en ?? '';
+};
+
+export default function StaffEdit({ staff }: StaffEditProps) {
+    const { t } = useTranslator('manage');
+
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+        { title: t('sidebar.admin.staff', '師資與職員'), href: '/manage/staff' },
+        { title: resolveStaffDisplayName(staff.name) || t('staff.form.staff.title_edit', '編輯職員'), href: `/manage/staff/${staff.id}/edit` },
+    ];
+
+    const handleSubmit = (data: StaffFormData) => {
+        router.post(`/manage/staff/${staff.id}`, {
+            ...data,
+            _method: 'put',
+        }, {
+            preserveScroll: true,
+        });
+    };
+
+    return (
+        <ManageLayout breadcrumbs={breadcrumbs}>
+            <Head title={t('staff.form.staff.title_edit', '編輯職員資料')} />
+
+            <ManagePageHeader
+                title={t('staff.form.staff.title_edit', '編輯職員資料')}
+                description={t('staff.index.description', '管理系所教師與職員資料，維護個人檔案與聯絡資訊。')}
+                badge={{ label: t('staff.index.tabs.staff', '職員管理') }}
+            />
+
+            <div className="mt-6">
+                <StaffForm
+                    staff={staff}
+                    onSubmit={handleSubmit}
+                    submitLabel={t('staff.form.actions.save', '儲存')}
+                />
+            </div>
+        </ManageLayout>
+    );
+}
+
+StaffEdit.layout = (page: ReactElement) => page;

--- a/resources/js/pages/manage/staff/index.tsx
+++ b/resources/js/pages/manage/staff/index.tsx
@@ -1,44 +1,829 @@
-import { Head } from '@inertiajs/react';
+import { FormEvent, useCallback, useMemo, useState } from 'react';
+import { Head, Link, router } from '@inertiajs/react';
+import { Edit2, Eye, EyeOff, Plus, RefreshCcw, RotateCcw, Trash2 } from 'lucide-react';
+
 import ManageLayout from '@/layouts/manage/manage-layout';
 import { ManagePageHeader } from '@/components/manage/manage-page-header';
-import { useTranslator } from '@/hooks/use-translator';
-import type { BreadcrumbItem } from '@/types';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import Pagination from '@/components/ui/pagination';
 
-/**
- * 師資與職員管理頁面
- * 提供師資與職員資料的檢視、建立、編輯和刪除功能
- */
-export default function StaffIndex() {
+import { useTranslator } from '@/hooks/use-translator';
+
+import type { BreadcrumbItem } from '@/types';
+import type { StaffIndexProps, Staff, Teacher } from '@/types/staff';
+
+const buildStatusBadgeClass = (status: string): string => {
+    switch (status) {
+        case 'active':
+            return 'bg-emerald-100 text-emerald-700 border-emerald-200';
+        case 'inactive':
+            return 'bg-amber-100 text-amber-700 border-amber-200';
+        case 'retired':
+        case 'left':
+            return 'bg-rose-100 text-rose-700 border-rose-200';
+        default:
+            return 'bg-slate-100 text-slate-600 border-slate-200';
+    }
+};
+
+const buildVisibilityBadgeClass = (visible: boolean): string =>
+    visible
+        ? 'bg-emerald-50 text-emerald-600 border-emerald-200'
+        : 'bg-slate-100 text-slate-500 border-slate-200';
+
+const resolveDisplayName = (record: Staff | Teacher): string => {
+    const zhName = record.name?.['zh-TW']?.trim();
+    const enName = record.name?.en?.trim();
+
+    if (zhName && enName) {
+        return `${zhName} / ${enName}`;
+    }
+
+    return zhName ?? enName ?? '-';
+};
+
+const resolvePosition = (record: Staff | Teacher): string => {
+    const zh = (record as Staff).position?.['zh-TW'] ?? (record as Teacher).title?.['zh-TW'];
+    const en = (record as Staff).position?.en ?? (record as Teacher).title?.en;
+
+    if (zh && en) {
+        return `${zh} / ${en}`;
+    }
+
+    return zh ?? en ?? '-';
+};
+
+const resolveEmploymentPeriod = (record: Staff | Teacher, ongoingLabel: string): string => {
+    const start = record.employment_started_at ?? '';
+    const end = record.employment_ended_at ?? '';
+
+    if (!start && !end) {
+        return '-';
+    }
+
+    const endLabel = end || ongoingLabel;
+
+    return `${start || '?'} ~ ${endLabel}`;
+};
+
+const buildStaffName = (staff: Staff): string =>
+    staff.name?.['zh-TW']?.trim() || staff.name?.en?.trim() || `#${staff.id}`;
+
+const buildTeacherName = (teacher: Teacher): string =>
+    teacher.name?.['zh-TW']?.trim() || teacher.name?.en?.trim() || `#${teacher.id}`;
+
+export default function StaffIndex({
+    initialTab,
+    staff,
+    teachers,
+    filters,
+    perPageOptions,
+    employmentStatusOptions,
+    visibilityOptions,
+}: StaffIndexProps) {
     const { t } = useTranslator('manage');
 
-    const breadcrumbs: BreadcrumbItem[] = [
-        { title: t('layout.breadcrumbs.dashboard'), href: '/manage/dashboard' },
-        { title: t('sidebar.admin.staff'), href: '/manage/staff' },
-    ];
+    const breadcrumbs: BreadcrumbItem[] = useMemo(
+        () => [
+            { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+            { title: t('sidebar.admin.staff', '師資與職員'), href: '/manage/staff' },
+        ],
+        [t],
+    );
+
+    const [activeTab, setActiveTab] = useState<'staff' | 'teachers'>(initialTab);
+    const [filterState, setFilterState] = useState({
+        search: filters.search ?? '',
+        status: filters.status ?? '',
+        visible: filters.visible ?? '',
+        per_page: String(filters.per_page ?? perPageOptions[0] ?? 15),
+    });
+
+    const staffStatusLabels = useMemo(
+        () => ({
+            active: t('staff.staff.status.active', '在職'),
+            inactive: t('staff.staff.status.inactive', '暫離'),
+            retired: t('staff.teachers.status.retired', '退休'),
+            left: t('staff.teachers.status.left', '離職'),
+        }),
+        [t],
+    );
+
+    const teacherStatusLabels = useMemo(
+        () => ({
+            active: t('staff.teachers.status.active', '在職'),
+            inactive: t('staff.staff.status.inactive', '暫離'),
+            retired: t('staff.teachers.status.retired', '退休'),
+            left: t('staff.teachers.status.left', '離職'),
+        }),
+        [t],
+    );
+
+    const employmentOngoingLabel = t('staff.index.employment.present', '至今');
+
+    const buildFilterQuery = useCallback(
+        (state: typeof filterState = filterState, tab: 'staff' | 'teachers' = activeTab) => {
+            const params: Record<string, string> = { tab };
+            const trimmedSearch = state.search.trim();
+
+            if (trimmedSearch !== '') {
+                params.search = trimmedSearch;
+            }
+
+            if (state.status) {
+                params.status = state.status;
+            }
+
+            if (state.visible) {
+                params.visible = state.visible;
+            }
+
+            if (state.per_page) {
+                params.per_page = state.per_page;
+            }
+
+            return params;
+        },
+        [filterState, activeTab],
+    );
+
+    const applyFilters = useCallback(
+        (state: typeof filterState = filterState, tab: 'staff' | 'teachers' = activeTab) => {
+            router.get('/manage/staff', buildFilterQuery(state, tab), {
+                preserveState: true,
+                preserveScroll: true,
+            });
+        },
+        [buildFilterQuery, filterState, activeTab],
+    );
+
+    const handleFilterSubmit = useCallback(
+        (event: FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            applyFilters();
+        },
+        [applyFilters],
+    );
+
+    const handleFilterReset = useCallback(() => {
+        const resetState = {
+            search: '',
+            status: '',
+            visible: '',
+            per_page: String(perPageOptions[0] ?? 15),
+        };
+        setFilterState(resetState);
+        applyFilters(resetState);
+    }, [applyFilters, perPageOptions]);
+
+    const handleTabChange = useCallback(
+        (value: string) => {
+            const nextTab: 'staff' | 'teachers' = value === 'teachers' ? 'teachers' : 'staff';
+            setActiveTab(nextTab);
+            applyFilters(filterState, nextTab);
+        },
+        [applyFilters, filterState],
+    );
+
+    const handlePerPageChange = useCallback(
+        (perPage: number) => {
+            const nextState = { ...filterState, per_page: String(perPage) };
+            setFilterState(nextState);
+            applyFilters(nextState);
+        },
+        [applyFilters, filterState],
+    );
+
+    const toggleStaffStatus = useCallback((member: Staff) => {
+        router.patch(`/manage/staff/${member.id}/status`, {}, {
+            preserveScroll: true,
+            preserveState: true,
+        });
+    }, []);
+
+    const toggleStaffVisibility = useCallback((member: Staff) => {
+        router.patch(`/manage/staff/${member.id}/visibility`, {}, {
+            preserveScroll: true,
+            preserveState: true,
+        });
+    }, []);
+
+    const deleteStaff = useCallback((member: Staff) => {
+        if (!window.confirm(`確定要刪除職員「${buildStaffName(member)}」嗎？`)) {
+            return;
+        }
+
+        router.delete(`/manage/staff/${member.id}`, {
+            preserveScroll: true,
+        });
+    }, []);
+
+    const restoreStaff = useCallback((member: Staff) => {
+        router.patch(`/manage/staff/${member.id}/restore`, {}, {
+            preserveScroll: true,
+            preserveState: true,
+        });
+    }, []);
+
+    const forceDeleteStaff = useCallback((member: Staff) => {
+        if (!window.confirm(`確定要永久刪除職員「${buildStaffName(member)}」嗎？此操作無法復原。`)) {
+            return;
+        }
+
+        router.delete(`/manage/staff/${member.id}/force`, {
+            preserveScroll: true,
+        });
+    }, []);
+
+    const toggleTeacherStatus = useCallback((teacher: Teacher) => {
+        router.patch(`/manage/teachers/${teacher.id}/status`, {}, {
+            preserveScroll: true,
+            preserveState: true,
+        });
+    }, []);
+
+    const toggleTeacherVisibility = useCallback((teacher: Teacher) => {
+        router.patch(`/manage/teachers/${teacher.id}/visibility`, {}, {
+            preserveScroll: true,
+            preserveState: true,
+        });
+    }, []);
+
+    const deleteTeacher = useCallback((teacher: Teacher) => {
+        if (!window.confirm(`確定要刪除教師「${buildTeacherName(teacher)}」嗎？`)) {
+            return;
+        }
+
+        router.delete(`/manage/teachers/${teacher.id}`, {
+            preserveScroll: true,
+        });
+    }, []);
+
+    const restoreTeacher = useCallback((teacher: Teacher) => {
+        router.patch(`/manage/teachers/${teacher.id}/restore`, {}, {
+            preserveScroll: true,
+            preserveState: true,
+        });
+    }, []);
+
+    const forceDeleteTeacher = useCallback((teacher: Teacher) => {
+        if (!window.confirm(`確定要永久刪除教師「${buildTeacherName(teacher)}」嗎？此操作無法復原。`)) {
+            return;
+        }
+
+        router.delete(`/manage/teachers/${teacher.id}/force`, {
+            preserveScroll: true,
+        });
+    }, []);
+
+    const badgeLabel = activeTab === 'staff'
+        ? t('staff.index.tabs.staff', '職員管理')
+        : t('staff.index.tabs.teachers', '教師管理');
+
+    const filterHasValue =
+        filterState.search.trim() !== '' ||
+        filterState.status !== '' ||
+        filterState.visible !== '';
 
     return (
         <ManageLayout breadcrumbs={breadcrumbs}>
-            <Head title={t('sidebar.admin.staff')} />
+            <Head title={t('staff.index.title', '師資與職員管理')} />
 
             <ManagePageHeader
-                title={t('sidebar.admin.staff')}
-                description="管理系所師資與職員資料"
-                badge={{ label: "師資管理" }}
+                title={t('staff.index.title', '師資與職員管理')}
+                description={t('staff.index.description', '管理系所教師與職員資料，維護個人檔案與聯絡資訊。')}
+                badge={{ label: badgeLabel }}
+                actions={(
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                        <Button variant="outline" asChild>
+                            <Link href="/manage/staff/create">
+                                <Plus className="size-4" />
+                                {t('staff.index.create_staff', '新增職員')}
+                            </Link>
+                        </Button>
+                        <Button asChild>
+                            <Link href="/manage/teachers/create">
+                                <Plus className="size-4" />
+                                {t('staff.index.create_teacher', '新增教師')}
+                            </Link>
+                        </Button>
+                    </div>
+                )}
+                className="mb-6"
             />
 
-            <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-                <div className="text-center py-12">
-                    <div className="mx-auto h-12 w-12 text-gray-400">
-                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
-                        </svg>
-                    </div>
-                    <h3 className="mt-2 text-sm font-medium text-gray-900">師資與職員管理功能開發中</h3>
-                    <p className="mt-1 text-sm text-gray-500">
-                        此功能正在開發中，敬請期待
-                    </p>
-                </div>
-            </div>
+            <Card className="mb-6 border border-slate-200 bg-white shadow-sm">
+                <CardHeader>
+                    <CardTitle>{t('staff.index.title', '師資與職員管理')}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <form onSubmit={handleFilterSubmit} className="grid gap-4 md:grid-cols-5">
+                        <div className="md:col-span-2">
+                            <Label htmlFor="search">{t('staff.filters.search', '關鍵字')}</Label>
+                            <Input
+                                id="search"
+                                value={filterState.search}
+                                placeholder={t('staff.filters.search_placeholder', '搜尋姓名、職稱或聯絡資訊')}
+                                onChange={(event) =>
+                                    setFilterState((previous) => ({
+                                        ...previous,
+                                        search: event.target.value,
+                                    }))
+                                }
+                            />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="status">{t('staff.staff.table.status', '狀態')}</Label>
+                            <Select
+                                id="status"
+                                value={filterState.status}
+                                onChange={(event) =>
+                                    setFilterState((previous) => ({
+                                        ...previous,
+                                        status: event.target.value,
+                                    }))
+                                }
+                            >
+                                {employmentStatusOptions.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </Select>
+                        </div>
+
+                        <div>
+                            <Label htmlFor="visible">{t('staff.filters.visible', '顯示狀態')}</Label>
+                            <Select
+                                id="visible"
+                                value={filterState.visible}
+                                onChange={(event) =>
+                                    setFilterState((previous) => ({
+                                        ...previous,
+                                        visible: event.target.value,
+                                    }))
+                                }
+                            >
+                                {visibilityOptions.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </Select>
+                        </div>
+
+                        <div>
+                            <Label htmlFor="per-page">{t('staff.filters.per_page', '每頁筆數')}</Label>
+                            <Select
+                                id="per-page"
+                                value={filterState.per_page}
+                                onChange={(event) =>
+                                    setFilterState((previous) => ({
+                                        ...previous,
+                                        per_page: event.target.value,
+                                    }))
+                                }
+                            >
+                                {perPageOptions.map((option) => (
+                                    <option key={option} value={String(option)}>
+                                        {option}
+                                    </option>
+                                ))}
+                            </Select>
+                        </div>
+
+                        <div className="flex items-end gap-2">
+                            <Button type="submit" className="flex-1">
+                                {t('staff.filters.apply', '套用篩選')}
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                className="flex-1"
+                                onClick={handleFilterReset}
+                                disabled={!filterHasValue}
+                            >
+                                {t('staff.filters.reset', '清除')}
+                            </Button>
+                        </div>
+                    </form>
+                </CardContent>
+            </Card>
+
+            <Tabs value={activeTab} onValueChange={handleTabChange}>
+                <TabsList className="mb-4">
+                    <TabsTrigger value="staff">{t('staff.index.tabs.staff', '職員管理')}</TabsTrigger>
+                    <TabsTrigger value="teachers">{t('staff.index.tabs.teachers', '教師管理')}</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="staff">
+                    <Card className="border border-slate-200 bg-white shadow-sm">
+                        <CardHeader>
+                            <CardTitle>{t('staff.staff.title', '職員管理')}</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {staff.active.length === 0 ? (
+                                <p className="text-sm text-slate-500">
+                                    {t('staff.staff.empty', '目前沒有職員資料。')}
+                                </p>
+                            ) : (
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead className="w-[18%]">{t('staff.staff.table.name', '姓名')}</TableHead>
+                                            <TableHead className="w-[18%]">{t('staff.staff.table.position', '職位')}</TableHead>
+                                            <TableHead className="w-[22%]">{t('staff.staff.table.email', '聯絡資訊')}</TableHead>
+                                            <TableHead className="w-[18%]">{t('staff.staff.table.status', '狀態')}</TableHead>
+                                            <TableHead className="w-[14%]">{t('staff.staff.user', '帳號對應')}</TableHead>
+                                            <TableHead className="w-[10%] text-right">{t('staff.staff.table.actions', '操作')}</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {staff.active.map((member) => (
+                                            <TableRow key={member.id}>
+                                                <TableCell>
+                                                    <div className="font-medium text-slate-900">{resolveDisplayName(member)}</div>
+                                                    {member.avatar_url && (
+                                                        <a
+                                                            href={member.avatar_url}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                            className="text-xs text-primary hover:underline"
+                                                        >
+                                                            {t('staff.staff.avatar', '檢視照片')}
+                                                        </a>
+                                                    )}
+                                                </TableCell>
+                                                <TableCell>
+                                                    <div className="text-sm text-slate-900">{resolvePosition(member)}</div>
+                                                    {member.sort_order !== undefined && (
+                                                        <div className="text-xs text-slate-500">
+                                                            {t('staff.staff.sort_order', '排序')}
+                                                            ：{member.sort_order}
+                                                        </div>
+                                                    )}
+                                                </TableCell>
+                                                <TableCell>
+                                                    <div className="flex flex-col gap-1 text-sm">
+                                                        {member.email && (
+                                                            <a href={`mailto:${member.email}`} className="text-primary hover:underline">
+                                                                {member.email}
+                                                            </a>
+                                                        )}
+                                                        {member.phone && <span>{member.phone}</span>}
+                                                        {member.office && (
+                                                            <span className="text-xs text-slate-500">
+                                                                {t('staff.staff.office', '辦公室')}
+                                                                ：{member.office}
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <div className="flex flex-col gap-2">
+                                                        <Badge className={buildStatusBadgeClass(member.employment_status)}>
+                                                            {staffStatusLabels[member.employment_status] ?? member.employment_status}
+                                                        </Badge>
+                                                        <Badge className={buildVisibilityBadgeClass(member.visible)}>
+                                                            {member.visible
+                                                                ? t('staff.visibility.visible', '前台顯示')
+                                                                : t('staff.visibility.hidden', '已隱藏')}
+                                                        </Badge>
+                                                        <span className="text-xs text-slate-500">
+                                                            {t('staff.staff.employment_period', '任職期間')}
+                                                            ：{resolveEmploymentPeriod(member, employmentOngoingLabel)}
+                                                        </span>
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>
+                                                    {member.user ? (
+                                                        <div className="text-sm">
+                                                            <div className="font-medium text-slate-900">{member.user.name}</div>
+                                                            <div className="text-xs text-slate-500">{member.user.email}</div>
+                                                            <div className="text-xs text-slate-400">{member.user.role}</div>
+                                                        </div>
+                                                    ) : (
+                                                        <span className="text-xs text-slate-500">
+                                                            {t('staff.staff.no_user', '尚未綁定帳號')}
+                                                        </span>
+                                                    )}
+                                                </TableCell>
+                                                <TableCell className="text-right">
+                                                    <div className="flex flex-wrap justify-end gap-1">
+                                                        <Button variant="ghost" size="sm" asChild>
+                                                            <Link href={`/manage/staff/${member.id}/edit`}>
+                                                                <Edit2 className="size-4" />
+                                                                {t('staff.staff.actions.edit', '編輯')}
+                                                            </Link>
+                                                        </Button>
+                                                        <Button
+                                                            type="button"
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() => toggleStaffStatus(member)}
+                                                        >
+                                                            <RefreshCcw className="size-4" />
+                                                            {t('staff.staff.actions.toggle_status', '切換狀態')}
+                                                        </Button>
+                                                        <Button
+                                                            type="button"
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() => toggleStaffVisibility(member)}
+                                                        >
+                                                            {member.visible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+                                                            {member.visible
+                                                                ? t('staff.staff.actions.hide', '隱藏')
+                                                                : t('staff.staff.actions.show', '顯示')}
+                                                        </Button>
+                                                        <Button
+                                                            type="button"
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() => deleteStaff(member)}
+                                                        >
+                                                            <Trash2 className="size-4" />
+                                                            {t('staff.staff.actions.delete', '刪除')}
+                                                        </Button>
+                                                    </div>
+                                                </TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    {staff.trashed.length > 0 && (
+                        <Card className="mt-6 border border-rose-100 bg-white shadow-sm">
+                            <CardHeader>
+                                <CardTitle>{t('staff.staff.trashed', '回收站')}</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead className="w-[30%]">{t('staff.staff.table.name', '姓名')}</TableHead>
+                                            <TableHead className="w-[30%]">{t('staff.staff.table.email', '聯絡資訊')}</TableHead>
+                                            <TableHead className="w-[20%]">{t('staff.staff.deleted_at', '刪除時間')}</TableHead>
+                                            <TableHead className="w-[20%] text-right">{t('staff.staff.table.actions', '操作')}</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {staff.trashed.map((member) => (
+                                            <TableRow key={`trashed-${member.id}`}>
+                                                <TableCell>{resolveDisplayName(member)}</TableCell>
+                                                <TableCell>{member.email ?? '-'}</TableCell>
+                                                <TableCell>{member.deleted_at ?? '-'}</TableCell>
+                                                <TableCell className="text-right">
+                                                    <div className="flex justify-end gap-1">
+                                                        <Button
+                                                            type="button"
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() => restoreStaff(member)}
+                                                        >
+                                                            <RotateCcw className="size-4" />
+                                                            {t('staff.staff.actions.restore', '還原')}
+                                                        </Button>
+                                                        <Button
+                                                            type="button"
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() => forceDeleteStaff(member)}
+                                                        >
+                                                            <Trash2 className="size-4" />
+                                                            {t('staff.staff.actions.force_delete', '永久刪除')}
+                                                        </Button>
+                                                    </div>
+                                                </TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </CardContent>
+                        </Card>
+                    )}
+                </TabsContent>
+
+                <TabsContent value="teachers">
+                    <Card className="border border-slate-200 bg-white shadow-sm">
+                        <CardHeader>
+                            <CardTitle>{t('staff.teachers.title', '教師管理')}</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {teachers.data.length === 0 ? (
+                                <p className="text-sm text-slate-500">
+                                    {t('staff.teachers.empty', '目前沒有教師資料。')}
+                                </p>
+                            ) : (
+                                <>
+                                    <Table>
+                                        <TableHeader>
+                                            <TableRow>
+                                                <TableHead className="w-[18%]">{t('staff.teachers.table.name', '姓名')}</TableHead>
+                                                <TableHead className="w-[18%]">{t('staff.teachers.table.title', '職稱')}</TableHead>
+                                                <TableHead className="w-[22%]">{t('staff.teachers.table.email', '聯絡資訊')}</TableHead>
+                                                <TableHead className="w-[18%]">{t('staff.teachers.table.status', '狀態')}</TableHead>
+                                                <TableHead className="w-[14%]">{t('staff.teachers.table.specialization', '所屬單位')}</TableHead>
+                                                <TableHead className="w-[10%] text-right">{t('staff.teachers.table.actions', '操作')}</TableHead>
+                                            </TableRow>
+                                        </TableHeader>
+                                        <TableBody>
+                                            {teachers.data.map((teacher) => (
+                                                <TableRow key={teacher.id}>
+                                                    <TableCell>
+                                                        <div className="font-medium text-slate-900">{resolveDisplayName(teacher)}</div>
+                                                        {teacher.avatar_url && (
+                                                            <a
+                                                                href={teacher.avatar_url}
+                                                                target="_blank"
+                                                                rel="noopener noreferrer"
+                                                                className="text-xs text-primary hover:underline"
+                                                            >
+                                                                {t('staff.teachers.avatar', '檢視照片')}
+                                                            </a>
+                                                        )}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <div className="text-sm text-slate-900">{resolvePosition(teacher)}</div>
+                                                        {teacher.sort_order !== undefined && (
+                                                            <div className="text-xs text-slate-500">
+                                                                {t('staff.teachers.sort_order', '排序')}
+                                                                ：{teacher.sort_order}
+                                                            </div>
+                                                        )}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <div className="flex flex-col gap-1 text-sm">
+                                                            {teacher.email && (
+                                                                <a href={`mailto:${teacher.email}`} className="text-primary hover:underline">
+                                                                    {teacher.email}
+                                                                </a>
+                                                            )}
+                                                            {teacher.phone && <span>{teacher.phone}</span>}
+                                                            {teacher.office && (
+                                                                <span className="text-xs text-slate-500">
+                                                                    {t('staff.teachers.office', '辦公室')}
+                                                                    ：{teacher.office}
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <div className="flex flex-col gap-2">
+                                                            <Badge className={buildStatusBadgeClass(teacher.employment_status)}>
+                                                                {teacherStatusLabels[teacher.employment_status] ?? teacher.employment_status}
+                                                            </Badge>
+                                                            <Badge className={buildVisibilityBadgeClass(teacher.visible)}>
+                                                                {teacher.visible
+                                                                    ? t('staff.visibility.visible', '前台顯示')
+                                                                    : t('staff.visibility.hidden', '已隱藏')}
+                                                            </Badge>
+                                                            <span className="text-xs text-slate-500">
+                                                                {t('staff.teachers.employment_period', '任職期間')}
+                                                                ：{resolveEmploymentPeriod(teacher, employmentOngoingLabel)}
+                                                            </span>
+                                                        </div>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        {teacher.labs && teacher.labs.length > 0 ? (
+                                                            <div className="flex flex-wrap gap-1">
+                                                                {teacher.labs.map((lab) => (
+                                                                    <Badge key={lab.id} variant="outline">
+                                                                        {lab.name?.['zh-TW'] ?? lab.name?.en ?? lab.code ?? '-'}
+                                                                    </Badge>
+                                                                ))}
+                                                            </div>
+                                                        ) : (
+                                                            <span className="text-xs text-slate-500">
+                                                                {t('staff.teachers.no_lab', '未分配實驗室')}
+                                                            </span>
+                                                        )}
+                                                    </TableCell>
+                                                    <TableCell className="text-right">
+                                                        <div className="flex flex-wrap justify-end gap-1">
+                                                            <Button variant="ghost" size="sm" asChild>
+                                                                <Link href={`/manage/teachers/${teacher.id}/edit`}>
+                                                                    <Edit2 className="size-4" />
+                                                                    {t('staff.teachers.actions.edit', '編輯')}
+                                                                </Link>
+                                                            </Button>
+                                                            <Button
+                                                                type="button"
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                onClick={() => toggleTeacherStatus(teacher)}
+                                                            >
+                                                                <RefreshCcw className="size-4" />
+                                                                {t('staff.teachers.actions.toggle_status', '切換狀態')}
+                                                            </Button>
+                                                            <Button
+                                                                type="button"
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                onClick={() => toggleTeacherVisibility(teacher)}
+                                                            >
+                                                                {teacher.visible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+                                                                {teacher.visible
+                                                                    ? t('staff.teachers.actions.hide', '隱藏')
+                                                                    : t('staff.teachers.actions.show', '顯示')}
+                                                            </Button>
+                                                            <Button
+                                                                type="button"
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                onClick={() => deleteTeacher(teacher)}
+                                                            >
+                                                                <Trash2 className="size-4" />
+                                                                {t('staff.teachers.actions.delete', '刪除')}
+                                                            </Button>
+                                                        </div>
+                                                    </TableCell>
+                                                </TableRow>
+                                            ))}
+                                        </TableBody>
+                                    </Table>
+
+                                    {teachers.meta.last_page > 1 && (
+                                        <Pagination
+                                            meta={{
+                                                ...teachers.meta,
+                                                links: teachers.links,
+                                            }}
+                                            perPageOptions={perPageOptions}
+                                            onPerPageChange={handlePerPageChange}
+                                            className="mt-4"
+                                        />
+                                    )}
+                                </>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    {teachers.trashed.length > 0 && (
+                        <Card className="mt-6 border border-rose-100 bg-white shadow-sm">
+                            <CardHeader>
+                                <CardTitle>{t('staff.teachers.trashed', '回收站')}</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead className="w-[30%]">{t('staff.teachers.table.name', '姓名')}</TableHead>
+                                            <TableHead className="w-[30%]">{t('staff.teachers.table.email', '聯絡資訊')}</TableHead>
+                                            <TableHead className="w-[20%]">{t('staff.teachers.deleted_at', '刪除時間')}</TableHead>
+                                            <TableHead className="w-[20%] text-right">{t('staff.teachers.table.actions', '操作')}</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {teachers.trashed.map((teacher) => (
+                                            <TableRow key={`trashed-teacher-${teacher.id}`}>
+                                                <TableCell>{resolveDisplayName(teacher)}</TableCell>
+                                                <TableCell>{teacher.email ?? '-'}</TableCell>
+                                                <TableCell>{teacher.deleted_at ?? '-'}</TableCell>
+                                                <TableCell className="text-right">
+                                                    <div className="flex justify-end gap-1">
+                                                        <Button
+                                                            type="button"
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() => restoreTeacher(teacher)}
+                                                        >
+                                                            <RotateCcw className="size-4" />
+                                                            {t('staff.teachers.actions.restore', '還原')}
+                                                        </Button>
+                                                        <Button
+                                                            type="button"
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() => forceDeleteTeacher(teacher)}
+                                                        >
+                                                            <Trash2 className="size-4" />
+                                                            {t('staff.teachers.actions.force_delete', '永久刪除')}
+                                                        </Button>
+                                                    </div>
+                                                </TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </CardContent>
+                        </Card>
+                    )}
+                </TabsContent>
+            </Tabs>
         </ManageLayout>
     );
 }
+
+StaffIndex.layout = (page: React.ReactElement) => page;

--- a/resources/js/pages/manage/staff/show.tsx
+++ b/resources/js/pages/manage/staff/show.tsx
@@ -1,0 +1,122 @@
+import type { ReactElement } from 'react';
+import { Head } from '@inertiajs/react';
+
+import ManageLayout from '@/layouts/manage/manage-layout';
+import { ManagePageHeader } from '@/components/manage/manage-page-header';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+import { useTranslator } from '@/hooks/use-translator';
+
+import type { BreadcrumbItem } from '@/types';
+import type { StaffShowProps } from '@/types/staff';
+
+const formatLocalized = (value?: { 'zh-TW'?: string; en?: string }) => {
+    const zh = value?.['zh-TW']?.trim();
+    const en = value?.en?.trim();
+
+    if (zh && en) {
+        return `${zh} / ${en}`;
+    }
+
+    return zh ?? en ?? '-';
+};
+
+export default function StaffShow({ staff }: StaffShowProps) {
+    const { t } = useTranslator('manage');
+
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: t('layout.breadcrumbs.dashboard', '管理首頁'), href: '/manage/dashboard' },
+        { title: t('sidebar.admin.staff', '師資與職員'), href: '/manage/staff' },
+        { title: formatLocalized(staff.name), href: `/manage/staff/${staff.id}` },
+    ];
+
+    return (
+        <ManageLayout breadcrumbs={breadcrumbs}>
+            <Head title={formatLocalized(staff.name)} />
+
+            <ManagePageHeader
+                title={formatLocalized(staff.name)}
+                description={t('staff.index.description', '管理系所教師與職員資料，維護個人檔案與聯絡資訊。')}
+                badge={{ label: t('staff.index.tabs.staff', '職員管理') }}
+            />
+
+            <Card className="mt-6 border border-slate-200 bg-white shadow-sm">
+                <CardHeader>
+                    <CardTitle>{t('staff.staff.title', '職員管理')}</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm text-slate-700">
+                    <div>
+                        <h3 className="text-xs font-semibold uppercase text-slate-500">
+                            {t('staff.staff.table.position', '職位')}
+                        </h3>
+                        <p>{formatLocalized(staff.position)}</p>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                        <Badge>{staff.employment_status}</Badge>
+                        <Badge variant="outline">
+                            {staff.visible
+                                ? t('staff.visibility.visible', '前台顯示')
+                                : t('staff.visibility.hidden', '已隱藏')}
+                        </Badge>
+                    </div>
+
+                    <div>
+                        <h3 className="text-xs font-semibold uppercase text-slate-500">
+                            {t('staff.staff.employment_period', '任職期間')}
+                        </h3>
+                        <p>
+                            {staff.employment_started_at ?? '?'} ~{' '}
+                            {staff.employment_ended_at ?? t('staff.index.employment.present', '至今')}
+                        </p>
+                    </div>
+
+                    <div className="space-y-1">
+                        <h3 className="text-xs font-semibold uppercase text-slate-500">
+                            {t('staff.staff.table.email', '聯絡資訊')}
+                        </h3>
+                        {staff.email && (
+                            <p>
+                                <a href={`mailto:${staff.email}`} className="text-primary hover:underline">
+                                    {staff.email}
+                                </a>
+                            </p>
+                        )}
+                        {staff.phone && <p>{staff.phone}</p>}
+                        {staff.office && (
+                            <p className="text-xs text-slate-500">
+                                {t('staff.staff.office', '辦公室')}：{staff.office}
+                            </p>
+                        )}
+                    </div>
+
+                    {staff.user && (
+                        <div>
+                            <h3 className="text-xs font-semibold uppercase text-slate-500">
+                                {t('staff.staff.user', '帳號對應')}
+                            </h3>
+                            <p className="font-medium text-slate-900">{staff.user.name}</p>
+                            <p className="text-xs text-slate-500">{staff.user.email}</p>
+                        </div>
+                    )}
+
+                    {staff.bio && (
+                        <div className="space-y-1">
+                            <h3 className="text-xs font-semibold uppercase text-slate-500">
+                                {t('staff.form.staff.fields.bio_zh', '中文簡介')}
+                            </h3>
+                            <p>{staff.bio['zh-TW'] ?? '-'}</p>
+                            <h3 className="text-xs font-semibold uppercase text-slate-500">
+                                {t('staff.form.staff.fields.bio_en', '英文簡介')}
+                            </h3>
+                            <p>{staff.bio.en ?? '-'}</p>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </ManageLayout>
+    );
+}
+
+StaffShow.layout = (page: ReactElement) => page;

--- a/resources/js/types/staff.d.ts
+++ b/resources/js/types/staff.d.ts
@@ -1,49 +1,13 @@
-// TypeScript interfaces for Staff Management
+// TypeScript interfaces for Staff & Teacher Management
 
 export interface LocalizedContent {
-    'zh-TW': string;
+    'zh-TW'?: string;
     en?: string;
 }
 
-export interface Staff {
-    id: number;
-    name: string;
-    name_en: string;
-    position: string;
-    position_en: string;
-    email?: string;
-    phone?: string;
-    photo_url?: string;
-    bio?: string;
-    bio_en?: string;
-    visible: boolean;
-    sort_order: number;
-    created_at?: string;
-    updated_at?: string;
-    deleted_at?: string;
-}
+export type EmploymentStatus = 'active' | 'inactive' | 'retired' | 'left';
 
-export interface Teacher {
-    id: number;
-    name: LocalizedContent;
-    title: LocalizedContent;
-    email: string;
-    phone?: string;
-    office?: string;
-    bio?: LocalizedContent;
-    specialties?: LocalizedContent[];
-    education?: LocalizedContent[];
-    avatar?: string;
-    website?: string;
-    lab_id?: number;
-    visible: boolean;
-    sort_order: number;
-    lab?: Lab;
-    created_at?: string;
-    updated_at?: string;
-}
-
-export interface User {
+export interface StaffUser {
     id: number;
     name: string;
     email: string;
@@ -52,21 +16,71 @@ export interface User {
 
 export interface Lab {
     id: number;
+    code?: string | null;
     name: LocalizedContent;
     description?: LocalizedContent;
 }
 
-export interface StaffManagementState {
-    currentTab: 'staff' | 'teachers';
-    staffList: Staff[];
-    teacherList: Teacher[];
-    loading: boolean;
-    filters: {
-        search: string;
-        visible: boolean | null;
-        perPage: number;
-    };
-    pagination: PaginationMeta;
+export interface Staff {
+    id: number;
+    name: LocalizedContent;
+    position: LocalizedContent;
+    email?: string | null;
+    phone?: string | null;
+    office?: string | null;
+    bio?: LocalizedContent | null;
+    avatar_url?: string | null;
+    visible: boolean;
+    sort_order: number;
+    employment_status: EmploymentStatus;
+    employment_started_at?: string | null;
+    employment_ended_at?: string | null;
+    deleted_at?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    user?: StaffUser | null;
+}
+
+export interface Teacher {
+    id: number;
+    name: LocalizedContent;
+    title: LocalizedContent;
+    email: string;
+    phone?: string | null;
+    office?: string | null;
+    job_title?: string | null;
+    bio?: LocalizedContent | null;
+    expertise?: Record<'zh-TW' | 'en', string[]> | null;
+    education?: Record<'zh-TW' | 'en', string[]> | null;
+    specialties?: LocalizedContent[]; // 為了相容舊表單資料保留
+    avatar_url?: string | null;
+    website?: string | null;
+    lab_id?: number | null;
+    visible: boolean;
+    sort_order: number;
+    employment_status: EmploymentStatus;
+    employment_started_at?: string | null;
+    employment_ended_at?: string | null;
+    deleted_at?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    user?: StaffUser | null;
+    labs?: Array<{ id: number; code?: string | null; name: LocalizedContent }>;
+}
+
+export interface PaginationLink {
+    url: string | null;
+    label: string;
+    active: boolean;
+}
+
+export interface PaginationMeta {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number;
+    to: number;
 }
 
 export interface StaffFormState {
@@ -80,15 +94,6 @@ export interface TeacherFormState {
     errors: Record<string, string>;
     processing: boolean;
     availableLabs: Lab[];
-}
-
-export interface PaginationMeta {
-    current_page: number;
-    from: number;
-    last_page: number;
-    per_page: number;
-    to: number;
-    total: number;
 }
 
 // Form data types for API requests
@@ -124,21 +129,24 @@ export interface TeacherFormData {
 export interface StaffIndexProps {
     initialTab: 'staff' | 'teachers';
     staff: {
-        data: Staff[];
-        meta: PaginationMeta;
+        active: Staff[];
+        trashed: Staff[];
     };
     teachers: {
         data: Teacher[];
+        trashed: Teacher[];
         meta: PaginationMeta;
+        links: PaginationLink[];
     };
     filters: {
-        search: string;
-        visible: boolean | null;
-        per_page: number;
+        search?: string;
+        status?: string;
+        visible?: string;
+        per_page?: number;
     };
-    translations: {
-        manage: Record<string, string>;
-    };
+    perPageOptions: number[];
+    employmentStatusOptions: Array<{ value: string; label: string }>;
+    visibilityOptions: Array<{ value: string; label: string }>;
 }
 
 export interface StaffCreateProps {

--- a/routes/manage.php
+++ b/routes/manage.php
@@ -54,11 +54,23 @@ Route::middleware(['auth', 'role:admin|teacher'])
 
         // 師資與職員管理
         Route::resource('staff', AdminStaffController::class);
+        Route::patch('staff/{staff}/status', [AdminStaffController::class, 'toggleStatus'])
+            ->name('staff.toggle-status');
+        Route::patch('staff/{staff}/visibility', [AdminStaffController::class, 'toggleVisibility'])
+            ->name('staff.toggle-visibility');
         Route::patch('staff/{staff}/restore', [AdminStaffController::class, 'restore'])
             ->name('staff.restore');
         Route::delete('staff/{staff}/force', [AdminStaffController::class, 'forceDelete'])
             ->name('staff.force-delete');
         Route::resource('teachers', AdminTeacherController::class);
+        Route::patch('teachers/{teacher}/status', [AdminTeacherController::class, 'toggleStatus'])
+            ->name('teachers.toggle-status');
+        Route::patch('teachers/{teacher}/visibility', [AdminTeacherController::class, 'toggleVisibility'])
+            ->name('teachers.toggle-visibility');
+        Route::patch('teachers/{teacher}/restore', [AdminTeacherController::class, 'restore'])
+            ->name('teachers.restore');
+        Route::delete('teachers/{teacher}/force', [AdminTeacherController::class, 'forceDelete'])
+            ->name('teachers.force-delete');
 
         // 學術研究管理
         Route::resource('labs', AdminLabController::class);


### PR DESCRIPTION
## Summary
- eager load user, lab, and related teacher associations when rendering manage teacher detail and edit pages so the resource exposes the unified payload expected by the frontend

## Testing
- php artisan test --filter=TeacherManagementTest
- php artisan test --filter=StaffManagementTest

------
https://chatgpt.com/codex/tasks/task_e_68da99618a10832384857b053f63fa99