### PR TITLE
feat: centralize manage navigation and permissions

### DIFF
--- a/lang/en/manage.php
+++ b/lang/en/manage.php
@@ -50,6 +50,7 @@ return [
             'users' => 'Users',
             'messages' => 'Messages',
             'attachments' => 'Attachments',
+            'nav_label' => 'Administration',
         ],
         'teacher' => [
             'dashboard' => 'Teaching Home',
@@ -73,6 +74,12 @@ return [
             'docs' => 'Documentation',
             'repo' => 'Repository',
         ],
+    ],
+    'access' => [
+        'denied_title' => 'Access denied',
+        'denied_description' => 'You do not have permission to access this feature. Please contact a system administrator if you believe this is an error.',
+        'back_to_dashboard' => 'Back to dashboard',
+        'denied_role' => 'Current role: :role',
     ],
     'success' => [
         'created' => ':item created successfully',

--- a/lang/zh-TW/manage.php
+++ b/lang/zh-TW/manage.php
@@ -50,6 +50,7 @@ return [
             'users' => '使用者管理',
             'messages' => '聯絡訊息',
             'attachments' => '附件管理',
+            'nav_label' => '系統管理',
         ],
         'teacher' => [
             'dashboard' => '教學首頁',
@@ -73,6 +74,12 @@ return [
             'docs' => '說明文件',
             'repo' => '原始碼庫',
         ],
+    ],
+    'access' => [
+        'denied_title' => '沒有存取權限',
+        'denied_description' => '您沒有權限使用此功能，如需協助請聯絡系統管理員。',
+        'back_to_dashboard' => '返回管理首頁',
+        'denied_role' => '目前身分：:role',
     ],
     'success' => [
         'created' => ':item 建立成功',

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -1,0 +1,20 @@
+import { Sidebar, SidebarContent, SidebarHeader } from '@/components/ui/sidebar';
+
+/**
+ * 前台側邊欄的預設佈局
+ * 若未設計導覽內容，先提供友善的佔位提示
+ */
+export function AppSidebar() {
+    return (
+        <Sidebar className="bg-white text-slate-900">
+            <SidebarHeader className="border-b border-slate-200 px-4 py-4">
+                <div className="text-lg font-semibold">CSIE Portal</div>
+                <p className="text-xs text-slate-500">尚未設定導覽項目</p>
+            </SidebarHeader>
+            <SidebarContent className="flex flex-1 items-center justify-center p-4 text-sm text-slate-400">
+                <span>請於 AppSidebar 組件中配置導覽內容</span>
+            </SidebarContent>
+        </Sidebar>
+    );
+}
+

--- a/resources/js/components/manage/manage-unauthorized.tsx
+++ b/resources/js/components/manage/manage-unauthorized.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+
+import { AlertTriangle } from 'lucide-react';
+import { Link } from '@inertiajs/react';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useTranslator } from '@/hooks/use-translator';
+import type { ManageRole } from '@/components/manage/manage-brand';
+
+interface ManageUnauthorizedProps {
+    role: ManageRole;
+}
+
+/**
+ * 沒有權限時統一顯示的提示區塊
+ */
+export default function ManageUnauthorized({ role }: ManageUnauthorizedProps) {
+    const { t } = useTranslator('manage');
+    const roleLabel = useMemo(
+        () =>
+            (
+                {
+                    admin: t('layout.brand.admin.primary'),
+                    teacher: t('layout.brand.teacher.primary'),
+                    user: t('layout.brand.user.primary'),
+                } satisfies Record<ManageRole, string>
+            )[role],
+        [role, t],
+    );
+
+    return (
+        <Card className="border border-rose-200 bg-white/70 shadow-sm">
+            <CardContent className="flex flex-col gap-6 p-8 text-center">
+                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-rose-100 text-rose-600">
+                    <AlertTriangle className="h-8 w-8" aria-hidden />
+                </div>
+                <div className="space-y-2">
+                    <p className="text-sm font-medium text-rose-500">
+                        {t('access.denied_role', undefined, { role: roleLabel })}
+                    </p>
+                    <h2 className="text-2xl font-semibold text-slate-900">
+                        {t('access.denied_title')}
+                    </h2>
+                    <p className="text-sm leading-relaxed text-slate-600">
+                        {t('access.denied_description')}
+                    </p>
+                </div>
+                <div className="flex flex-wrap items-center justify-center gap-3">
+                    <Button asChild variant="default">
+                        <Link href="/manage/dashboard">{t('access.back_to_dashboard')}</Link>
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+

--- a/resources/js/components/manage/routes/manage-route-config.ts
+++ b/resources/js/components/manage/routes/manage-route-config.ts
@@ -1,0 +1,332 @@
+import type { LucideIcon } from 'lucide-react';
+import {
+    LayoutGrid,
+    Megaphone,
+    NotebookPen,
+    Beaker,
+    School,
+    GraduationCap,
+    Users,
+    Mail,
+    FileText,
+    Settings,
+    User as UserIcon,
+    ShieldCheck,
+    HelpCircle,
+    Folder,
+    LifeBuoy,
+} from 'lucide-react';
+
+import type { ManageRole } from '@/components/manage/manage-brand';
+import type { PermissionKey } from '@/components/manage/utils/permission-utils';
+import { MANAGE_PERMISSIONS } from '@/components/manage/utils/permission-utils';
+
+/**
+ * 管理後台主要導覽項目的定義
+ */
+interface ManageRouteDefinition {
+    id: string;
+    href: string;
+    icon: LucideIcon;
+    permission: PermissionKey;
+    /**
+     * 依角色對應的翻譯 key
+     */
+    labels: Partial<Record<ManageRole, string>> & { admin?: string };
+    /**
+     * 若不同角色需要不同圖示，於此覆寫
+     */
+    iconByRole?: Partial<Record<ManageRole, LucideIcon>>;
+}
+
+interface ManageFooterLinkDefinition {
+    id: string;
+    href: string;
+    icon: LucideIcon;
+    labels: Partial<Record<ManageRole, string>>;
+    permission?: PermissionKey | null;
+}
+
+interface ResolvedRouteDefinition extends ManageRouteDefinition {
+    labelKey: string;
+    iconForRole: LucideIcon;
+}
+
+interface ResolvedFooterLinkDefinition extends ManageFooterLinkDefinition {
+    labelKey: string;
+}
+
+const MAIN_ROUTE_DEFINITIONS: ManageRouteDefinition[] = [
+    {
+        id: 'dashboard',
+        href: '/manage/dashboard',
+        icon: LayoutGrid,
+        permission: 'VIEW_DASHBOARD',
+        labels: {
+            admin: 'sidebar.admin.dashboard',
+            teacher: 'sidebar.teacher.dashboard',
+            user: 'sidebar.user.dashboard',
+        },
+    },
+    {
+        id: 'posts',
+        href: '/manage/posts',
+        icon: Megaphone,
+        permission: 'MANAGE_POSTS',
+        labels: {
+            admin: 'sidebar.admin.posts',
+            teacher: 'sidebar.teacher.posts',
+        },
+    },
+    {
+        id: 'tags',
+        href: '/manage/tags',
+        icon: NotebookPen,
+        permission: 'MANAGE_TAGS',
+        labels: {
+            admin: 'sidebar.admin.tags',
+        },
+    },
+    {
+        id: 'labs',
+        href: '/manage/labs',
+        icon: Beaker,
+        permission: 'MANAGE_LABS',
+        labels: {
+            admin: 'sidebar.admin.labs',
+            teacher: 'sidebar.teacher.labs',
+        },
+    },
+    {
+        id: 'classrooms',
+        href: '/manage/classrooms',
+        icon: School,
+        permission: 'MANAGE_CLASSROOMS',
+        labels: {
+            admin: 'sidebar.admin.classrooms',
+        },
+    },
+    {
+        id: 'academics',
+        href: '/manage/academics',
+        icon: GraduationCap,
+        permission: 'MANAGE_ACADEMICS',
+        labels: {
+            admin: 'sidebar.admin.academics',
+        },
+    },
+    {
+        id: 'users',
+        href: '/manage/users',
+        icon: Users,
+        permission: 'MANAGE_USERS',
+        labels: {
+            admin: 'sidebar.admin.users',
+        },
+    },
+    {
+        id: 'contact-messages',
+        href: '/manage/contact-messages',
+        icon: Mail,
+        permission: 'MANAGE_CONTACT_MESSAGES',
+        labels: {
+            admin: 'sidebar.admin.messages',
+        },
+    },
+    {
+        id: 'attachments',
+        href: '/manage/attachments',
+        icon: FileText,
+        permission: 'MANAGE_ATTACHMENTS',
+        labels: {
+            admin: 'sidebar.admin.attachments',
+        },
+    },
+    {
+        id: 'projects',
+        href: '/manage/projects',
+        icon: NotebookPen,
+        permission: 'MANAGE_PROJECTS',
+        labels: {
+            teacher: 'sidebar.teacher.projects',
+        },
+    },
+    {
+        id: 'profile',
+        href: '/manage/settings/profile',
+        icon: Settings,
+        permission: 'MANAGE_PROFILE',
+        labels: {
+            teacher: 'sidebar.teacher.profile',
+            user: 'sidebar.user.profile',
+        },
+        iconByRole: {
+            user: UserIcon,
+        },
+    },
+    {
+        id: 'password',
+        href: '/manage/settings/password',
+        icon: ShieldCheck,
+        permission: 'MANAGE_PASSWORD',
+        labels: {
+            user: 'sidebar.user.security',
+        },
+    },
+];
+
+const FOOTER_LINK_DEFINITIONS: ManageFooterLinkDefinition[] = [
+    {
+        id: 'settings',
+        href: '/manage/settings/profile',
+        icon: Settings,
+        permission: 'MANAGE_PROFILE',
+        labels: {
+            admin: 'sidebar.footer.settings',
+        },
+    },
+    {
+        id: 'docs',
+        href: 'https://laravel.com/docs',
+        icon: HelpCircle,
+        labels: {
+            admin: 'sidebar.footer.docs',
+        },
+        permission: null,
+    },
+    {
+        id: 'repo',
+        href: 'https://github.com/Grasonyang/csie_web',
+        icon: Folder,
+        labels: {
+            admin: 'sidebar.footer.repo',
+        },
+        permission: null,
+    },
+    {
+        id: 'teacher-guide',
+        href: 'https://github.com/Grasonyang/csie_web',
+        icon: HelpCircle,
+        labels: {
+            teacher: 'sidebar.teacher.guide',
+        },
+        permission: null,
+    },
+    {
+        id: 'user-support',
+        href: 'mailto:csie@cc.ncue.edu.tw',
+        icon: LifeBuoy,
+        labels: {
+            user: 'sidebar.user.support',
+        },
+        permission: null,
+    },
+];
+
+const NAV_LABEL_KEYS: Record<ManageRole, string> = {
+    admin: 'sidebar.admin.nav_label',
+    teacher: 'sidebar.teacher.nav_label',
+    user: 'sidebar.user.nav_label',
+};
+
+interface ManageRoutePermissionRule {
+    prefix: string;
+    permission: PermissionKey;
+}
+
+const ROUTE_PERMISSION_RULES: ManageRoutePermissionRule[] = [
+    { prefix: '/manage/dashboard', permission: 'VIEW_DASHBOARD' },
+    { prefix: '/manage/posts', permission: 'MANAGE_POSTS' },
+    { prefix: '/manage/post-categories', permission: 'MANAGE_POSTS' },
+    { prefix: '/manage/tags', permission: 'MANAGE_TAGS' },
+    { prefix: '/manage/labs', permission: 'MANAGE_LABS' },
+    { prefix: '/manage/classrooms', permission: 'MANAGE_CLASSROOMS' },
+    { prefix: '/manage/academics', permission: 'MANAGE_ACADEMICS' },
+    { prefix: '/manage/programs', permission: 'MANAGE_PROGRAMS' },
+    { prefix: '/manage/projects', permission: 'MANAGE_PROJECTS' },
+    { prefix: '/manage/publications', permission: 'MANAGE_PUBLICATIONS' },
+    { prefix: '/manage/users', permission: 'MANAGE_USERS' },
+    { prefix: '/manage/contact-messages', permission: 'MANAGE_CONTACT_MESSAGES' },
+    { prefix: '/manage/attachments', permission: 'MANAGE_ATTACHMENTS' },
+    { prefix: '/manage/settings/profile', permission: 'MANAGE_PROFILE' },
+    { prefix: '/manage/settings/password', permission: 'MANAGE_PASSWORD' },
+];
+
+const byLongestPrefix = (a: ManageRoutePermissionRule, b: ManageRoutePermissionRule) =>
+    b.prefix.length - a.prefix.length;
+
+ROUTE_PERMISSION_RULES.sort(byLongestPrefix);
+
+const roleHasPermission = (role: ManageRole, permission: PermissionKey | null | undefined): boolean => {
+    if (!permission) {
+        return true;
+    }
+
+    const allowedRoles = MANAGE_PERMISSIONS[permission];
+    if (!allowedRoles) {
+        return false;
+    }
+
+    return allowedRoles.includes(role);
+};
+
+const resolveRoutesForRole = (role: ManageRole): ResolvedRouteDefinition[] =>
+    MAIN_ROUTE_DEFINITIONS.flatMap((route) => {
+        const labelKey = route.labels[role];
+        if (!labelKey) {
+            return [];
+        }
+
+        if (!roleHasPermission(role, route.permission)) {
+            return [];
+        }
+
+        const iconForRole = route.iconByRole?.[role] ?? route.icon;
+
+        return [{
+            ...route,
+            labelKey,
+            iconForRole,
+        }];
+    });
+
+const resolveFooterLinksForRole = (role: ManageRole): ResolvedFooterLinkDefinition[] =>
+    FOOTER_LINK_DEFINITIONS.flatMap((item) => {
+        const labelKey = item.labels[role];
+
+        if (!labelKey) {
+            return [];
+        }
+
+        if (!roleHasPermission(role, item.permission ?? null)) {
+            return [];
+        }
+
+        return [
+            {
+                ...item,
+                labelKey,
+            },
+        ];
+    });
+
+export function getMainRoutesForRole(role: ManageRole) {
+    return resolveRoutesForRole(role);
+}
+
+export function getFooterLinksForRole(role: ManageRole) {
+    return resolveFooterLinksForRole(role);
+}
+
+export function getNavLabelKey(role: ManageRole): string {
+    return NAV_LABEL_KEYS[role] ?? NAV_LABEL_KEYS.admin;
+}
+
+export function resolvePermissionByPath(pathname: string): PermissionKey | null {
+    const normalizedPath = pathname.split('?')[0];
+
+    const rule = ROUTE_PERMISSION_RULES.find(({ prefix }) => normalizedPath.startsWith(prefix));
+
+    return rule?.permission ?? null;
+}
+

--- a/resources/js/components/manage/routes/use-manage-navigation.ts
+++ b/resources/js/components/manage/routes/use-manage-navigation.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+
+import type { ManageRole } from '@/components/manage/manage-brand';
+import { useTranslator } from '@/hooks/use-translator';
+import type { NavItem } from '@/types';
+
+import {
+    getFooterLinksForRole,
+    getMainRoutesForRole,
+    getNavLabelKey,
+} from '@/components/manage/routes/manage-route-config';
+
+interface UseManageNavigationResult {
+    mainNavItems: NavItem[];
+    footerNavItems: NavItem[];
+    navLabel: string;
+}
+
+/**
+ * 根據目前角色動態產生側邊導覽使用的選單資料
+ */
+export function useManageNavigation(role: ManageRole): UseManageNavigationResult {
+    const { t } = useTranslator('manage');
+
+    const mainNavItems = useMemo<NavItem[]>(
+        () =>
+            getMainRoutesForRole(role).map((route) => ({
+                title: t(route.labelKey),
+                href: route.href,
+                icon: route.iconForRole,
+            })),
+        [role, t],
+    );
+
+    const footerNavItems = useMemo<NavItem[]>(
+        () =>
+            getFooterLinksForRole(role).map((item) => ({
+                title: t(item.labelKey),
+                href: item.href,
+                icon: item.icon,
+            })),
+        [role, t],
+    );
+
+    const navLabel = useMemo(() => t(getNavLabelKey(role)), [role, t]);
+
+    return { mainNavItems, footerNavItems, navLabel };
+}
+

--- a/resources/js/components/manage/sidebar/manage-sidebar.tsx
+++ b/resources/js/components/manage/sidebar/manage-sidebar.tsx
@@ -2,29 +2,11 @@ import { NavFooter } from '@/components/nav-footer';
 import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
-import { type NavItem, type SharedData } from '@/types';
+import { type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
-import {
-    LayoutGrid,
-    Users,
-    Beaker,
-    School,
-    GraduationCap,
-    Megaphone,
-    FileText,
-    Mail,
-    Settings,
-    Folder,
-    HelpCircle,
-    NotebookPen,
-    User,
-    ShieldCheck,
-    LifeBuoy,
-} from 'lucide-react';
 import ManageBrand, { type ManageRole } from '@/components/manage/manage-brand';
-import { useTranslator } from '@/hooks/use-translator';
-import { useMemo } from 'react';
 import { deriveManageRole } from '@/components/manage/utils/role-helpers';
+import { useManageNavigation } from '@/components/manage/routes/use-manage-navigation';
 
 interface ManageSidebarProps {
     role?: ManageRole;
@@ -33,87 +15,7 @@ interface ManageSidebarProps {
 export default function ManageSidebar({ role: roleOverride }: ManageSidebarProps) {
     const { auth } = usePage<SharedData>().props;
     const role = deriveManageRole(auth?.user ?? null, roleOverride ?? null);
-    const { t } = useTranslator('manage');
-
-    const adminNavItems: NavItem[] = useMemo(
-        () => [
-            { title: t('sidebar.admin.dashboard'), href: '/manage/dashboard', icon: LayoutGrid },
-            { title: t('sidebar.admin.posts'), href: '/manage/posts', icon: Megaphone },
-            { title: t('sidebar.admin.tags'), href: '/manage/tags', icon: NotebookPen },
-            { title: t('sidebar.admin.labs'), href: '/manage/labs', icon: Beaker },
-            { title: t('sidebar.admin.classrooms'), href: '/manage/classrooms', icon: School },
-            { title: t('sidebar.admin.academics'), href: '/manage/academics', icon: GraduationCap },
-            { title: t('sidebar.admin.users'), href: '/manage/users', icon: Users },
-            { title: t('sidebar.admin.messages'), href: '/manage/contact-messages', icon: Mail },
-            { title: t('sidebar.admin.attachments'), href: '/manage/attachments', icon: FileText },
-        ],
-        [t],
-    );
-
-    const teacherNavItems: NavItem[] = useMemo(
-        () => [
-            { title: t('sidebar.teacher.dashboard'), href: '/manage/dashboard', icon: LayoutGrid },
-            { title: t('sidebar.teacher.posts'), href: '/manage/posts', icon: Megaphone },
-            { title: t('sidebar.teacher.labs'), href: '/manage/labs', icon: Beaker },
-            { title: t('sidebar.teacher.projects'), href: '/manage/projects', icon: NotebookPen },
-            { title: t('sidebar.teacher.profile'), href: '/manage/settings/profile', icon: Settings },
-        ],
-        [t],
-    );
-
-    const userNavItems: NavItem[] = useMemo(
-        () => [
-            { title: t('sidebar.user.dashboard'), href: '/manage/dashboard', icon: LayoutGrid },
-            { title: t('sidebar.user.profile'), href: '/manage/settings/profile', icon: User },
-            { title: t('sidebar.user.security'), href: '/manage/settings/password', icon: ShieldCheck },
-        ],
-        [t],
-    );
-
-    const mainNavItemsByRole: Record<ManageRole, NavItem[]> = useMemo(
-        () => ({
-            admin: adminNavItems,
-            teacher: teacherNavItems,
-            user: userNavItems,
-        }),
-        [adminNavItems, teacherNavItems, userNavItems],
-    );
-
-    const adminFooterItems: NavItem[] = useMemo(
-        () => [
-            { title: t('sidebar.footer.settings'), href: '/manage/settings/profile', icon: Settings },
-            { title: t('sidebar.footer.docs'), href: 'https://laravel.com/docs', icon: HelpCircle },
-            { title: t('sidebar.footer.repo'), href: 'https://github.com/Grasonyang/csie_web', icon: Folder },
-        ],
-        [t],
-    );
-
-    const teacherFooterItems: NavItem[] = useMemo(
-        () => [{ title: t('sidebar.teacher.guide'), href: 'https://github.com/Grasonyang/csie_web', icon: HelpCircle }],
-        [t],
-    );
-
-    const userFooterItems: NavItem[] = useMemo(
-        () => [{ title: t('sidebar.user.support'), href: 'mailto:csie@cc.ncue.edu.tw', icon: LifeBuoy }],
-        [t],
-    );
-
-    const footerNavItemsByRole: Record<ManageRole, NavItem[]> = useMemo(
-        () => ({
-            admin: adminFooterItems,
-            teacher: teacherFooterItems,
-            user: userFooterItems,
-        }),
-        [adminFooterItems, teacherFooterItems, userFooterItems],
-    );
-
-    const navLabelsByRole: Partial<Record<ManageRole, string>> = useMemo(
-        () => ({
-            teacher: t('sidebar.teacher.nav_label'),
-            user: t('sidebar.user.nav_label'),
-        }),
-        [t],
-    );
+    const { mainNavItems, footerNavItems, navLabel } = useManageNavigation(role);
 
     return (
         <Sidebar>
@@ -129,14 +31,11 @@ export default function ManageSidebar({ role: roleOverride }: ManageSidebarProps
                 </SidebarMenu>
             </SidebarHeader>
             <SidebarContent>
-                <NavMain
-                    items={mainNavItemsByRole[role] ?? []}
-                    label={navLabelsByRole[role] ?? t('sidebar.admin.nav_label')}
-                />
+                <NavMain items={mainNavItems} label={navLabel} />
             </SidebarContent>
             <SidebarFooter className="border-t border-slate-200">
-                <NavFooter items={footerNavItemsByRole[role] ?? []} />
-                <NavUser user={auth?.user} />
+                <NavFooter items={footerNavItems} />
+                <NavUser />
             </SidebarFooter>
         </Sidebar>
     );

--- a/resources/js/layouts/manage/manage-layout.tsx
+++ b/resources/js/layouts/manage/manage-layout.tsx
@@ -3,16 +3,30 @@ import { AppShell } from '@/components/app-shell';
 import ManageSidebar from '@/components/manage/sidebar/manage-sidebar';
 import AdminFooter from '@/components/admin-footer';
 import { Breadcrumbs } from '@/components/breadcrumbs';
-import { type PropsWithChildren } from 'react';
+import { type PropsWithChildren, type ReactNode, useCallback, useMemo } from 'react';
 import { usePage } from '@inertiajs/react';
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import ManageHeader from '@/components/manage/manage-header';
 import { type ManageRole } from '@/components/manage/manage-brand';
 import { deriveManageRole } from '@/components/manage/utils/role-helpers';
+import ManageUnauthorized from '@/components/manage/manage-unauthorized';
+import {
+    MANAGE_PERMISSIONS,
+    type PermissionKey,
+} from '@/components/manage/utils/permission-utils';
+import { resolvePermissionByPath } from '@/components/manage/routes/manage-route-config';
 
 interface ManageLayoutProps {
     role?: ManageRole;
     breadcrumbs?: BreadcrumbItem[];
+    /**
+     * 指定頁面所需權限，若未提供則會依據路徑自動判斷
+     */
+    permission?: PermissionKey | PermissionKey[];
+    /**
+     * 沒有權限時的自訂畫面
+     */
+    fallback?: ReactNode;
 }
 
 /**
@@ -24,10 +38,62 @@ export default function ManageLayout({
     children,
     breadcrumbs = [],
     role: roleOverride,
+    permission,
+    fallback,
 }: PropsWithChildren<ManageLayoutProps>) {
-    const { auth } = usePage<SharedData>().props;
+    const page = usePage<SharedData>();
+    const { auth } = page.props;
+    const currentUrl = page.url ?? '';
 
     const role = deriveManageRole(auth?.user ?? null, roleOverride ?? null);
+
+    const rolePool = useMemo(() => {
+        const roles = new Set<ManageRole>([role]);
+
+        if (Array.isArray(auth?.user?.roles)) {
+            for (const candidate of auth.user.roles) {
+                if (candidate === 'admin' || candidate === 'teacher' || candidate === 'user') {
+                    roles.add(candidate);
+                }
+            }
+        }
+
+        return Array.from(roles);
+    }, [auth?.user?.roles, role]);
+
+    const inferredPermission = useMemo(() => resolvePermissionByPath(currentUrl), [currentUrl]);
+
+    const requiredPermissions = useMemo(() => {
+        if (permission) {
+            return Array.isArray(permission) ? permission : [permission];
+        }
+
+        return inferredPermission ? [inferredPermission] : [];
+    }, [permission, inferredPermission]);
+
+    const hasPermission = useCallback(
+        (permissionKey: PermissionKey) => {
+            const allowedRoles = MANAGE_PERMISSIONS[permissionKey];
+
+            if (!allowedRoles) {
+                return false;
+            }
+
+            return rolePool.some((candidate) => allowedRoles.includes(candidate));
+        },
+        [rolePool],
+    );
+
+    const canAccess = useMemo(() => {
+        if (requiredPermissions.length === 0) {
+            return true;
+        }
+
+        return requiredPermissions.some((permissionKey) => hasPermission(permissionKey));
+    }, [hasPermission, requiredPermissions]);
+
+    const shouldGuard = requiredPermissions.length > 0;
+    const unauthorizedView = fallback ?? <ManageUnauthorized role={role} />;
 
     return (
         <AppShell variant="sidebar">
@@ -53,7 +119,7 @@ export default function ManageLayout({
                                     </div>
                                 </div>
                             )}
-                            {children}
+                            {shouldGuard && !canAccess ? unauthorizedView : children}
                         </div>
                     </main>
 


### PR DESCRIPTION
## Summary
- introduce centralized manage route configuration with role-based navigation utilities and layout permission enforcement
- add reusable unauthorized state, translations, and a placeholder app sidebar container

## Testing
- npm run types

------
https://chatgpt.com/codex/tasks/task_e_68db5248f3a0832395a908a4d09b9a1d