### PR TITLE
建立新版資料庫模型

### DIFF
--- a/app/Models/Classroom.php
+++ b/app/Models/Classroom.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Schema;
+
+class Classroom extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * 空間類型代碼：教室。
+     */
+    public const TYPE_CLASSROOM = 3;
+
+    /**
+     * 使用共用的空間資料表。
+     *
+     * @var string
+     */
+    protected $table = 'spaces';
+
+    /**
+     * 可批次指定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'code',
+        'name',
+        'name_en',
+        'location',
+        'capacity',
+        'equipment_summary',
+        'description',
+        'description_en',
+        'sort_order',
+        'visible',
+        'tags',
+    ];
+
+    /**
+     * 欄位轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'capacity' => 'integer',
+        'sort_order' => 'integer',
+        'visible' => 'boolean',
+    ];
+
+    /**
+     * 暫存待同步的標籤。
+     *
+     * @var array<int, string>|null
+     */
+    protected ?array $pendingTagNames = null;
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope('classroom', function (Builder $builder) {
+            $builder->where('space_type', self::TYPE_CLASSROOM);
+        });
+
+        static::creating(function (Classroom $classroom) {
+            $classroom->setAttribute('space_type', self::TYPE_CLASSROOM);
+        });
+    }
+
+    /**
+     * 服務人員。
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'space_user', 'space_id', 'user_id');
+    }
+
+    /**
+     * 標籤關聯。
+     */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'space_tag', 'space_id', 'tag_id');
+    }
+
+    /**
+     * 取得標籤名稱。
+     *
+     * @return array<int, string>
+     */
+    public function getTagsAttribute(): array
+    {
+        if (! Schema::hasTable('tags')) {
+            return [];
+        }
+
+        if ($this->relationLoaded('tags')) {
+            return $this->getRelation('tags')->pluck('name')->all();
+        }
+
+        return $this->tags()->pluck('tags.name')->all();
+    }
+
+    /**
+     * 攔截標籤設定。
+     */
+    public function setAttribute($key, $value)
+    {
+        if ($key === 'tags') {
+            $this->pendingTagNames = $this->normalizeTags($value);
+
+            return $this;
+        }
+
+        return parent::setAttribute($key, $value);
+    }
+
+    /**
+     * 儲存後同步標籤。
+     */
+    public function save(array $options = [])
+    {
+        $saved = parent::save($options);
+
+        if ($saved && $this->pendingTagNames !== null) {
+            $this->syncTags($this->pendingTagNames);
+            $this->pendingTagNames = null;
+        }
+
+        return $saved;
+    }
+
+    /**
+     * 同步標籤。
+     */
+    public function syncTags(array $tags): void
+    {
+        if (! Schema::hasTable('tags')) {
+            return;
+        }
+
+        $tags = collect($tags)
+            ->map(fn ($value) => trim((string) $value))
+            ->filter()
+            ->unique()
+            ->values();
+
+        if ($tags->isEmpty()) {
+            $this->tags()->sync([]);
+
+            return;
+        }
+
+        $tagIds = $tags->map(function (string $name): ?int {
+            $tag = Tag::findOrCreateForContext('classrooms', $name);
+
+            return $tag?->id;
+        })->filter()->values();
+
+        $this->tags()->sync($tagIds->all());
+    }
+
+    /**
+     * 標準化標籤資料。
+     *
+     * @param  mixed  $value
+     * @return array<int, string>
+     */
+    protected function normalizeTags($value): array
+    {
+        if (is_string($value)) {
+            $items = explode(',', $value);
+        } elseif (is_array($value)) {
+            $items = $value;
+        } elseif ($value instanceof \Traversable) {
+            $items = iterator_to_array($value);
+        } else {
+            return [];
+        }
+
+        return collect($items)
+            ->map(fn ($item) => trim((string) $item))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/app/Models/ContactMessage.php
+++ b/app/Models/ContactMessage.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ContactMessage extends Model
+{
+    use HasFactory;
+
+    /**
+     * 狀態對應表。
+     *
+     * @var array<string, int>
+     */
+    public const STATUS_MAP = [
+        'new' => 1,
+        'processing' => 2,
+        'resolved' => 3,
+        'spam' => 4,
+    ];
+
+    /**
+     * 可批次設定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'locale',
+        'name',
+        'email',
+        'subject',
+        'message',
+        'file_url',
+        'status',
+        'processed_by',
+        'processed_at',
+    ];
+
+    /**
+     * 欄位轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'processed_at' => 'datetime',
+    ];
+
+    /**
+     * 狀態屬性轉換。
+     */
+    protected function status(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value): string => array_flip(self::STATUS_MAP)[$value] ?? 'new',
+            set: function ($value) {
+                if (is_int($value)) {
+                    return $value;
+                }
+
+                $key = is_string($value) ? strtolower($value) : 'new';
+
+                return self::STATUS_MAP[$key] ?? self::STATUS_MAP['new'];
+            }
+        );
+    }
+
+    /**
+     * 處理訊息的使用者。
+     */
+    public function processor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'processed_by');
+    }
+}

--- a/app/Models/Lab.php
+++ b/app/Models/Lab.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Schema;
+
+class Lab extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * 空間類型代碼：實驗室。
+     */
+    public const TYPE_LAB = 2;
+
+    /**
+     * 允許批次指定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'code',
+        'name',
+        'name_en',
+        'location',
+        'capacity',
+        'website_url',
+        'contact_email',
+        'contact_phone',
+        'email',
+        'phone',
+        'tags',
+        'cover_image_url',
+        'equipment_summary',
+        'description',
+        'description_en',
+        'sort_order',
+        'visible',
+    ];
+
+    /**
+     * 欄位轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'capacity' => 'integer',
+        'visible' => 'boolean',
+        'sort_order' => 'integer',
+    ];
+
+    /**
+     * 暫存待同步的標籤。
+     *
+     * @var array<int, string>|null
+     */
+    protected ?array $pendingTagNames = null;
+
+    /**
+     * 使用共用的空間資料表。
+     *
+     * @var string
+     */
+    protected $table = 'spaces';
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope('lab', function (Builder $builder) {
+            $builder->where('space_type', self::TYPE_LAB);
+        });
+
+        static::creating(function (Lab $lab) {
+            $lab->setAttribute('space_type', self::TYPE_LAB);
+        });
+    }
+
+    /**
+     * 教師成員。
+     */
+    public function members(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'space_user', 'space_id', 'user_id');
+    }
+
+    /**
+     * 電子郵件欄位映射。
+     */
+    protected function email(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value, array $attributes) => $attributes['contact_email'] ?? null,
+            set: fn ($value) => ['contact_email' => $value],
+        );
+    }
+
+    /**
+     * 聯絡電話欄位映射。
+     */
+    protected function phone(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value, array $attributes) => $attributes['contact_phone'] ?? null,
+            set: fn ($value) => ['contact_phone' => $value],
+        );
+    }
+
+    /**
+     * 標籤關聯。
+     */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'space_tag', 'space_id', 'tag_id');
+    }
+
+    /**
+     * 取得標籤名稱陣列。
+     *
+     * @return array<int, string>
+     */
+    public function getTagsAttribute(): array
+    {
+        if (! Schema::hasTable('tags')) {
+            return [];
+        }
+
+        if ($this->relationLoaded('tags')) {
+            return $this->getRelation('tags')->pluck('name')->all();
+        }
+
+        return $this->tags()->pluck('tags.name')->all();
+    }
+
+    /**
+     * 攔截標籤設定。
+     */
+    public function setAttribute($key, $value)
+    {
+        if ($key === 'tags') {
+            $this->pendingTagNames = $this->normalizeTags($value);
+
+            return $this;
+        }
+
+        if ($key === 'email') {
+            return parent::setAttribute('contact_email', $value);
+        }
+
+        if ($key === 'phone') {
+            return parent::setAttribute('contact_phone', $value);
+        }
+
+        return parent::setAttribute($key, $value);
+    }
+
+    /**
+     * 儲存後同步標籤。
+     */
+    public function save(array $options = [])
+    {
+        $saved = parent::save($options);
+
+        if ($saved && $this->pendingTagNames !== null) {
+            $this->syncTags($this->pendingTagNames);
+            $this->pendingTagNames = null;
+        }
+
+        return $saved;
+    }
+
+    /**
+     * 同步實驗室標籤。
+     */
+    public function syncTags(array $tags): void
+    {
+        if (! Schema::hasTable('tags')) {
+            return;
+        }
+
+        $tags = collect($tags)
+            ->map(fn ($value) => trim((string) $value))
+            ->filter()
+            ->unique()
+            ->values();
+
+        if ($tags->isEmpty()) {
+            $this->tags()->sync([]);
+
+            return;
+        }
+
+        $tagIds = $tags->map(function (string $name): ?int {
+            $tag = Tag::findOrCreateForContext('labs', $name);
+
+            return $tag?->id;
+        })->filter()->values();
+
+        $this->tags()->sync($tagIds->all());
+    }
+
+    /**
+     * 標準化標籤陣列。
+     *
+     * @param  mixed  $value
+     * @return array<int, string>
+     */
+    protected function normalizeTags($value): array
+    {
+        if (is_string($value)) {
+            $items = explode(',', $value);
+        } elseif (is_array($value)) {
+            $items = $value;
+        } elseif ($value instanceof \Traversable) {
+            $items = iterator_to_array($value);
+        } else {
+            return [];
+        }
+
+        return collect($items)
+            ->map(fn ($item) => trim((string) $item))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Schema;
+
+class Post extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * 公告狀態對應表。
+     *
+     * @var array<string, int>
+     */
+    public const STATUS_MAP = [
+        'draft' => 0,
+        'published' => 1,
+        'hidden' => 2,
+        'scheduled' => 3,
+    ];
+
+    /**
+     * 內容來源類型對應表。
+     *
+     * @var array<string, int>
+     */
+    public const SOURCE_TYPE_MAP = [
+        'manual' => 1,
+        'import' => 2,
+        'external' => 3,
+    ];
+
+    /**
+     * 欄位可批次填充設定。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'category_id',
+        'slug',
+        'status',
+        'source_type',
+        'source_url',
+        'publish_at',
+        'expire_at',
+        'pinned',
+        'cover_image_url',
+        'title',
+        'title_en',
+        'summary',
+        'summary_en',
+        'content',
+        'content_en',
+        'views',
+        'created_by',
+        'updated_by',
+    ];
+
+    /**
+     * 自動轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'publish_at' => 'datetime',
+        'expire_at' => 'datetime',
+        'pinned' => 'boolean',
+        'views' => 'integer',
+    ];
+
+    /**
+     * 暫存待同步的標籤名稱。
+     *
+     * @var array<int, string>|null
+     */
+    protected ?array $pendingTagNames = null;
+
+    /**
+     * 設定公告狀態。
+     */
+    protected function status(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value): string => array_flip(self::STATUS_MAP)[$value] ?? 'draft',
+            set: function ($value) {
+                if (is_int($value)) {
+                    return $value;
+                }
+
+                $key = is_string($value) ? strtolower($value) : 'draft';
+
+                return self::STATUS_MAP[$key] ?? self::STATUS_MAP['draft'];
+            }
+        );
+    }
+
+    /**
+     * 設定公告來源類型。
+     */
+    protected function sourceType(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value): string => array_flip(self::SOURCE_TYPE_MAP)[$value] ?? 'manual',
+            set: function ($value) {
+                if (is_int($value)) {
+                    return $value;
+                }
+
+                $key = is_string($value) ? strtolower($value) : 'manual';
+
+                return self::SOURCE_TYPE_MAP[$key] ?? self::SOURCE_TYPE_MAP['manual'];
+            }
+        );
+    }
+
+    /**
+     * 多型附件關聯。
+     */
+    public function attachments(): MorphMany
+    {
+        return $this->morphMany(Attachment::class, 'attachable', 'attached_to_type', 'attached_to_id');
+    }
+
+    /**
+     * 公告分類。
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(PostCategory::class, 'category_id');
+    }
+
+    /**
+     * 建立者。
+     */
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /**
+     * 最後更新者。
+     */
+    public function updater(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+
+    /**
+     * 公告標籤關聯。
+     */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'post_tag');
+    }
+
+    /**
+     * 學程關聯。
+     */
+    public function programs(): BelongsToMany
+    {
+        return $this->belongsToMany(Program::class, 'program_post')
+            ->withPivot(['relation_type', 'sort_order']);
+    }
+
+    /**
+     * 取得公告的標籤名稱陣列。
+     *
+     * @return array<int, string>
+     */
+    public function getTagsAttribute(): array
+    {
+        if (! Schema::hasTable('tags')) {
+            return [];
+        }
+
+        if ($this->relationLoaded('tags')) {
+            return $this->getRelation('tags')->pluck('name')->all();
+        }
+
+        return $this->tags()->pluck('tags.name')->all();
+    }
+
+    /**
+     * 攔截自訂屬性設定。
+     */
+    public function setAttribute($key, $value)
+    {
+        if ($key === 'tags') {
+            $this->pendingTagNames = $this->normalizeTags($value);
+
+            return $this;
+        }
+
+        return parent::setAttribute($key, $value);
+    }
+
+    /**
+     * 儲存模型時一併同步標籤。
+     */
+    public function save(array $options = [])
+    {
+        $saved = parent::save($options);
+
+        if ($saved && $this->pendingTagNames !== null) {
+            $this->syncTags($this->pendingTagNames);
+            $this->pendingTagNames = null;
+        }
+
+        return $saved;
+    }
+
+    /**
+     * 查詢範圍：取得已發布的公告。
+     */
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query->where(function (Builder $builder) {
+            $builder->where('status', self::STATUS_MAP['published'])
+                ->orWhere(function (Builder $scheduled) {
+                    $scheduled->where('status', self::STATUS_MAP['scheduled'])
+                        ->whereNotNull('publish_at')
+                        ->where('publish_at', '<=', now());
+                });
+        });
+    }
+
+    /**
+     * 查詢範圍：依置頂與發布時間排序。
+     */
+    public function scopeOrderedForListing(Builder $query): Builder
+    {
+        return $query
+            ->orderByDesc('pinned')
+            ->orderByDesc('publish_at')
+            ->orderByDesc('created_at');
+    }
+
+    /**
+     * 同步標籤資料。
+     */
+    public function syncTags(array $tags): void
+    {
+        if (! Schema::hasTable('tags')) {
+            return;
+        }
+
+        $tags = collect($tags)
+            ->map(fn ($value) => trim((string) $value))
+            ->filter()
+            ->unique()
+            ->values();
+
+        if ($tags->isEmpty()) {
+            $this->tags()->sync([]);
+
+            return;
+        }
+
+        $tagIds = $tags->map(function (string $name): ?int {
+            $tag = Tag::findOrCreateForContext('posts', $name);
+
+            return $tag?->id;
+        })->filter()->values();
+
+        $this->tags()->sync($tagIds->all());
+    }
+
+    /**
+     * 標準化標籤輸入。
+     *
+     * @param  mixed  $value
+     * @return array<int, string>
+     */
+    protected function normalizeTags($value): array
+    {
+        if (is_string($value)) {
+            $items = explode(',', $value);
+        } elseif (is_array($value)) {
+            $items = $value;
+        } elseif ($value instanceof \Traversable) {
+            $items = iterator_to_array($value);
+        } else {
+            return [];
+        }
+
+        return collect($items)
+            ->map(fn ($item) => trim((string) $item))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/app/Models/PostCategory.php
+++ b/app/Models/PostCategory.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class PostCategory extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * 允許批次指定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'parent_id',
+        'slug',
+        'name',
+        'name_en',
+        'sort_order',
+        'visible',
+    ];
+
+    /**
+     * 屬性轉型。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'visible' => 'boolean',
+        'sort_order' => 'integer',
+    ];
+
+    /**
+     * 上層分類。
+     */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    /**
+     * 子分類。
+     */
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+
+    /**
+     * 分類底下的公告。
+     */
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class, 'category_id');
+    }
+}

--- a/app/Models/Program.php
+++ b/app/Models/Program.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+
+class Program extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * 學制對應表。
+     *
+     * @var array<string, string>
+     */
+    public const LEVEL_LABELS = [
+        'bachelor' => '學士班',
+        'master' => '碩士班',
+        'ai_inservice' => 'AI 在職專班',
+        'dual' => '雙聯學制',
+    ];
+
+    /**
+     * 關聯公告類型。
+     *
+     * @var array<string, string>
+     */
+    public const POST_TYPE_LABELS = [
+        'curriculum' => '課程資訊',
+        'regulation' => '修業規定',
+        'course_map' => '課程地圖',
+        'other' => '其他',
+    ];
+
+    /**
+     * 可批次指定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'code',
+        'level',
+        'name',
+        'name_en',
+        'description',
+        'description_en',
+        'website_url',
+        'visible',
+        'sort_order',
+    ];
+
+    /**
+     * 欄位轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'visible' => 'boolean',
+        'sort_order' => 'integer',
+    ];
+
+    /**
+     * 學程關聯的公告。
+     */
+    public function posts(): BelongsToMany
+    {
+        $pivot = self::pivotTableName();
+
+        return $this->belongsToMany(Post::class, $pivot)
+            ->withPivot(['post_type', 'sort_order'])
+            ->orderBy($pivot . '.sort_order');
+    }
+
+    /**
+     * 取得課程資訊公告。
+     */
+    public function getCurriculumPosts(): Collection
+    {
+        return $this->posts()->wherePivot('post_type', 'curriculum')->get();
+    }
+
+    /**
+     * 取得修業規定公告。
+     */
+    public function getRegulationPosts(): Collection
+    {
+        return $this->posts()->wherePivot('post_type', 'regulation')->get();
+    }
+
+    /**
+     * 取得課程地圖公告。
+     */
+    public function getCourseMapPosts(): Collection
+    {
+        return $this->posts()->wherePivot('post_type', 'course_map')->get();
+    }
+
+    /**
+     * 查詢範圍：僅顯示可見學程。
+     */
+    public function scopeVisible(Builder $query): Builder
+    {
+        return $query->where('visible', true);
+    }
+
+    /**
+     * 查詢範圍：依學制篩選。
+     */
+    public function scopeByLevel(Builder $query, string $level): Builder
+    {
+        return $query->where('level', $level);
+    }
+
+    /**
+     * 查詢範圍：依排序設定排序。
+     */
+    public function scopeOrdered(Builder $query): Builder
+    {
+        return $query->orderBy('sort_order')->orderBy('name');
+    }
+
+    /**
+     * 取得學制顯示名稱。
+     */
+    public function getLevelNameAttribute(): ?string
+    {
+        return self::LEVEL_LABELS[$this->level] ?? null;
+    }
+
+    /**
+     * 取得學制選項。
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public static function getLevelOptions(): array
+    {
+        return collect(self::LEVEL_LABELS)
+            ->map(fn ($label, $value) => ['value' => $value, 'label' => $label])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * 取得公告類型選項。
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public static function getPostTypeOptions(): array
+    {
+        return collect(self::POST_TYPE_LABELS)
+            ->map(fn ($label, $value) => ['value' => $value, 'label' => $label])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * 判斷實際使用的樞紐表名稱。
+     */
+    protected static function pivotTableName(): string
+    {
+        return Schema::hasTable('program_posts') ? 'program_posts' : 'program_post';
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Project extends Model
+{
+    use HasFactory;
+
+    /**
+     * 使用新的研究計畫資料表。
+     *
+     * @var string
+     */
+    protected $table = 'research_projects';
+
+    /**
+     * 可批次設定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'start_date',
+        'end_date',
+        'title',
+        'sponsor',
+        'total_budget',
+        'principal_investigator',
+        'summary',
+    ];
+
+    /**
+     * 欄位轉型。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date' => 'date',
+        'total_budget' => 'integer',
+    ];
+
+    /**
+     * 計畫所使用的標籤。
+     */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'research_project_tag');
+    }
+}

--- a/app/Models/Publication.php
+++ b/app/Models/Publication.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Publication extends Model
+{
+    use HasFactory;
+
+    /**
+     * 期刊類型對應表。
+     *
+     * @var array<string, int>
+     */
+    public const TYPE_MAP = [
+        'journal' => 1,
+        'conference' => 2,
+    ];
+
+    /**
+     * 使用新的論文資料表。
+     *
+     * @var string
+     */
+    protected $table = 'papers';
+
+    /**
+     * 可批次指定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'type',
+        'published_date',
+        'title',
+        'venue_name',
+        'authors',
+        'summary',
+        'doi',
+        'location',
+    ];
+
+    /**
+     * 欄位轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'published_date' => 'date',
+    ];
+
+    /**
+     * 類型屬性轉換。
+     */
+    protected function type(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value): string => array_flip(self::TYPE_MAP)[$value] ?? 'journal',
+            set: function ($value) {
+                if (is_int($value)) {
+                    return $value;
+                }
+
+                $key = is_string($value) ? strtolower($value) : 'journal';
+
+                return self::TYPE_MAP[$key] ?? self::TYPE_MAP['journal'];
+            }
+        );
+    }
+
+    /**
+     * 論文所屬的標籤。
+     */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'paper_tag');
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    /**
+     * 可批次設定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'display_name',
+        'priority',
+    ];
+
+    /**
+     * 欄位轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'priority' => 'integer',
+    ];
+
+    /**
+     * 角色擁有的使用者。
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'user_roles')
+            ->withPivot(['status', 'assigned_at']);
+    }
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    /**
+     * 支援的標籤範疇。
+     *
+     * @var array<string, string>
+     */
+    public const CONTEXTS = [
+        'posts' => '公告',
+        'attachments' => '附件',
+        'labs' => '研究實驗室',
+        'classrooms' => '教室',
+        'programs' => '學程',
+        'projects' => '研究計畫',
+    ];
+
+    /**
+     * 可批次指定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'context',
+        'name',
+        'slug',
+        'description',
+        'sort_order',
+    ];
+
+    /**
+     * 欄位轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'sort_order' => 'integer',
+    ];
+
+    /**
+     * 取得 slug 時統一為小寫。
+     */
+    protected function slug(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => is_string($value) ? strtolower($value) : $value,
+            set: fn ($value) => is_string($value) ? strtolower($value) : $value,
+        );
+    }
+
+    /**
+     * 判斷資料表是否存在。
+     */
+    public static function tableExists(): bool
+    {
+        return Schema::hasTable((new static())->getTable());
+    }
+
+    /**
+     * 依範疇篩選。
+     */
+    public function scopeForContext(Builder $query, string $context): Builder
+    {
+        return $query->where('context', $context);
+    }
+
+    /**
+     * 產生唯一 slug。
+     */
+    public static function generateUniqueSlug(string $name, string $context, ?int $ignoreId = null): string
+    {
+        $base = Str::slug($name);
+        if ($base === '') {
+            $base = Str::slug(Str::random(8));
+        }
+
+        $candidate = strtolower($base);
+        $suffix = 1;
+
+        $exists = static::query()
+            ->where('context', $context)
+            ->when($ignoreId, fn ($query) => $query->where('id', '!=', $ignoreId))
+            ->where('slug', $candidate)
+            ->exists();
+
+        while ($exists) {
+            $candidate = $base . '-' . $suffix;
+            $suffix++;
+
+            $exists = static::query()
+                ->where('context', $context)
+                ->when($ignoreId, fn ($query) => $query->where('id', '!=', $ignoreId))
+                ->where('slug', $candidate)
+                ->exists();
+        }
+
+        return strtolower($candidate);
+    }
+
+    /**
+     * 取得或建立特定範疇的標籤。
+     */
+    public static function findOrCreateForContext(string $context, string $name): ?self
+    {
+        if ($name === '' || ! static::tableExists()) {
+            return null;
+        }
+
+        $normalized = mb_strtolower($name);
+
+        $existing = static::query()
+            ->where('context', $context)
+            ->whereRaw('LOWER(name) = ?', [$normalized])
+            ->first();
+
+        if ($existing) {
+            return $existing;
+        }
+
+        $slug = static::generateUniqueSlug($name, $context);
+
+        return static::create([
+            'context' => $context,
+            'name' => $name,
+            'slug' => $slug,
+            'description' => null,
+            'sort_order' => 0,
+        ]);
+    }
+}

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Test extends Model
+{
+    use HasFactory;
+
+    /**
+     * 可批次指定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
+
+class User extends Authenticatable implements MustVerifyEmail
+{
+    use HasFactory;
+    use Notifiable;
+    use SoftDeletes;
+
+    /**
+     * 使用者狀態與儲存數值對應。
+     *
+     * @var array<string, int>
+     */
+    public const STATUS_MAP = [
+        'active' => 1,
+        'inactive' => 2,
+    ];
+
+    /**
+     * 可批次指定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+        'locale',
+        'status',
+        'email_verified_at',
+    ];
+
+    /**
+     * 隱藏欄位設定。
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * 轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+    ];
+
+    /**
+     * 狀態屬性轉換。
+     */
+    protected function status(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value): string => array_flip(self::STATUS_MAP)[$value] ?? 'inactive',
+            set: function ($value) {
+                if (is_int($value)) {
+                    return $value;
+                }
+
+                $key = is_string($value) ? strtolower($value) : 'active';
+
+                return self::STATUS_MAP[$key] ?? self::STATUS_MAP['active'];
+            }
+        );
+    }
+
+    /**
+     * 使用者角色的關聯資料。
+     */
+    public function userRoles(): HasMany
+    {
+        return $this->hasMany(UserRole::class);
+    }
+
+    /**
+     * 直接取得角色資料。
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'user_roles')
+            ->withPivot(['status', 'assigned_at']);
+    }
+
+    /**
+     * 使用者個人檔案。
+     */
+    public function profile(): HasOne
+    {
+        return $this->hasOne(UserProfile::class);
+    }
+
+    /**
+     * 取得啟用中的角色列表。
+     *
+     * @return array<int, string>
+     */
+    public function getActiveRoles(): array
+    {
+        return $this->activeRoleCollection()
+            ->sortByDesc(fn (Role $role) => $role->priority ?? 0)
+            ->pluck('name')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * 判斷是否擁有指定角色。
+     */
+    public function hasRole(string $role): bool
+    {
+        return in_array($role, $this->getActiveRoles(), true);
+    }
+
+    /**
+     * 判斷是否擁有指定角色或更高權限。
+     */
+    public function hasRoleOrHigher(string $role): bool
+    {
+        $targetPriority = Role::query()->where('name', $role)->value('priority');
+        if ($targetPriority === null) {
+            return $this->hasRole($role);
+        }
+
+        return $this->activeRoleCollection()
+            ->contains(fn (Role $roleModel) => ($roleModel->priority ?? 0) >= $targetPriority);
+    }
+
+    /**
+     * 主要角色存取器。
+     */
+    public function getRoleAttribute(): ?string
+    {
+        return $this->activeRoleCollection()
+            ->sortByDesc(fn (Role $role) => $role->priority ?? 0)
+            ->pluck('name')
+            ->first();
+    }
+
+    /**
+     * 是否為管理員。
+     */
+    public function isAdmin(): bool
+    {
+        return $this->hasRole('admin');
+    }
+
+    /**
+     * 是否為教師。
+     */
+    public function isTeacher(): bool
+    {
+        return $this->hasRole('teacher');
+    }
+
+    /**
+     * 查詢範圍：僅啟用的使用者。
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_MAP['active']);
+    }
+
+    /**
+     * 取得目前啟用中的角色集合。
+     */
+    protected function activeRoleCollection(): Collection
+    {
+        $roles = $this->relationLoaded('roles')
+            ? $this->getRelation('roles')
+            : $this->roles()->get();
+
+        return $roles->filter(function (Role $role) {
+            $status = $role->pivot->status ?? 'active';
+
+            return strtolower((string) $status) === 'active';
+        });
+    }
+}

--- a/app/Models/UserProfile.php
+++ b/app/Models/UserProfile.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class UserProfile extends Model
+{
+    use HasFactory;
+
+    /**
+     * 允許批次指定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'avatar_url',
+        'bio',
+        'experience',
+        'education',
+    ];
+
+    /**
+     * 欄位轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'experience' => 'array',
+        'education' => 'array',
+    ];
+
+    /**
+     * 關聯的使用者。
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * 個人檔案的外部連結。
+     */
+    public function links(): HasMany
+    {
+        return $this->hasMany(UserProfileLink::class);
+    }
+}

--- a/app/Models/UserProfileLink.php
+++ b/app/Models/UserProfileLink.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserProfileLink extends Model
+{
+    use HasFactory;
+
+    /**
+     * 可批次指定的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_profile_id',
+        'type',
+        'label',
+        'url',
+        'sort_order',
+    ];
+
+    /**
+     * 欄位轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'sort_order' => 'integer',
+    ];
+
+    /**
+     * 所屬的個人檔案。
+     */
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(UserProfile::class, 'user_profile_id');
+    }
+}

--- a/app/Models/UserRole.php
+++ b/app/Models/UserRole.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserRole extends Model
+{
+    use HasFactory;
+
+    /**
+     * 允許批次填充的欄位。
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'role_id',
+        'status',
+        'assigned_at',
+    ];
+
+    /**
+     * 欄位轉型設定。
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'assigned_at' => 'datetime',
+    ];
+
+    /**
+     * 關聯的使用者。
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * 關聯的角色。
+     */
+    public function role(): BelongsTo
+    {
+        return $this->belongsTo(Role::class);
+    }
+}


### PR DESCRIPTION
## Summary
- 建立 Attachment、Post 與 Tag 等內容管理模型，提供欄位轉換、關聯與標籤同步邏輯
- 新增 User、Role、UserProfile 相關模型，支援帳號狀態與角色權限判斷
- 補齊 Program、Lab、Classroom、Project 等模組的資料模型與樞紐關聯

## Testing
- `php artisan test` *(失敗：缺少 vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb1e995dc8323b09576007921bffa