### PR TITLE
feat: unify mobile header actions

### DIFF
--- a/resources/js/components/app/app-inline-action.tsx
+++ b/resources/js/components/app/app-inline-action.tsx
@@ -1,0 +1,76 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import type { ComponentProps } from 'react';
+import { Link } from '@inertiajs/react';
+import { cn } from '@/lib/utils';
+
+const baseClasses =
+    'group inline-flex items-center gap-2 rounded-md bg-transparent px-2.5 py-1 text-sm font-semibold leading-none text-neutral-900 transition-colors duration-200 hover:text-neutral-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:ring-offset-0';
+
+interface AppInlineActionButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'className' | 'children'> {
+    children: ReactNode;
+    className?: string;
+    isActive?: boolean;
+}
+
+export function AppInlineActionButton({
+    children,
+    className,
+    isActive,
+    type = 'button',
+    ...props
+}: AppInlineActionButtonProps) {
+    return (
+        <button
+            {...props}
+            data-active={isActive ? 'true' : undefined}
+            className={cn(baseClasses, isActive && 'text-blue-600', className)}
+            type={type}
+        >
+            {children}
+        </button>
+    );
+}
+
+interface AppInlineActionLinkProps extends Omit<ComponentProps<typeof Link>, 'className' | 'children'> {
+    children: ReactNode;
+    className?: string;
+    isActive?: boolean;
+}
+
+export function AppInlineActionLink({
+    children,
+    className,
+    isActive,
+    ...props
+}: AppInlineActionLinkProps) {
+    return (
+        <Link
+            {...props}
+            data-active={isActive ? 'true' : undefined}
+            className={cn(baseClasses, isActive && 'text-blue-600', className)}
+        >
+            {children}
+        </Link>
+    );
+}
+
+interface AppInlineActionLabelProps {
+    children: ReactNode;
+    className?: string;
+    isActive?: boolean;
+}
+
+export function AppInlineActionLabel({ children, className, isActive }: AppInlineActionLabelProps) {
+    return (
+        <span className={cn('relative inline-flex items-center gap-1 leading-none text-current', className)}>
+            <span className="relative z-10">{children}</span>
+            <span
+                aria-hidden="true"
+                className={cn(
+                    'pointer-events-none absolute left-0 top-full mt-0.5 h-px w-full origin-left scale-x-0 bg-current transition-transform duration-300 ease-out group-hover:scale-x-100',
+                    isActive && 'scale-x-100'
+                )}
+            />
+        </span>
+    );
+}

--- a/resources/js/components/app/app-lang-switcher.tsx
+++ b/resources/js/components/app/app-lang-switcher.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils';
 import type { SharedData } from '@/types';
 import { usePage, router } from '@inertiajs/react';
 import { Languages } from 'lucide-react';
+import { AppInlineActionButton, AppInlineActionLabel } from './app-inline-action';
 
 interface LanguageSwitcherProps {
     className?: string;
@@ -26,26 +27,19 @@ export default function LanguageSwitcher({ className = '' }: LanguageSwitcherPro
     };
 
     return (
-        <button
-            type="button"
-            className={cn(
-                'group inline-flex items-center gap-1 rounded-md bg-transparent px-2.5 py-1 text-sm font-bold leading-none text-neutral-900 transition-colors duration-200 hover:text-neutral-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:ring-offset-0',
-                className,
-            )}
-            aria-label={t('layout.language_label', '語言')}
+        <AppInlineActionButton
             onClick={handleLanguageSwitch}
+            aria-label={t('layout.language_label', '語言')}
+            className={cn('text-neutral-900', className)}
         >
-            <span className="flex items-center gap-1">
-                <Languages
-                    aria-hidden
-                    className="h-3.5 w-3.5 text-current transition-transform duration-200 group-hover:-translate-y-0.5"
-                    strokeWidth={1.6}
-                />
-                <span className="relative uppercase tracking-[0.18em]">
-                    <span className="relative z-10">{isZh ? zhBtnText : enBtnText}</span>
-                    <span className="absolute left-0 top-full mt-0.5 h-[1px] w-full origin-left scale-x-0 bg-neutral-900 transition-transform duration-300 ease-out group-hover:scale-x-100" />
-                </span>
-            </span>
-        </button>
+            <Languages
+                aria-hidden
+                className="h-3.5 w-3.5 text-current transition-transform duration-200 group-hover:-translate-y-0.5"
+                strokeWidth={1.6}
+            />
+            <AppInlineActionLabel className="uppercase tracking-[0.18em]">
+                {isZh ? zhBtnText : enBtnText}
+            </AppInlineActionLabel>
+        </AppInlineActionButton>
     );
 }

--- a/resources/js/components/app/app-mobile-navbar.tsx
+++ b/resources/js/components/app/app-mobile-navbar.tsx
@@ -6,6 +6,11 @@ import type { SharedData } from '@/types';
 import LanguageSwitcher from './app-lang-switcher';
 import { ArrowRight, ChevronDown, LogIn, Search, User, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import {
+    AppInlineActionButton,
+    AppInlineActionLabel,
+    AppInlineActionLink,
+} from './app-inline-action';
 
 interface NavItem {
     key: string;
@@ -119,30 +124,60 @@ export default function AppMobileNavbar({
                     </div>
                 ))}
 
-                {/* 搜尋欄位 */}
-                <div className="px-4">
-                    <button
-                        type="button"
-                        onClick={isSearchOpen ? handleSearchClose : handleSearchToggle}
-                        className={cn(
-                            'flex w-full items-center px-4 py-2 text-gray-700 transition-colors hover:bg-gray-50 rounded-lg',
-                            isSearchOpen && 'bg-blue-50 text-blue-600 hover:bg-blue-100'
+                {/* 快速操作：搜尋 / 登入 / 語言切換 */}
+                <div className="border-t px-4 py-4 space-y-3">
+                    <div className="flex flex-wrap items-center gap-3">
+                        <AppInlineActionButton
+                            onClick={isSearchOpen ? handleSearchClose : handleSearchToggle}
+                            aria-expanded={isSearchOpen}
+                            aria-controls="mobile-search-panel"
+                            isActive={isSearchOpen}
+                        >
+                            <Search
+                                className={cn(
+                                    'h-3.5 w-3.5 text-current transition-transform duration-200 group-hover:-translate-y-0.5',
+                                    isSearchOpen && '-translate-y-0.5'
+                                )}
+                            />
+                            <AppInlineActionLabel className="text-sm" isActive={isSearchOpen}>
+                                {t('search', '搜尋')}
+                            </AppInlineActionLabel>
+                        </AppInlineActionButton>
+
+                        {isAuthenticated ? (
+                            <AppInlineActionLink href="/dashboard" onClick={onClose} className="text-neutral-900">
+                                <User className="h-3.5 w-3.5 text-current transition-transform duration-200 group-hover:-translate-y-0.5" />
+                                <AppInlineActionLabel className="text-sm">
+                                    {t('auth.dashboard', 'Dashboard')}
+                                </AppInlineActionLabel>
+                            </AppInlineActionLink>
+                        ) : (
+                            <AppInlineActionLink
+                                href="/login"
+                                onClick={onClose}
+                                className="text-blue-600 hover:text-blue-500"
+                            >
+                                <LogIn className="h-3.5 w-3.5 text-current transition-transform duration-200 group-hover:-translate-y-0.5" />
+                                <AppInlineActionLabel className="text-sm">
+                                    {t('auth.login', 'Login')}
+                                </AppInlineActionLabel>
+                            </AppInlineActionLink>
                         )}
-                        aria-expanded={isSearchOpen}
-                    >
-                        <Search className="h-4 w-4 mr-3" />
-                        {t('search', '搜尋')}
-                    </button>
+
+                        <LanguageSwitcher className="text-neutral-900" />
+                    </div>
+
                     <div
+                        id="mobile-search-panel"
                         className={cn(
                             'overflow-hidden transition-all duration-300 ease-out',
-                            isSearchOpen ? 'max-h-32 opacity-100' : 'max-h-0 opacity-0'
+                            isSearchOpen ? 'max-h-40 opacity-100' : 'max-h-0 opacity-0'
                         )}
                         aria-hidden={!isSearchOpen}
                     >
                         <form
                             onSubmit={handleSearchSubmit}
-                            className="mt-3 flex items-center gap-3 px-1"
+                            className="flex items-center gap-3 px-1"
                         >
                             <Search className="h-4 w-4 flex-shrink-0 text-gray-400" />
                             <div className="relative flex-1">
@@ -183,35 +218,6 @@ export default function AppMobileNavbar({
                             </button>
                         </form>
                     </div>
-                </div>
-
-                {/* 分隔線 */}
-                <div className="border-t my-2"></div>
-
-                {/* 登入/使用者 */}
-                {isAuthenticated ? (
-                    <Link
-                        href="/dashboard"
-                        className="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-50 transition-colors"
-                        onClick={onClose}
-                    >
-                        <User className="h-4 w-4 mr-3" />
-                        {t('auth.dashboard', 'Dashboard')}
-                    </Link>
-                ) : (
-                    <Link
-                        href="/login"
-                        className="flex items-center px-4 py-2 text-blue-600 hover:bg-blue-50 transition-colors"
-                        onClick={onClose}
-                    >
-                        <LogIn className="h-4 w-4 mr-3" />
-                        {t('auth.login', 'Login')}
-                    </Link>
-                )}
-
-                {/* 語言切換器 */}
-                <div className="px-4 py-2 border-t">
-                    <LanguageSwitcher />
                 </div>
             </nav>
         </div>


### PR DESCRIPTION
## Summary
- add a reusable inline action component to share styling and animation for small header controls
- refactor the language switcher to consume the new inline action presentation
- realign the mobile navbar actions so search, authentication, and language controls sit on one row with matching motion and an expanding search panel

## Testing
- npm run build *(fails: php artisan wayfinder:generate requires backend tooling in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc04abbbc083239ec03050e495572f