### PR TITLE
Use alias imports for app components

### DIFF
--- a/resources/js/components/app/app-header-actions.tsx
+++ b/resources/js/components/app/app-header-actions.tsx
@@ -1,7 +1,7 @@
 import { Link, usePage } from '@inertiajs/react';
 import type { SharedData } from '@/types';
 import { useTranslator } from '@/hooks/use-translator';
-import LanguageSwitcher from './app-lang-switcher';
+import LanguageSwitcher from '@/components/app/app-lang-switcher';
 import {
     Menu,
     X,
@@ -9,7 +9,7 @@ import {
     LogIn
 } from 'lucide-react';
 import type { FormEvent } from 'react';
-import AppSearchBar from './app-search-bar';
+import AppSearchBar from '@/components/app/app-search-bar';
 
 interface AppHeaderActionsProps {
     isMobileMenuOpen: boolean;

--- a/resources/js/components/app/app-lang-switcher.tsx
+++ b/resources/js/components/app/app-lang-switcher.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/lib/utils';
 import type { SharedData } from '@/types';
 import { usePage, router } from '@inertiajs/react';
 import { Languages } from 'lucide-react';
-import { AppInlineActionButton, AppInlineActionLabel } from './app-inline-action';
+import { AppInlineActionButton, AppInlineActionLabel } from '@/components/app/app-inline-action';
 
 interface LanguageSwitcherProps {
     className?: string;

--- a/resources/js/components/app/app-logo.tsx
+++ b/resources/js/components/app/app-logo.tsx
@@ -1,5 +1,5 @@
 import { usePage } from '@inertiajs/react';
-import AppLogoIcon from './app-logo-icon';
+import AppLogoIcon from '@/components/app/app-logo-icon';
 
 export default function AppLogo() {
     const page = usePage<any>();

--- a/resources/js/components/app/app-manage-logo.tsx
+++ b/resources/js/components/app/app-manage-logo.tsx
@@ -1,5 +1,5 @@
 import { usePage } from '@inertiajs/react';
-import AppLogoIcon from './app-logo-icon';
+import AppLogoIcon from '@/components/app/app-logo-icon';
 
 export default function AppLogo() {
     const page = usePage<any>();

--- a/resources/js/components/app/app-mobile-navbar.tsx
+++ b/resources/js/components/app/app-mobile-navbar.tsx
@@ -3,14 +3,14 @@ import type { FormEvent } from 'react';
 import { Link, usePage } from '@inertiajs/react';
 import { useTranslator } from '@/hooks/use-translator';
 import type { SharedData } from '@/types';
-import LanguageSwitcher from './app-lang-switcher';
+import LanguageSwitcher from '@/components/app/app-lang-switcher';
 import { ArrowRight, ChevronDown, LogIn, Search, User, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
     AppInlineActionButton,
     AppInlineActionLabel,
     AppInlineActionLink,
-} from './app-inline-action';
+} from '@/components/app/app-inline-action';
 
 interface NavItem {
     key: string;


### PR DESCRIPTION
## Summary
- replace relative imports in app components with the configured `@` alias for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc75f816288323a5762162a5f7ea15