### PR TITLE
feat: scaffold manage dashboard layout

### DIFF
--- a/resources/js/components/manage/manage-main-content.tsx
+++ b/resources/js/components/manage/manage-main-content.tsx
@@ -1,0 +1,15 @@
+import { cn } from '@/lib/utils';
+import type { ReactNode } from 'react';
+
+interface ManageMainContentProps {
+    children: ReactNode;
+    className?: string;
+}
+
+export default function ManageMainContent({ children, className }: ManageMainContentProps) {
+    return (
+        <section className={cn('flex flex-col gap-6', className)}>
+            {children}
+        </section>
+    );
+}

--- a/resources/js/components/manage/manage-main-footer.tsx
+++ b/resources/js/components/manage/manage-main-footer.tsx
@@ -1,0 +1,31 @@
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { useTranslator } from '@/hooks/use-translator';
+import type { ReactNode } from 'react';
+
+interface ManageMainFooterProps {
+    children?: ReactNode;
+}
+
+export default function ManageMainFooter({ children }: ManageMainFooterProps) {
+    const { t } = useTranslator('manage');
+
+    if (children) {
+        return <footer className="flex flex-col gap-2 text-sm text-neutral-500">{children}</footer>;
+    }
+
+    return (
+        <footer className="flex flex-col gap-4 rounded-xl border border-dashed border-neutral-200 bg-white/75 px-4 py-3 text-sm text-neutral-500">
+            <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline" className="rounded-full px-3 py-1 text-xs">
+                    {t('layout.footer', 'CSIE Admin')}
+                </Badge>
+                <span>{t('access.denied_role', '目前角色：:role', { role: t('sidebar.admin.nav_label', 'Administration') })}</span>
+            </div>
+            <Separator />
+            <p className="text-xs leading-relaxed text-neutral-500">
+                {t('settings.description', '管理個人資訊、安全性設定與介面外觀。')}
+            </p>
+        </footer>
+    );
+}

--- a/resources/js/components/manage/manage-main-header-breadcumb.tsx
+++ b/resources/js/components/manage/manage-main-header-breadcumb.tsx
@@ -1,0 +1,25 @@
+import { Breadcrumbs } from '@/components/breadcrumbs';
+import { useTranslator } from '@/hooks/use-translator';
+import type { BreadcrumbItem } from '@/types';
+
+interface ManageMainHeaderBreadcrumbProps {
+    breadcrumbs?: BreadcrumbItem[];
+}
+
+export default function ManageMainHeaderBreadcrumb({ breadcrumbs }: ManageMainHeaderBreadcrumbProps) {
+    const { t } = useTranslator('manage');
+    const resolvedBreadcrumbs = breadcrumbs?.length
+        ? breadcrumbs
+        : [
+              {
+                  title: t('layout.breadcrumbs.dashboard', '管理後台'),
+                  href: '/manage/dashboard',
+              },
+          ];
+
+    return (
+        <div className="flex flex-col gap-2">
+            <Breadcrumbs breadcrumbs={resolvedBreadcrumbs} />
+        </div>
+    );
+}

--- a/resources/js/components/manage/manage-main-header-navbar.tsx
+++ b/resources/js/components/manage/manage-main-header-navbar.tsx
@@ -1,0 +1,35 @@
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useTranslator } from '@/hooks/use-translator';
+import { Download, Filter, PlusCircle } from 'lucide-react';
+import type { MouseEventHandler } from 'react';
+
+interface ManageMainHeaderNavbarProps {
+    onCreate?: MouseEventHandler<HTMLButtonElement>;
+    onFilter?: MouseEventHandler<HTMLButtonElement>;
+    onExport?: MouseEventHandler<HTMLButtonElement>;
+}
+
+export default function ManageMainHeaderNavbar({ onCreate, onFilter, onExport }: ManageMainHeaderNavbarProps) {
+    const { t } = useTranslator('manage');
+
+    return (
+        <div className="flex flex-wrap items-center gap-2">
+            <Button size="sm" className="gap-2" onClick={onCreate}>
+                <PlusCircle className="h-4 w-4" />
+                {t('sidebar.admin.posts_create', '新增公告')}
+            </Button>
+            <Button variant="outline" size="sm" className="gap-2" onClick={onFilter}>
+                <Filter className="h-4 w-4" />
+                {t('sidebar.admin.tags', '條件篩選')}
+            </Button>
+            <Button variant="ghost" size="sm" className="gap-2" onClick={onExport}>
+                <Download className="h-4 w-4" />
+                {t('sidebar.admin.attachments', '匯出資料')}
+            </Button>
+            <Badge variant="outline" className="hidden rounded-full px-3 py-1 text-xs text-neutral-500 sm:inline-flex">
+                {t('layout.sidebar.admin.dashboard', '儀表板')}
+            </Badge>
+        </div>
+    );
+}

--- a/resources/js/components/manage/manage-main-header.tsx
+++ b/resources/js/components/manage/manage-main-header.tsx
@@ -1,0 +1,33 @@
+import ManageMainHeaderBreadcrumb from '@/components/manage/manage-main-header-breadcumb';
+import ManageMainHeaderNavbar from '@/components/manage/manage-main-header-navbar';
+import { useTranslator } from '@/hooks/use-translator';
+import type { BreadcrumbItem } from '@/types';
+import type { ReactNode } from 'react';
+
+interface ManageMainHeaderProps {
+    title?: string;
+    description?: string;
+    breadcrumbs?: BreadcrumbItem[];
+    actions?: ReactNode;
+}
+
+export default function ManageMainHeader({ title, description, breadcrumbs, actions }: ManageMainHeaderProps) {
+    const { t } = useTranslator('manage');
+    const resolvedTitle = title ?? t('layout.breadcrumbs.admin_dashboard', '系統概覽');
+    const resolvedDescription = description ?? t('settings.description', '快速檢視系統狀態與最新活動。');
+
+    return (
+        <div className="flex flex-col gap-4">
+            <ManageMainHeaderBreadcrumb breadcrumbs={breadcrumbs} />
+            <div className="flex flex-col gap-4 rounded-xl border border-neutral-200 bg-white/95 p-4 shadow-sm backdrop-blur-sm lg:flex-row lg:items-start lg:justify-between">
+                <div className="flex flex-1 flex-col gap-2">
+                    <h1 className="text-2xl font-semibold tracking-tight text-neutral-900 sm:text-3xl">{resolvedTitle}</h1>
+                    <p className="max-w-3xl text-sm text-neutral-600 sm:text-base">{resolvedDescription}</p>
+                </div>
+                <div className="flex flex-col justify-end gap-3 sm:flex-row sm:items-center">
+                    {actions ?? <ManageMainHeaderNavbar />}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/manage/manage-sidebar-footer.tsx
+++ b/resources/js/components/manage/manage-sidebar-footer.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@/components/ui/button';
+import { useTranslator } from '@/hooks/use-translator';
+import { ExternalLink, Github, Settings } from 'lucide-react';
+
+export default function ManageSidebarFooter() {
+    const { t } = useTranslator('manage');
+
+    return (
+        <div className="flex flex-col gap-2 p-4 text-sm text-white/80">
+            <Button variant="ghost" size="sm" className="justify-start gap-2 text-white/80 hover:bg-white/10 hover:text-white">
+                <Settings className="h-4 w-4" />
+                {t('sidebar.footer.settings', '系統設定')}
+            </Button>
+            <Button
+                variant="ghost"
+                size="sm"
+                className="justify-start gap-2 text-white/80 hover:bg-white/10 hover:text-white"
+                asChild
+            >
+                <a href="https://csie.ncku.edu.tw" target="_blank" rel="noreferrer">
+                    <ExternalLink className="h-4 w-4" />
+                    {t('sidebar.footer.docs', '操作手冊')}
+                </a>
+            </Button>
+            <Button
+                variant="ghost"
+                size="sm"
+                className="justify-start gap-2 text-white/80 hover:bg-white/10 hover:text-white"
+                asChild
+            >
+                <a href="https://github.com" target="_blank" rel="noreferrer">
+                    <Github className="h-4 w-4" />
+                    {t('sidebar.footer.repo', '程式碼倉庫')}
+                </a>
+            </Button>
+        </div>
+    );
+}

--- a/resources/js/components/manage/manage-sidebar-header.tsx
+++ b/resources/js/components/manage/manage-sidebar-header.tsx
@@ -1,0 +1,59 @@
+import ManageLogo from '@/components/manage/manage-logo';
+import { Select } from '@/components/ui/select';
+import { useTranslator } from '@/hooks/use-translator';
+import type { ChangeEvent } from 'react';
+
+interface ManageSidebarHeaderProps {
+    brand: {
+        primary: string;
+        secondary?: string;
+    };
+    locales: string[];
+    currentLocale: string;
+    onLocaleChange: (locale: string) => void;
+}
+
+export default function ManageSidebarHeader({ brand, locales, currentLocale, onLocaleChange }: ManageSidebarHeaderProps) {
+    const { t } = useTranslator('manage');
+
+    const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+        onLocaleChange(event.target.value);
+    };
+
+    const getLocaleLabel = (locale: string) => {
+        switch (locale) {
+            case 'zh-TW':
+                return '繁體中文';
+            case 'en':
+                return 'English';
+            default:
+                return locale;
+        }
+    };
+
+    return (
+        <div className="flex flex-col gap-4 p-4">
+            <div className="flex items-center gap-3">
+                <ManageLogo />
+                <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-white">{brand.primary}</p>
+                    {brand.secondary && (
+                        <p className="truncate text-xs text-white/70">{brand.secondary}</p>
+                    )}
+                </div>
+            </div>
+            <div className="flex flex-col gap-2">
+                <label className="text-xs font-medium uppercase tracking-wide text-white/70">
+                    {t('access.back_to_dashboard', '介面語言')}
+                </label>
+                <Select value={currentLocale} onChange={handleChange} className="bg-white/95 text-sm">
+                    {locales.map((locale) => (
+                        <option key={locale} value={locale}>
+                            {getLocaleLabel(locale)}
+                        </option>
+                    ))}
+                </Select>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/manage/manage-sidebar-main.tsx
+++ b/resources/js/components/manage/manage-sidebar-main.tsx
@@ -1,0 +1,169 @@
+import {
+    SidebarGroup,
+    SidebarGroupContent,
+    SidebarGroupLabel,
+    SidebarMenu,
+    SidebarMenuButton,
+    SidebarMenuItem,
+} from '@/components/ui/sidebar';
+import { useTranslator } from '@/hooks/use-translator';
+import type { NavItem } from '@/types';
+import { Link, usePage } from '@inertiajs/react';
+import {
+    FolderKanban,
+    GaugeCircle,
+    LayoutDashboard,
+    Megaphone,
+    MessageSquare,
+    Settings,
+    ShieldCheck,
+    Tag,
+    Users,
+} from 'lucide-react';
+
+interface ManageSidebarMainProps {
+    role: 'admin' | 'teacher' | 'user';
+}
+
+type TranslatorFn = (key: string, fallback?: string, replacements?: Record<string, string | number>) => string;
+
+export default function ManageSidebarMain({ role }: ManageSidebarMainProps) {
+    const { t } = useTranslator('manage');
+    const page = usePage();
+    const currentPath = page.url ?? '';
+
+    const groups = buildGroups(role, t);
+
+    return (
+        <SidebarMenu>
+            {groups.map((group) => (
+                <SidebarGroup key={group.title} className="space-y-2">
+                    <SidebarGroupLabel className="px-2 text-xs font-semibold uppercase tracking-wider text-white/60">
+                        {group.title}
+                    </SidebarGroupLabel>
+                    <SidebarGroupContent className="space-y-1">
+                        {group.items.map((item) => (
+                            <SidebarMenuItem key={item.href}>
+                                <SidebarMenuButton asChild isActive={currentPath.startsWith(item.href)}>
+                                    <Link href={item.href} className="flex items-center gap-3">
+                                        {item.icon && <item.icon className="h-4 w-4" />}
+                                        <span>{item.title}</span>
+                                    </Link>
+                                </SidebarMenuButton>
+                            </SidebarMenuItem>
+                        ))}
+                    </SidebarGroupContent>
+                </SidebarGroup>
+            ))}
+        </SidebarMenu>
+    );
+}
+
+function buildGroups(role: 'admin' | 'teacher' | 'user', t: TranslatorFn): Array<{ title: string; items: NavItem[] }> {
+    switch (role) {
+        case 'teacher':
+            return [
+                {
+                    title: t('sidebar.teacher.nav_label', '教學'),
+                    items: [
+                        {
+                            title: t('sidebar.teacher.dashboard', '教學首頁'),
+                            href: '/manage/dashboard',
+                            icon: LayoutDashboard,
+                        },
+                        {
+                            title: t('sidebar.teacher.posts', '公告管理'),
+                            href: '/manage/posts',
+                            icon: Megaphone,
+                        },
+                        {
+                            title: t('sidebar.teacher.labs', '實驗室'),
+                            href: '/manage/labs',
+                            icon: FolderKanban,
+                        },
+                        {
+                            title: t('sidebar.teacher.projects', '研究計畫'),
+                            href: '/manage/projects',
+                            icon: GaugeCircle,
+                        },
+                        {
+                            title: t('sidebar.teacher.profile', '個人設定'),
+                            href: '/manage/settings/profile',
+                            icon: Settings,
+                        },
+                    ],
+                },
+            ];
+        case 'user':
+            return [
+                {
+                    title: t('sidebar.user.nav_label', '會員專區'),
+                    items: [
+                        {
+                            title: t('sidebar.user.dashboard', '會員首頁'),
+                            href: '/manage/dashboard',
+                            icon: LayoutDashboard,
+                        },
+                        {
+                            title: t('sidebar.user.profile', '個人檔案'),
+                            href: '/manage/settings/profile',
+                            icon: Users,
+                        },
+                        {
+                            title: t('sidebar.user.appearance', '外觀設定'),
+                            href: '/manage/settings/appearance',
+                            icon: GaugeCircle,
+                        },
+                        {
+                            title: t('sidebar.user.security', '安全設定'),
+                            href: '/manage/settings/password',
+                            icon: ShieldCheck,
+                        },
+                        {
+                            title: t('sidebar.user.support', '技術支援'),
+                            href: '/manage/support',
+                            icon: MessageSquare,
+                        },
+                    ],
+                },
+            ];
+        default:
+            return [
+                {
+                    title: t('sidebar.admin.nav_label', '行政管理'),
+                    items: [
+                        {
+                            title: t('sidebar.admin.dashboard', '儀表板'),
+                            href: '/manage/dashboard',
+                            icon: LayoutDashboard,
+                        },
+                        {
+                            title: t('sidebar.admin.posts', '公告訊息'),
+                            href: '/manage/posts',
+                            icon: Megaphone,
+                        },
+                        {
+                            title: t('sidebar.admin.tags', '標籤管理'),
+                            href: '/manage/tags',
+                            icon: Tag,
+                        },
+                        {
+                            title: t('sidebar.admin.users', '使用者'),
+                            href: '/manage/users',
+                            icon: Users,
+                        },
+                        {
+                            title: t('sidebar.admin.attachments', '附件資源'),
+                            href: '/manage/attachments',
+                            icon: FolderKanban,
+                        },
+                        {
+                            title: t('sidebar.admin.messages', '聯絡表單'),
+                            href: '/manage/messages',
+                            icon: MessageSquare,
+                        },
+                    ],
+                },
+            ];
+    }
+}

--- a/resources/js/layouts/manage/manage-layout.tsx
+++ b/resources/js/layouts/manage/manage-layout.tsx
@@ -1,0 +1,118 @@
+import ManagePage, { type ManagePageProps } from '@/layouts/manage/manage-page';
+import ManageSidebar, { type ManageSidebarProps } from '@/layouts/manage/manage-siderbar';
+import { useTranslator } from '@/hooks/use-translator';
+import type { SharedData, User } from '@/types';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from '@/components/ui/sidebar';
+import { usePage } from '@inertiajs/react';
+import { isValidElement, cloneElement, type ReactElement, type ReactNode } from 'react';
+import { LifeBuoy, ShieldCheck } from 'lucide-react';
+
+interface ManageLayoutProps {
+    children: ReactNode;
+}
+
+function resolvePrimaryRole(user: User | undefined): 'admin' | 'teacher' | 'user' {
+    if (!user) {
+        return 'admin';
+    }
+
+    if (user.primary_role) {
+        return user.primary_role;
+    }
+
+    if (user.roles?.length) {
+        return user.roles[0];
+    }
+
+    return 'admin';
+}
+
+export default function ManageLayout({ children }: ManageLayoutProps) {
+    const page = usePage<SharedData>();
+    const { t } = useTranslator('manage');
+    const user = page.props.auth?.user;
+    const role = resolvePrimaryRole(user);
+    const locales = page.props.locales ?? ['zh-TW', 'en'];
+    const currentLocale = page.props.locale ?? locales[0] ?? 'zh-TW';
+
+    const brandCopy: ManageSidebarProps['brand'] = {
+        primary: t(`layout.brand.${role}.primary`, role === 'teacher' ? 'CSIE Teacher' : role === 'user' ? 'CSIE Member' : 'CSIE Admin'),
+        secondary: t(
+            `layout.brand.${role}.secondary`,
+            role === 'teacher' ? '教學主控台' : role === 'user' ? '會員專區' : '管理主控台'
+        ),
+    };
+
+    const sidebarProps: ManageSidebarProps = {
+        brand: brandCopy,
+        role,
+        currentLocale,
+        locales,
+    };
+
+    const defaultPageProps: ManagePageProps = {
+        title: t('layout.breadcrumbs.admin_dashboard', '系統總覽'),
+        description: t('access.denied_description', '歡迎回到管理後台。'),
+        breadcrumbs: [
+            {
+                title: t('layout.breadcrumbs.dashboard', '管理後台'),
+                href: '/manage/dashboard',
+            },
+            {
+                title: t('layout.breadcrumbs.admin_dashboard', '系統總覽'),
+                href: '/manage/dashboard',
+            },
+        ],
+    };
+
+    const defaultToolbar = (
+        <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary" className="rounded-full px-3 py-1 text-xs font-medium tracking-wide">
+                {t(`sidebar.${role}.nav_label`, role === 'teacher' ? '教學' : role === 'user' ? '會員' : '管理')}
+            </Badge>
+            <Button variant="ghost" size="sm" className="gap-2 text-neutral-600 hover:text-neutral-900">
+                <ShieldCheck className="h-4 w-4" />
+                {t('settings.title', '帳號設定')}
+            </Button>
+            <Button variant="ghost" size="sm" className="gap-2 text-neutral-600 hover:text-neutral-900">
+                <LifeBuoy className="h-4 w-4" />
+                {t('sidebar.footer.docs', '使用說明')}
+            </Button>
+        </div>
+    );
+
+    let content: ReactNode;
+
+    if (isValidElement(children) && (children.type === ManagePage || (children.type as any)?.displayName === ManagePage.displayName)) {
+        const child = children as ReactElement<ManagePageProps>;
+        content = cloneElement(child, {
+            title: child.props.title ?? defaultPageProps.title,
+            description: child.props.description ?? defaultPageProps.description,
+            breadcrumbs: child.props.breadcrumbs ?? defaultPageProps.breadcrumbs,
+            toolbar: child.props.toolbar ?? defaultToolbar,
+        });
+    } else {
+        content = (
+            <ManagePage
+                title={defaultPageProps.title}
+                description={defaultPageProps.description}
+                breadcrumbs={defaultPageProps.breadcrumbs}
+                toolbar={defaultToolbar}
+            >
+                {children}
+            </ManagePage>
+        );
+    }
+
+    return (
+        <SidebarProvider defaultOpen>
+            <Sidebar>
+                <ManageSidebar {...sidebarProps} />
+            </Sidebar>
+            <SidebarInset className="bg-neutral-50 text-neutral-900">{content}</SidebarInset>
+            <SidebarRail />
+        </SidebarProvider>
+    );
+}

--- a/resources/js/layouts/manage/manage-main.tsx
+++ b/resources/js/layouts/manage/manage-main.tsx
@@ -1,0 +1,24 @@
+import ManageMainContent from '@/components/manage/manage-main-content';
+import ManageMainFooter from '@/components/manage/manage-main-footer';
+import ManageMainHeader from '@/components/manage/manage-main-header';
+import type { BreadcrumbItem } from '@/types';
+import type { ReactNode } from 'react';
+
+export interface ManageMainProps {
+    title?: string;
+    description?: string;
+    breadcrumbs?: BreadcrumbItem[];
+    actions?: ReactNode;
+    footer?: ReactNode;
+    children: ReactNode;
+}
+
+export default function ManageMain({ title, description, breadcrumbs, actions, footer, children }: ManageMainProps) {
+    return (
+        <div className="flex min-h-full flex-1 flex-col gap-6">
+            <ManageMainHeader title={title} description={description} breadcrumbs={breadcrumbs} actions={actions} />
+            <ManageMainContent>{children}</ManageMainContent>
+            <ManageMainFooter>{footer}</ManageMainFooter>
+        </div>
+    );
+}

--- a/resources/js/layouts/manage/manage-page.tsx
+++ b/resources/js/layouts/manage/manage-page.tsx
@@ -1,0 +1,70 @@
+import ManageMain, { type ManageMainProps } from '@/layouts/manage/manage-main';
+import ManageMainHeaderNavbar from '@/components/manage/manage-main-header-navbar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useTranslator } from '@/hooks/use-translator';
+import { cn } from '@/lib/utils';
+import { RefreshCcw, CalendarCheck } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+export interface ManagePageProps extends ManageMainProps {
+    toolbar?: ReactNode;
+    className?: string;
+}
+
+function ManagePage({
+    title,
+    description,
+    breadcrumbs,
+    actions,
+    footer,
+    toolbar,
+    className,
+    children,
+}: ManagePageProps) {
+    const { t } = useTranslator('manage');
+    const resolvedToolbar = toolbar ?? (
+        <div className="flex flex-wrap items-center gap-2">
+            <Button variant="outline" size="sm" className="hidden sm:inline-flex">
+                <RefreshCcw className="mr-2 h-3.5 w-3.5" />
+                {t('layout.refresh', '重新整理')}
+            </Button>
+            <div className="flex items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-3 py-1 text-xs text-neutral-600">
+                <CalendarCheck className="h-3.5 w-3.5" />
+                {t('layout.brand.admin.secondary', '管理主控台')}
+            </div>
+        </div>
+    );
+    const resolvedActions = actions ?? <ManageMainHeaderNavbar />;
+
+    return (
+        <div className={cn('flex min-h-full flex-1 flex-col', className)}>
+            <header className="flex flex-col gap-3 border-b border-neutral-200 bg-white/95 px-4 py-3 shadow-sm backdrop-blur-sm lg:flex-row lg:items-center lg:justify-between lg:px-8">
+                <div className="flex items-center gap-3 text-neutral-500">
+                    <SidebarTrigger className="text-neutral-500" />
+                    <Badge variant="outline" className="hidden rounded-full border-neutral-200 px-3 py-1 text-xs font-medium tracking-wide text-neutral-600 sm:inline-flex">
+                        {t('sidebar.admin.nav_label', '管理區')}
+                    </Badge>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-sm text-neutral-600">{resolvedToolbar}</div>
+            </header>
+            <main className="flex-1 overflow-y-auto px-4 py-6 lg:px-8">
+                <ManageMain
+                    title={title}
+                    description={description}
+                    breadcrumbs={breadcrumbs}
+                    actions={resolvedActions}
+                    footer={footer}
+                >
+                    {children}
+                </ManageMain>
+            </main>
+        </div>
+    );
+}
+
+ManagePage.displayName = 'ManagePage';
+
+export default ManagePage;
+export type { ManagePageProps };

--- a/resources/js/layouts/manage/manage-siderbar.tsx
+++ b/resources/js/layouts/manage/manage-siderbar.tsx
@@ -1,0 +1,46 @@
+import ManageSidebarFooter from '@/components/manage/manage-sidebar-footer';
+import ManageSidebarHeader from '@/components/manage/manage-sidebar-header';
+import ManageSidebarMain from '@/components/manage/manage-sidebar-main';
+import { SidebarContent, SidebarFooter, SidebarHeader, SidebarSeparator } from '@/components/ui/sidebar';
+import { router } from '@inertiajs/react';
+
+export interface ManageSidebarProps {
+    brand: {
+        primary: string;
+        secondary?: string;
+    };
+    role: 'admin' | 'teacher' | 'user';
+    locales: string[];
+    currentLocale: string;
+}
+
+export default function ManageSidebar({ brand, role, locales, currentLocale }: ManageSidebarProps) {
+    const handleLocaleChange = (locale: string) => {
+        // 使用 GET 進行語系切換，保留捲動位置讓體驗更順暢
+        router.visit(`/lang/${locale}`, {
+            method: 'get',
+            preserveScroll: true,
+            preserveState: true,
+        });
+    };
+
+    return (
+        <>
+            <SidebarHeader>
+                <ManageSidebarHeader
+                    brand={brand}
+                    locales={locales}
+                    currentLocale={currentLocale}
+                    onLocaleChange={handleLocaleChange}
+                />
+            </SidebarHeader>
+            <SidebarContent>
+                <ManageSidebarMain role={role} />
+            </SidebarContent>
+            <SidebarSeparator />
+            <SidebarFooter>
+                <ManageSidebarFooter />
+            </SidebarFooter>
+        </>
+    );
+}

--- a/resources/js/pages/manage/dashboard.tsx
+++ b/resources/js/pages/manage/dashboard.tsx
@@ -1,0 +1,149 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import AppLayout from '@/layouts/app-layout';
+import ManagePage from '@/layouts/manage/manage-page';
+import { useTranslator } from '@/hooks/use-translator';
+import type { BreadcrumbItem } from '@/types';
+import { Head } from '@inertiajs/react';
+import { Activity, CalendarClock, FileText, Megaphone, Users } from 'lucide-react';
+import type { ReactElement } from 'react';
+
+const stats = [
+    {
+        icon: Megaphone,
+        labelKey: 'sidebar.admin.posts',
+        fallbackLabel: '公告總數',
+        value: '24',
+        trend: '+3',
+    },
+    {
+        icon: Users,
+        labelKey: 'sidebar.admin.users',
+        fallbackLabel: '活躍使用者',
+        value: '1,280',
+        trend: '+12%',
+    },
+    {
+        icon: FileText,
+        labelKey: 'sidebar.admin.attachments',
+        fallbackLabel: '附件總量',
+        value: '542',
+        trend: '+18',
+    },
+];
+
+const activities = [
+    {
+        title: 'CSIE 新進師資公告',
+        status: '已發佈',
+        time: '2024/03/18',
+    },
+    {
+        title: '期中考試教室調整',
+        status: '審核中',
+        time: '2024/03/17',
+    },
+    {
+        title: '學生競賽獲獎名單',
+        status: '草稿',
+        time: '2024/03/16',
+    },
+];
+
+export default function ManageDashboard() {
+    const { t } = useTranslator('manage');
+
+    const breadcrumbs: BreadcrumbItem[] = [
+        {
+            title: t('layout.breadcrumbs.dashboard', '管理後台'),
+            href: '/manage/dashboard',
+        },
+        {
+            title: t('layout.breadcrumbs.admin_dashboard', '系統總覽'),
+            href: '/manage/dashboard',
+        },
+    ];
+
+    const pageTitle = t('layout.breadcrumbs.admin_dashboard', '系統總覽');
+    const pageDescription = t('settings.description', '管理個人資訊、安全性設定與介面外觀。');
+
+    return (
+        <>
+            <Head title={pageTitle} />
+            <ManagePage title={pageTitle} description={pageDescription} breadcrumbs={breadcrumbs}>
+                <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                    {stats.map((item) => (
+                        <Card key={item.labelKey} className="overflow-hidden border border-neutral-200/80">
+                            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                                <CardTitle className="text-sm font-medium text-neutral-500">
+                                    {t(item.labelKey, item.fallbackLabel)}
+                                </CardTitle>
+                                <item.icon className="h-4 w-4 text-neutral-400" />
+                            </CardHeader>
+                            <CardContent>
+                                <div className="text-2xl font-semibold text-neutral-900">{item.value}</div>
+                                <p className="text-xs text-emerald-600">{item.trend}</p>
+                            </CardContent>
+                        </Card>
+                    ))}
+                    <Card className="border border-neutral-200/80">
+                        <CardHeader className="space-y-1">
+                            <Badge variant="outline" className="w-fit gap-2 text-xs text-neutral-500">
+                                <Activity className="h-3.5 w-3.5" />
+                                {t('sidebar.admin.messages', '最新訊息')}
+                            </Badge>
+                            <CardTitle className="text-base font-semibold text-neutral-900">
+                                {t('layout.brand.admin.secondary', '管理主控台')}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4 text-sm text-neutral-600">
+                            <p>{t('access.denied_description', '掌握系統最新狀態與公告動態。')}</p>
+                            <Button size="sm" className="w-full gap-2">
+                                <CalendarClock className="h-4 w-4" />
+                                {t('access.back_to_dashboard', '今日行程')}
+                            </Button>
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <section className="rounded-xl border border-neutral-200/80 bg-white/95 shadow-sm">
+                    <div className="flex items-center justify-between gap-4 border-b border-neutral-200 px-4 py-3">
+                        <h2 className="text-base font-semibold text-neutral-800">
+                            {t('sidebar.admin.posts', '最新公告')}
+                        </h2>
+                        <Button variant="outline" size="sm" className="gap-2">
+                            <Megaphone className="h-4 w-4" />
+                            {t('sidebar.admin.posts_create', '新增公告')}
+                        </Button>
+                    </div>
+                    <Table>
+                        <TableHeader>
+                            <TableRow className="border-neutral-200/80">
+                                <TableHead className="w-1/2 text-neutral-500">{t('sidebar.admin.posts', '標題')}</TableHead>
+                                <TableHead className="w-1/4 text-neutral-500">{t('sidebar.admin.tags', '狀態')}</TableHead>
+                                <TableHead className="w-1/4 text-right text-neutral-500">{t('sidebar.admin.attachments', '更新時間')}</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {activities.map((activity) => (
+                                <TableRow key={activity.title} className="border-neutral-200/60">
+                                    <TableCell className="font-medium text-neutral-800">{activity.title}</TableCell>
+                                    <TableCell>
+                                        <Badge variant="secondary" className="capitalize">
+                                            {activity.status}
+                                        </Badge>
+                                    </TableCell>
+                                    <TableCell className="text-right text-neutral-500">{activity.time}</TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </section>
+            </ManagePage>
+        </>
+    );
+}
+
+ManageDashboard.layout = (page: ReactElement) => <AppLayout>{page}</AppLayout>;


### PR DESCRIPTION
## Summary
- add a manage layout that wires the sidebar provider, localized brand copy, and language switcher
- implement reusable manage header/content/footer/sidebar components that share UI primitives and translations
- scaffold a manage dashboard page template with stats and activity placeholders on top of AppLayout

## Testing
- npm run build *(fails: @laravel/vite-plugin-wayfinder requires php artisan wayfinder:generate)*

------
https://chatgpt.com/codex/tasks/task_e_68dca536ef80832393781685368d8527