### PR TITLE
feat: 建立管理後台路由及角色權限

### DIFF
--- a/routes/manage/admin.php
+++ b/routes/manage/admin.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+
+Route::middleware(['auth', 'verified', 'role:admin'])
+    ->prefix('manage')
+    ->as('manage.')
+    ->group(function () {
+        Route::get('/tags', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'admin';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'tags',
+            ]);
+        })->name('tags.index');
+
+        Route::get('/users', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'admin';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'users',
+            ]);
+        })->name('users.index');
+
+        Route::get('/attachments', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'admin';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'attachments',
+            ]);
+        })->name('attachments.index');
+
+        Route::get('/messages', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'admin';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'messages',
+            ]);
+        })->name('messages.index');
+    });

--- a/routes/manage/setting.php
+++ b/routes/manage/setting.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+
+Route::middleware(['auth', 'verified', 'role:admin,teacher,user'])
+    ->prefix('manage/settings')
+    ->as('manage.settings.')
+    ->group(function () {
+        Route::get('/profile', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'user';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'settings.profile',
+            ]);
+        })->name('profile');
+
+        Route::get('/password', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'user';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'settings.password',
+            ]);
+        })->name('password');
+
+        Route::get('/appearance', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'user';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'settings.appearance',
+            ]);
+        })->name('appearance');
+    });
+
+Route::middleware(['auth', 'verified', 'role:admin,teacher,user'])
+    ->prefix('manage')
+    ->as('manage.')
+    ->group(function () {
+        Route::get('/support', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'user';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'support',
+            ]);
+        })->name('support');
+    });

--- a/routes/manage/teacher.php
+++ b/routes/manage/teacher.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+
+Route::middleware(['auth', 'verified', 'role:admin,teacher'])
+    ->prefix('manage')
+    ->as('manage.')
+    ->group(function () {
+        Route::get('/posts', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'teacher';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'posts',
+            ]);
+        })->name('posts.index');
+
+        Route::get('/labs', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'teacher';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'labs',
+            ]);
+        })->name('labs.index');
+
+        Route::get('/projects', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'teacher';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'projects',
+            ]);
+        })->name('projects.index');
+    });

--- a/routes/manage/user.php
+++ b/routes/manage/user.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+
+Route::middleware(['auth', 'verified'])
+    ->prefix('manage')
+    ->as('manage.')
+    ->group(function () {
+        Route::redirect('/', '/manage/dashboard')->name('index');
+
+        Route::get('/dashboard', function (Request $request) {
+            $user = $request->user();
+            $role = $user?->role ?? 'user';
+
+            return Inertia::render('manage/dashboard', [
+                'pageRole' => $role,
+                'pageSection' => 'dashboard',
+            ]);
+        })
+            ->middleware('role:admin,teacher,user')
+            ->name('dashboard');
+    });


### PR DESCRIPTION
## Summary
- add shared manage dashboard route with role-aware props and redirection
- create teacher/admin/user specific manage page routes guarded by role middleware
- wire settings and support pages under manage prefix with unified role access

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcbfdb37e48323a1d45d1cbe18398f