### PR TITLE
Ignore Python venv files in Vite watcher

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,15 @@ export default defineConfig({
             formVariants: true,
         }),
     ],
+    server: {
+        watch: {
+            ignored: [
+                // 忽略 Python 虛擬環境與測試套件，避免觸發過多檔案監聽器
+                'app/Agent/venv/**',
+                'app/Agent/venv/lib/**',
+            ],
+        },
+    },
     resolve: {
         alias: {
             '@': path.resolve(__dirname, './resources/js'),


### PR DESCRIPTION
## Summary
- prevent Vite from watching the Python virtual environment used for agent tooling
- avoid exhausting file watcher limits when running the dev server

## Testing
- `npm run build` *(fails: php artisan wayfinder:generate requires dependencies not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4784d1dc8323a817cc4ca128f607