### PR TITLE
Fix Manage layout duplication by using shared layout context

### DIFF
--- a/resources/js/layouts/manage/manage-layout-context.tsx
+++ b/resources/js/layouts/manage/manage-layout-context.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import type { BreadcrumbItem, NavItem } from '@/types/shared';
+
+export interface ManageLayoutContextValue {
+    quickNavItems?: NavItem[];
+    quickNavLabel?: string;
+    currentPath?: string;
+    defaultTitle?: string;
+    defaultDescription?: string;
+    defaultBreadcrumbs?: BreadcrumbItem[];
+}
+
+const ManageLayoutContext = createContext<ManageLayoutContextValue | null>(null);
+
+interface ManageLayoutProviderProps {
+    value: ManageLayoutContextValue;
+    children: ReactNode;
+}
+
+export function ManageLayoutProvider({ value, children }: ManageLayoutProviderProps) {
+    return <ManageLayoutContext.Provider value={value}>{children}</ManageLayoutContext.Provider>;
+}
+
+export function useManageLayoutContext() {
+    return useContext(ManageLayoutContext);
+}

--- a/resources/js/layouts/manage/manage-page.tsx
+++ b/resources/js/layouts/manage/manage-page.tsx
@@ -4,6 +4,7 @@ import LanguageSwitcher from '@/components/app/app-lang-switcher';
 import { Button } from '@/components/ui/button';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useTranslator } from '@/hooks/use-translator';
+import { useManageLayoutContext } from '@/layouts/manage/manage-layout-context';
 import { cn } from '@/lib/shared/utils';
 import type { NavItem, SharedData } from '@/types/shared';
 import { Link, usePage } from '@inertiajs/react';
@@ -33,15 +34,14 @@ function ManagePage({
     const { t } = useTranslator('manage');
     const page = usePage<SharedData>();
     const user = page.props.auth?.user;
-    // 注意：不要在這裡使用 ?? []，讓 undefined 保持 undefined
-    // 這樣 ManageLayout 才能正確注入 quickNavItems
-    const navItems = quickNavItems;
-    const resolvedPath = currentPath ?? page.url ?? '';
-
-    // 調試輸出
-    console.log('=== ManagePage 調試 ===');
-    console.log('接收到的 quickNavItems:', quickNavItems);
-    console.log('navItems 長度:', navItems ? navItems.length : 'undefined');
+    const layoutContext = useManageLayoutContext();
+    const resolvedQuickNavItems = quickNavItems ?? layoutContext?.quickNavItems;
+    const navItems = resolvedQuickNavItems ?? [];
+    const resolvedPath = currentPath ?? layoutContext?.currentPath ?? page.url ?? '';
+    const resolvedQuickNavLabel = quickNavLabel ?? layoutContext?.quickNavLabel ?? t('layout.quick_nav', '管理快速路徑');
+    const resolvedTitle = title ?? layoutContext?.defaultTitle;
+    const resolvedDescription = description ?? layoutContext?.defaultDescription;
+    const resolvedBreadcrumbs = breadcrumbs ?? layoutContext?.defaultBreadcrumbs;
 
     return (
         <div className={cn('flex min-h-full flex-1 flex-col', className)}>
@@ -72,17 +72,17 @@ function ManagePage({
             </header>
             <main className="flex-1 overflow-y-auto">
                 <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 lg:px-8">
-                    {navItems && navItems.length > 0 ? (
+                    {navItems.length > 0 ? (
                         <ManageQuickNav
                             items={navItems}
                             currentPath={resolvedPath}
-                            label={quickNavLabel ?? t('layout.quick_nav', '管理快速路徑')}
+                            label={resolvedQuickNavLabel}
                         />
                     ) : null}
                     <ManageMain
-                        title={title}
-                        description={description}
-                        breadcrumbs={breadcrumbs}
+                        title={resolvedTitle}
+                        description={resolvedDescription}
+                        breadcrumbs={resolvedBreadcrumbs}
                         actions={actions}
                         toolbar={toolbar}
                         footer={footer}


### PR DESCRIPTION
## Summary
- remove ManageLayout's ManagePage cloning logic and provide layout defaults through context to avoid duplicate rendering
- update ManagePage to consume quick navigation, breadcrumb, and title defaults from the shared context
- add a dedicated manage layout context module for sharing state between the layout and page components

## Testing
- npm run types *(fails: existing type errors in auth form routes and delete user component)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe8b3d84083238a98834e591f08a4