### PR TITLE
Fix contact messages translations and date picker

### DIFF
--- a/lang/en/manage.php
+++ b/lang/en/manage.php
@@ -848,6 +848,51 @@ return [
             ],
         ],
     ],
+    'messages' => [
+        'description' => 'Track and respond to inquiries from the contact form.',
+        'filters' => [
+            'keyword_label' => 'Search messages',
+            'keyword_placeholder' => 'Search by subject or sender',
+            'apply' => 'Apply',
+            'reset' => 'Reset',
+            'status_label' => 'Status filter',
+            'status_all' => 'All statuses',
+            'from' => 'Start date',
+            'to' => 'End date',
+        ],
+        'actions' => [
+            'export' => 'Export records',
+            'new' => 'Create message',
+        ],
+        'empty' => [
+            'title' => 'No messages yet',
+            'description' => 'There are currently no contact form records that match your filters.',
+        ],
+        'table' => [
+            'subject' => 'Subject',
+            'status' => 'Status',
+            'created' => 'Created at',
+            'processed' => 'Processed at',
+            'no_subject' => 'No subject provided',
+            'unprocessed' => 'Not processed yet',
+        ],
+        'status' => [
+            'new' => 'New',
+            'processing' => 'Processing',
+            'resolved' => 'Resolved',
+            'spam' => 'Spam',
+        ],
+        'detail' => [
+            'no_subject' => 'No subject provided',
+            'subheading' => 'Review the contact information and message sent by the visitor.',
+            'locale' => 'Locale: :locale',
+            'processed_at' => 'Processed at: :time',
+            'not_processed' => 'Processing time not recorded yet',
+            'processor' => 'Handled by: :name',
+            'attachment' => 'Download attachment',
+            'close' => 'Close',
+        ],
+    ],
     'staff' => [
         'index' => [
             'title' => 'Faculty & Staff Management',

--- a/lang/zh-TW/manage.php
+++ b/lang/zh-TW/manage.php
@@ -848,6 +848,51 @@ return [
             ],
         ],
     ],
+    'messages' => [
+        'description' => '追蹤與回覆訪客的聯絡資訊。',
+        'filters' => [
+            'keyword_label' => '搜尋訊息',
+            'keyword_placeholder' => '搜尋主旨或聯絡人',
+            'apply' => '套用',
+            'reset' => '重設',
+            'status_label' => '狀態篩選',
+            'status_all' => '全部狀態',
+            'from' => '起始日期',
+            'to' => '結束日期',
+        ],
+        'actions' => [
+            'export' => '匯出紀錄',
+            'new' => '建立新訊息',
+        ],
+        'empty' => [
+            'title' => '尚無訊息',
+            'description' => '目前沒有符合條件的聯絡表單紀錄。',
+        ],
+        'table' => [
+            'subject' => '主旨',
+            'status' => '狀態',
+            'created' => '建立時間',
+            'processed' => '處理時間',
+            'no_subject' => '未填寫主旨',
+            'unprocessed' => '尚未處理',
+        ],
+        'status' => [
+            'new' => '新進訊息',
+            'processing' => '處理中',
+            'resolved' => '已完成',
+            'spam' => '垃圾訊息',
+        ],
+        'detail' => [
+            'no_subject' => '未填寫主旨',
+            'subheading' => '檢視訪客傳送的聯絡資訊與內容。',
+            'locale' => '語系：:locale',
+            'processed_at' => '處理時間：:time',
+            'not_processed' => '尚未紀錄處理時間',
+            'processor' => '處理人員：:name',
+            'attachment' => '下載附件',
+            'close' => '關閉',
+        ],
+    ],
     'staff' => [
         'index' => [
             'title' => '師資與職員管理',

--- a/resources/js/pages/manage/admin/messages/index.tsx
+++ b/resources/js/pages/manage/admin/messages/index.tsx
@@ -19,7 +19,7 @@ import type {
 } from '@/types/manage';
 import type { BreadcrumbItem, SharedData } from '@/types/shared';
 import { Head, Link, router, usePage } from '@inertiajs/react';
-import type { ChangeEvent, FormEvent, ReactElement } from 'react';
+import type { ChangeEvent, FocusEvent, FormEvent, MouseEvent, ReactElement } from 'react';
 import { Download, Filter, Mail, MailPlus, User as UserIcon } from 'lucide-react';
 
 interface ManageAdminMessagesPageProps extends SharedData {
@@ -143,6 +143,11 @@ export default function ManageAdminMessagesIndex() {
         applyFilters({ [field]: value } as Partial<FilterFormState>);
     };
 
+    const openDatePicker = useCallback((event: FocusEvent<HTMLInputElement> | MouseEvent<HTMLInputElement>) => {
+        const input = event.currentTarget as HTMLInputElement & { showPicker?: () => void };
+        input.showPicker?.();
+    }, []);
+
     const handlePerPageChange = (value: string) => {
         setFilterForm((prev) => ({ ...prev, per_page: value }));
         applyFilters({ per_page: value }, { replace: true });
@@ -198,15 +203,23 @@ export default function ManageAdminMessagesIndex() {
                     <Input
                         id="filter-from"
                         type="date"
+                        name="from"
                         value={filterForm.from}
                         onChange={handleDateChange('from')}
+                        onClick={openDatePicker}
+                        onFocus={openDatePicker}
                         className="h-9 w-36"
                     />
                     <span className="text-neutral-400">~</span>
                     <Input
+                        id="filter-to"
                         type="date"
+                        name="to"
+                        aria-label={tMessages('filters.to', '結束日期')}
                         value={filterForm.to}
                         onChange={handleDateChange('to')}
+                        onClick={openDatePicker}
+                        onFocus={openDatePicker}
                         className="h-9 w-36"
                     />
                 </div>


### PR DESCRIPTION
## Summary
- add full translation coverage for the manage contact messages module in both English and Traditional Chinese
- improve the date filter inputs by exposing native pickers and accessible metadata

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0219402208323ba69d7b5d3752d59