### PR TITLE
Refine manage user filter layout

### DIFF
--- a/resources/js/components/manage/users/user-filter-form.tsx
+++ b/resources/js/components/manage/users/user-filter-form.tsx
@@ -4,6 +4,7 @@ import { Filter } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 
 import type { OptionItem, TranslatorFunction, UserFilterState } from './user-types';
@@ -47,11 +48,14 @@ export function UserFilterForm({
                 </CardTitle>
             </CardHeader>
             <CardContent>
-                <form onSubmit={onSubmit} className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6">
-                    <div className="xl:col-span-2 space-y-1">
-                        <label htmlFor="filter-q" className="text-sm font-medium text-slate-700">
+                <form
+                    onSubmit={onSubmit}
+                    className="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-4 xl:gap-6"
+                >
+                    <div className="flex flex-col gap-2 lg:col-span-2 xl:col-span-2">
+                        <Label htmlFor="filter-q" className="text-sm font-medium text-slate-700">
                             {t('users.index.filters.keyword', fallbackText('關鍵字', 'Keyword'))}
-                        </label>
+                        </Label>
                         <Input
                             id="filter-q"
                             value={filterState.q}
@@ -63,10 +67,40 @@ export function UserFilterForm({
                         />
                     </div>
 
-                    <div className="space-y-1">
-                        <label htmlFor="filter-role" className="text-sm font-medium text-slate-700">
+                    <fieldset className="flex flex-col gap-3 lg:col-span-2 xl:col-span-2">
+                        <legend className="text-sm font-medium text-slate-700">
+                            {fallbackText('建立日期', 'Created date')}
+                        </legend>
+                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                            <div className="flex flex-col gap-1">
+                                <Label htmlFor="filter-created-from" className="text-xs font-medium text-slate-500">
+                                    {t('users.index.filters.created_from', fallbackText('建立起始日', 'Created from'))}
+                                </Label>
+                                <Input
+                                    id="filter-created-from"
+                                    type="date"
+                                    value={filterState.created_from}
+                                    onChange={(event) => onChange('created_from', event.target.value)}
+                                />
+                            </div>
+                            <div className="flex flex-col gap-1">
+                                <Label htmlFor="filter-created-to" className="text-xs font-medium text-slate-500">
+                                    {t('users.index.filters.created_to', fallbackText('建立結束日', 'Created to'))}
+                                </Label>
+                                <Input
+                                    id="filter-created-to"
+                                    type="date"
+                                    value={filterState.created_to}
+                                    onChange={(event) => onChange('created_to', event.target.value)}
+                                />
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="filter-role" className="text-sm font-medium text-slate-700">
                             {t('users.index.filters.role', fallbackText('角色', 'Role'))}
-                        </label>
+                        </Label>
                         <Select
                             id="filter-role"
                             value={filterState.role}
@@ -81,10 +115,10 @@ export function UserFilterForm({
                         </Select>
                     </div>
 
-                    <div className="space-y-1">
-                        <label htmlFor="filter-status" className="text-sm font-medium text-slate-700">
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="filter-status" className="text-sm font-medium text-slate-700">
                             {t('users.index.filters.status', fallbackText('狀態', 'Status'))}
-                        </label>
+                        </Label>
                         <Select
                             id="filter-status"
                             value={filterState.status}
@@ -99,34 +133,10 @@ export function UserFilterForm({
                         </Select>
                     </div>
 
-                    <div className="space-y-1">
-                        <label htmlFor="filter-created-from" className="text-sm font-medium text-slate-700">
-                            {t('users.index.filters.created_from', fallbackText('建立起始日', 'Created from'))}
-                        </label>
-                        <Input
-                            id="filter-created-from"
-                            type="date"
-                            value={filterState.created_from}
-                            onChange={(event) => onChange('created_from', event.target.value)}
-                        />
-                    </div>
-
-                    <div className="space-y-1">
-                        <label htmlFor="filter-created-to" className="text-sm font-medium text-slate-700">
-                            {t('users.index.filters.created_to', fallbackText('建立結束日', 'Created to'))}
-                        </label>
-                        <Input
-                            id="filter-created-to"
-                            type="date"
-                            value={filterState.created_to}
-                            onChange={(event) => onChange('created_to', event.target.value)}
-                        />
-                    </div>
-
-                    <div className="space-y-1">
-                        <label htmlFor="filter-sort" className="text-sm font-medium text-slate-700">
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="filter-sort" className="text-sm font-medium text-slate-700">
                             {t('users.index.filters.sort', fallbackText('排序', 'Sort by'))}
-                        </label>
+                        </Label>
                         <Select
                             id="filter-sort"
                             value={filterState.sort}
@@ -140,10 +150,10 @@ export function UserFilterForm({
                         </Select>
                     </div>
 
-                    <div className="space-y-1">
-                        <label htmlFor="filter-per-page" className="text-sm font-medium text-slate-700">
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="filter-per-page" className="text-sm font-medium text-slate-700">
                             {t('users.index.filters.per_page', fallbackText('每頁筆數', 'Per page'))}
-                        </label>
+                        </Label>
                         <Select
                             id="filter-per-page"
                             value={filterState.per_page}
@@ -157,14 +167,14 @@ export function UserFilterForm({
                         </Select>
                     </div>
 
-                    <div className="flex items-end gap-2">
-                        <Button type="submit" className="w-full rounded-full">
+                    <div className="flex flex-col gap-2 lg:col-span-2 xl:col-span-4 xl:flex-row xl:items-end xl:justify-end">
+                        <Button type="submit" className="w-full rounded-full xl:w-auto">
                             {t('users.index.filters.apply', fallbackText('套用', 'Apply'))}
                         </Button>
                         <Button
                             type="button"
                             variant="secondary"
-                            className="w-full rounded-full"
+                            className="w-full rounded-full xl:w-auto"
                             disabled={!hasActiveFilters}
                             onClick={onReset}
                         >


### PR DESCRIPTION
## Summary
- reorganize the manage user filter grid for clearer spacing
- group the created date fields with a shared legend and compact labels
- align filter action buttons responsively for better balance

## Testing
- 未執行（前端視覺調整）

------
https://chatgpt.com/codex/tasks/task_e_68e0c377282883238737ff3f15778bb8