### PR TITLE
Refine admin messages and attachments responsive UI

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -61,8 +61,8 @@
 
 ### Milestone B — 頁面 UI 對齊（Week 2）
 - [x] `manage/admin/posts`：套用新按鈕配色、ResponsiveDataView、Mobile 卡片；補齊篩選器的自動換行。
-- [ ] `manage/admin/tags`：重構工具列與對話框，確保表單 spacing 與行動版操作；補上標籤顏色選擇器預覽。
-- [ ] `manage/admin/messages` 與 `manage/admin/attachments`：比照最佳實踐，萃取共用卡片與批次操作流程；加入附件縮圖。
+- [x] `manage/admin/tags`：重構工具列與對話框，確保表單 spacing 與行動版操作；補上標籤顏色選擇器預覽。
+- [x] `manage/admin/messages` 與 `manage/admin/attachments`：比照最佳實踐，萃取共用卡片與批次操作流程；加入附件縮圖。
 - [ ] `manage/admin/dashboard`：調整活動列表 hover/empty 狀態、語意色彩，補上關鍵 KPI 卡片。
 - [ ] `manage/admin/users`：工具列改用 `ManageToolbar`，行動版新增卡片摘要顯示（角色、狀態、最後登入）。
 - [ ] 追蹤舊樣式（tonal button 等）並清單化遺留項目供後續清理。

--- a/resources/js/pages/manage/admin/attachments/index.tsx
+++ b/resources/js/pages/manage/admin/attachments/index.tsx
@@ -1,11 +1,33 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ChangeEvent, FormEvent, ReactElement } from 'react';
+
+import { Head, Link, router, usePage } from '@inertiajs/react';
+import {
+    ArrowUpDown,
+    CheckCircle2,
+    CloudUpload,
+    Download,
+    Eye,
+    Filter,
+    LayoutGrid,
+    Link2,
+    List as ListIcon,
+    MoreHorizontal,
+    Paperclip,
+    RefreshCcw,
+    Trash2,
+} from 'lucide-react';
 
 import AppLayout from '@/layouts/app-layout';
 import ManagePage from '@/layouts/manage/manage-page';
+import ManageToolbar from '@/components/manage/manage-toolbar';
+import ResponsiveDataView from '@/components/manage/responsive-data-view';
+import DataCard from '@/components/manage/data-card';
 import AttachmentUploadModal from '@/components/manage/admin/attachment-upload-modal';
+import TableEmpty from '@/components/manage/table-empty';
+import ToastContainer from '@/components/ui/toast-container';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -14,11 +36,10 @@ import Pagination from '@/components/ui/pagination';
 import { Select } from '@/components/ui/select';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import TableEmpty from '@/components/manage/table-empty';
-import ToastContainer from '@/components/ui/toast-container';
 import { useTranslator } from '@/hooks/use-translator';
 import useToast from '@/hooks/use-toast';
 import { apiClient, isManageApiError } from '@/lib/manage/api-client';
+import { formatDateTime } from '@/lib/shared/format';
 import { cn, formatBytes } from '@/lib/shared/utils';
 import type {
     ManageAttachmentFilterOptions,
@@ -27,9 +48,6 @@ import type {
     ManageAttachmentListResponse,
 } from '@/types/manage';
 import type { BreadcrumbItem, SharedData } from '@/types/shared';
-import { Head, Link, router, usePage } from '@inertiajs/react';
-import type { ChangeEvent, FormEvent, ReactElement } from 'react';
-import { ArrowUpDown, CheckCircle2, CloudUpload, Download, Eye, Filter, LayoutGrid, List as ListIcon, RefreshCcw, Trash2 } from 'lucide-react';
 
 interface ManageAdminAttachmentsPageProps extends SharedData {
     attachments: ManageAttachmentListResponse;
@@ -56,16 +74,21 @@ interface FilterFormState {
     view: 'list' | 'grid';
 }
 
-const visibilityVariantMap: Record<string, 'default' | 'secondary' | 'outline'> = {
-    public: 'secondary',
-    private: 'outline',
+type BulkActionType = 'download' | 'delete';
+
+const VISIBILITY_BADGE: Record<string, string> = {
+    public: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    private: 'border-rose-200 bg-rose-50 text-rose-700',
+    internal: 'border-amber-200 bg-amber-50 text-amber-700',
 };
 
-const sortOptions: Array<{ value: string; label: string }> = [
-    { value: 'created_at', label: '最新上傳' },
-    { value: 'title', label: '名稱排序' },
-    { value: 'size', label: '檔案大小' },
+const SORT_OPTIONS: Array<{ value: string; label: string }> = [
+    { value: 'created_at', label: 'filters.sort.created_at' },
+    { value: 'title', label: 'filters.sort.title' },
+    { value: 'size', label: 'filters.sort.size' },
 ];
+
+const PER_PAGE_OPTIONS = ['10', '20', '50', '100'] as const;
 
 function buildPayload(state: FilterFormState) {
     return {
@@ -83,19 +106,148 @@ function buildPayload(state: FilterFormState) {
     };
 }
 
-function formatFileSize(size: number | null | undefined) {
-    if (!size || size <= 0) {
-        return '—';
+function isImageType(mime: string | null | undefined) {
+    return !!mime && mime.startsWith('image/');
+}
+
+function getAttachmentPreview(attachment: ManageAttachmentListItem) {
+    if (isImageType(attachment.type)) {
+        return attachment.file_url ?? attachment.external_url ?? undefined;
     }
 
-    return formatBytes(size);
+    return undefined;
+}
+
+function AttachmentCard({
+    attachment,
+    locale,
+    onSelect,
+    selected,
+    onOpen,
+    canDelete,
+    onDownload,
+}: {
+    attachment: ManageAttachmentListItem;
+    locale: string;
+    onSelect: (checked: boolean) => void;
+    selected: boolean;
+    onOpen: () => void;
+    canDelete: boolean;
+    onDownload: () => void;
+}) {
+    const { t: tAttachments } = useTranslator('manage.attachments');
+    const preview = getAttachmentPreview(attachment);
+    const downloadHref = attachment.download_url ?? attachment.external_url ?? attachment.file_url ?? '';
+
+    const metadata = [
+        {
+            label: tAttachments('table.type', '類型與可見性'),
+            value: (
+                <div className="flex flex-wrap items-center gap-2">
+                    <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600">{attachment.type}</span>
+                    <Badge
+                        variant="outline"
+                        className={cn(
+                            'rounded-full border px-2 py-0.5 text-xs',
+                            VISIBILITY_BADGE[attachment.visibility] ?? 'border-neutral-200 bg-neutral-100 text-neutral-600'
+                        )}
+                    >
+                        {tAttachments(`visibility.${attachment.visibility}`, attachment.visibility)}
+                    </Badge>
+                </div>
+            ),
+        },
+        {
+            label: tAttachments('table.size', '檔案大小'),
+            value: attachment.size ? formatBytes(attachment.size) : '—',
+        },
+        {
+            label: tAttachments('table.created_at', '上傳時間'),
+            value: formatDateTime(attachment.created_at ?? attachment.uploaded_at, locale) || '—',
+        },
+    ];
+
+    return (
+        <DataCard
+            title={attachment.title ?? attachment.filename ?? tAttachments('table.untitled', '未命名附件')}
+            description={attachment.description ?? undefined}
+            image={preview}
+            metadata={metadata}
+            footer={
+                attachment.uploader
+                    ? tAttachments('table.uploader', '由 :name 上傳', { name: attachment.uploader.name })
+                    : tAttachments('table.uploader_unknown', '上傳者未知')
+            }
+            actions={[
+                <Button key="open" type="button" variant="outline" className="w-full justify-center gap-2" onClick={onOpen}>
+                    <Eye className="h-4 w-4" />
+                    {tAttachments('actions.preview', '檢視資訊')}
+                </Button>,
+                <Button
+                    key="download"
+                    type="button"
+                    variant="outline"
+                    className="w-full justify-center gap-2"
+                    disabled={!downloadHref}
+                    onClick={onDownload}
+                >
+                    <Download className="h-4 w-4" />
+                    {tAttachments('table.download', '下載')}
+                </Button>,
+            ]}
+            mobileActions={[
+                <Button
+                    key="select"
+                    type="button"
+                    variant={selected ? 'default' : 'outline'}
+                    className="w-full justify-center gap-2"
+                    onClick={() => onSelect(!selected)}
+                >
+                    <CheckCircle2 className="h-4 w-4" />
+                    {selected
+                        ? tAttachments('selection.added', '已加入批次操作')
+                        : tAttachments('selection.add', '加入批次操作')}
+                </Button>,
+                canDelete ? (
+                    <Button
+                        key="delete"
+                        type="button"
+                        variant="destructive"
+                        className="w-full justify-center gap-2"
+                        onClick={() => onSelect(true)}
+                    >
+                        <Trash2 className="h-4 w-4" />
+                        {tAttachments('bulk.delete', '批次刪除')}
+                    </Button>
+                ) : null,
+            ]}
+        >
+            {attachment.tags && attachment.tags.length > 0 ? (
+                <div className="flex flex-wrap gap-2 text-xs text-neutral-500">
+                    {attachment.tags.map((tag) => (
+                        <span key={tag} className="rounded-full bg-neutral-100 px-2 py-0.5">
+                            #{tag}
+                        </span>
+                    ))}
+                </div>
+            ) : null}
+            {attachment.space ? (
+                <div className="text-xs text-neutral-500">
+                    {tAttachments('table.space', '歸屬空間：:name', { name: attachment.space.name })}
+                </div>
+            ) : null}
+        </DataCard>
+    );
 }
 
 export default function ManageAdminAttachmentsIndex() {
     const page = usePage<ManageAdminAttachmentsPageProps>();
     const { attachments, filters, filterOptions, viewMode, abilities } = page.props;
+    const locale = page.props.locale ?? 'zh-TW';
+
     const { t } = useTranslator('manage');
     const { t: tAttachments } = useTranslator('manage.attachments');
+    const { toasts, showSuccess, showError, dismissToast } = useToast();
 
     const breadcrumbs: BreadcrumbItem[] = [
         {
@@ -118,7 +270,7 @@ export default function ManageAdminAttachmentsIndex() {
         tag: filters.tag ?? '',
         from: filters.from ?? '',
         to: filters.to ?? '',
-        per_page: String(filters.per_page ?? attachments.meta.per_page ?? 15),
+        per_page: String(filters.per_page ?? attachments.meta.per_page ?? Number(PER_PAGE_OPTIONS[0])),
         sort: filters.sort ?? 'created_at',
         direction: (filters.direction ?? 'desc') as 'asc' | 'desc',
         view: viewMode ?? 'list',
@@ -126,14 +278,12 @@ export default function ManageAdminAttachmentsIndex() {
 
     const [filterForm, setFilterForm] = useState<FilterFormState>(defaultFilterForm);
     const [selectedIds, setSelectedIds] = useState<number[]>([]);
-    const [pendingBulkAction, setPendingBulkAction] = useState<'download' | 'delete' | null>(null);
+    const [pendingBulkAction, setPendingBulkAction] = useState<BulkActionType | null>(null);
     const [confirmBulkOpen, setConfirmBulkOpen] = useState(false);
     const [detailAttachment, setDetailAttachment] = useState<ManageAttachmentListItem | null>(null);
     const [detailOpen, setDetailOpen] = useState(false);
     const [uploadModalOpen, setUploadModalOpen] = useState(false);
     const keywordTimer = useRef<number | null>(null);
-
-    const { toasts, showSuccess, showError, dismissToast } = useToast();
 
     useEffect(() => {
         setFilterForm(defaultFilterForm);
@@ -141,7 +291,7 @@ export default function ManageAdminAttachmentsIndex() {
 
     useEffect(() => {
         setSelectedIds([]);
-    }, [attachments.data.map(att => att.id).join('-')]);
+    }, [attachments.data.map((item) => item.id).join('-')]);
 
     const applyFilters = useCallback(
         (overrides: Partial<FilterFormState> = {}, options: { replace?: boolean } = {}) => {
@@ -180,11 +330,6 @@ export default function ManageAdminAttachmentsIndex() {
         setFilterForm((prev) => ({ ...prev, keyword: event.target.value }));
     };
 
-    const handleFilterSubmit = (event: FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-        applyFilters();
-    };
-
     const handleTypeChange = (event: ChangeEvent<HTMLSelectElement>) => {
         const value = event.target.value;
         setFilterForm((prev) => ({ ...prev, type: value }));
@@ -215,9 +360,10 @@ export default function ManageAdminAttachmentsIndex() {
         applyFilters({ [field]: value } as Partial<FilterFormState>);
     };
 
-    const handlePerPageChange = (value: string) => {
-        setFilterForm((prev) => ({ ...prev, per_page: value }));
-        applyFilters({ per_page: value }, { replace: true });
+    const handlePerPageChange = (value: number) => {
+        const next = String(value);
+        setFilterForm((prev) => ({ ...prev, per_page: next }));
+        applyFilters({ per_page: next }, { replace: true });
     };
 
     const handleSortChange = (event: ChangeEvent<HTMLSelectElement>) => {
@@ -240,37 +386,38 @@ export default function ManageAdminAttachmentsIndex() {
         applyFilters({ view: mode }, { replace: true });
     };
 
+    const handleFilterSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        applyFilters();
+    };
+
     const handleResetFilters = () => {
         setFilterForm(defaultFilterForm);
         applyFilters(defaultFilterForm, { replace: true });
     };
 
-    /**
-     * 處理全選/取消全選附件。
-     */
     const handleSelectAll = (checked: boolean) => {
         if (checked) {
-            setSelectedIds(attachments.data.map(att => att.id));
+            setSelectedIds(attachments.data.map((item) => item.id));
         } else {
             setSelectedIds([]);
         }
     };
 
-    /**
-     * 處理單一附件的選取狀態。
-     */
-    const handleRowSelect = (id: number, checked: boolean) => {
-        setSelectedIds(prev => {
+    const toggleSelection = (id: number, checked: boolean) => {
+        setSelectedIds((prev) => {
             if (checked) {
                 return [...new Set([...prev, id])];
             }
-            return prev.filter(item => item !== id);
+            return prev.filter((item) => item !== id);
         });
     };
 
-    /**
-     * 批次刪除附件：呼叫後端 API 並重新載入列表。
-     */
+    const openDetail = (attachment: ManageAttachmentListItem) => {
+        setDetailAttachment(attachment);
+        setDetailOpen(true);
+    };
+
     const executeBulkDelete = async () => {
         try {
             const response = await apiClient.post<{ message?: string }>('/admin/attachments/bulk-delete', {
@@ -290,13 +437,10 @@ export default function ManageAdminAttachmentsIndex() {
         }
     };
 
-    /**
-     * 批次下載附件：逐一開啟下載連結（瀏覽器會處理多檔下載）。
-     */
     const executeBulkDownload = () => {
-        const selectedAttachments = attachments.data.filter(att => selectedIds.includes(att.id));
-        selectedAttachments.forEach((att) => {
-            const href = att.download_url ?? att.external_url ?? att.file_url;
+        const selectedAttachments = attachments.data.filter((attachment) => selectedIds.includes(attachment.id));
+        selectedAttachments.forEach((attachment) => {
+            const href = attachment.download_url ?? attachment.external_url ?? attachment.file_url;
             if (href) {
                 window.open(href, '_blank');
             }
@@ -306,429 +450,471 @@ export default function ManageAdminAttachmentsIndex() {
         setConfirmBulkOpen(false);
     };
 
-    /**
-     * 開啟附件詳細資訊抽屜。
-     */
-    const openDetail = (attachment: ManageAttachmentListItem) => {
-        setDetailAttachment(attachment);
-        setDetailOpen(true);
-    };
-
     const toolbar = (
-        <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-            <form className="flex flex-wrap items-center gap-2" onSubmit={handleFilterSubmit}>
-                <div className="flex items-center gap-2">
+        <ManageToolbar
+            wrap
+            primary={[
+                <div key="keyword" className="grid w-full gap-1 sm:w-64">
+                    <label htmlFor="filter-keyword" className="text-xs font-medium text-neutral-600">
+                        {tAttachments('filters.keyword_label', '搜尋附件')}
+                    </label>
                     <Input
+                        id="filter-keyword"
                         type="search"
                         value={filterForm.keyword}
                         onChange={handleKeywordChange}
                         placeholder={tAttachments('filters.keyword_placeholder', '搜尋附件名稱或檔名')}
-                        className="w-56"
-                        aria-label={tAttachments('filters.keyword_label', '搜尋附件')}
                     />
-                    <Button type="submit" size="sm" className="gap-1 bg-[#3B82F6] hover:bg-[#2563EB] text-white border-transparent">
-                        <Filter className="h-4 w-4" />
-                        {tAttachments('filters.apply', '套用')}
+                </div>,
+                <div key="type" className="grid w-full gap-1 sm:w-44">
+                    <label htmlFor="filter-type" className="text-xs font-medium text-neutral-600">
+                        {tAttachments('filters.type_label', '附件類型')}
+                    </label>
+                    <Select id="filter-type" value={filterForm.type} onChange={handleTypeChange}>
+                        <option value="">{tAttachments('filters.type_all', '全部類型')}</option>
+                        {filterOptions.types.map((option) => (
+                            <option key={String(option.value)} value={String(option.value)}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </Select>
+                </div>,
+                <div key="visibility" className="grid w-full gap-1 sm:w-44">
+                    <label htmlFor="filter-visibility" className="text-xs font-medium text-neutral-600">
+                        {tAttachments('filters.visibility_label', '可見性')}
+                    </label>
+                    <Select id="filter-visibility" value={filterForm.visibility} onChange={handleVisibilityChange}>
+                        <option value="">{tAttachments('filters.visibility_all', '全部可見性')}</option>
+                        {filterOptions.visibilities.map((option) => (
+                            <option key={String(option.value)} value={String(option.value)}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </Select>
+                </div>,
+            ]}
+            secondary={
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
+                    {selectedIds.length > 0 ? (
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button type="button" size="sm" variant="outline" className="gap-2">
+                                    <CheckCircle2 className="h-4 w-4" />
+                                    {tAttachments('bulk.actions', '批次操作')} ({selectedIds.length})
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" className="w-48">
+                                <DropdownMenuLabel>{tAttachments('bulk.title', '選擇批次動作')}</DropdownMenuLabel>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                    onSelect={() => {
+                                        setPendingBulkAction('download');
+                                        setConfirmBulkOpen(true);
+                                    }}
+                                    className="gap-2"
+                                >
+                                    <Download className="h-4 w-4" />
+                                    {tAttachments('bulk.download', '批次下載')}
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                    disabled={!abilities.canDelete}
+                                    onSelect={() => {
+                                        setPendingBulkAction('delete');
+                                        setConfirmBulkOpen(true);
+                                    }}
+                                    className="gap-2 text-rose-600"
+                                >
+                                    <Trash2 className="h-4 w-4" />
+                                    {tAttachments('bulk.delete', '批次刪除')}
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    ) : null}
+
+                    <div className="flex items-center gap-1">
+                        <Button
+                            type="button"
+                            variant={filterForm.view === 'list' ? 'default' : 'outline'}
+                            size="sm"
+                            onClick={() => handleViewChange('list')}
+                            aria-label={tAttachments('view.list', '列表模式')}
+                        >
+                            <ListIcon className="h-4 w-4" />
+                        </Button>
+                        <Button
+                            type="button"
+                            variant={filterForm.view === 'grid' ? 'default' : 'outline'}
+                            size="sm"
+                            onClick={() => handleViewChange('grid')}
+                            aria-label={tAttachments('view.grid', '卡片模式')}
+                        >
+                            <LayoutGrid className="h-4 w-4" />
+                        </Button>
+                    </div>
+
+                    {abilities.canUpload ? (
+                        <Button
+                            type="button"
+                            size="sm"
+                            className="gap-2 bg-[#10B981] text-white hover:bg-[#059669]"
+                            onClick={() => setUploadModalOpen(true)}
+                        >
+                            <CloudUpload className="h-4 w-4" />
+                            {tAttachments('actions.upload', '上傳附件')}
+                        </Button>
+                    ) : null}
+                </div>
+            }
+        >
+            <form onSubmit={handleFilterSubmit} className="flex w-full flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                <div className="flex flex-col gap-3 md:flex-row md:items-end">
+                    <div className="grid gap-1">
+                        <label htmlFor="filter-space" className="text-xs font-medium text-neutral-600">
+                            {tAttachments('filters.space_label', '綁定空間')}
+                        </label>
+                        <Select id="filter-space" value={filterForm.space} onChange={handleSpaceChange} className="sm:w-48">
+                            <option value="">{tAttachments('filters.space_all', '全部空間')}</option>
+                            {filterOptions.spaces.map((option) => (
+                                <option key={String(option.value)} value={String(option.value)}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="grid gap-1">
+                        <label htmlFor="filter-tag" className="text-xs font-medium text-neutral-600">
+                            {tAttachments('filters.tag_label', '標籤篩選')}
+                        </label>
+                        <Select id="filter-tag" value={filterForm.tag} onChange={handleTagChange} className="sm:w-48">
+                            <option value="">{tAttachments('filters.tag_all', '全部標籤')}</option>
+                            {filterOptions.tags.map((option) => (
+                                <option key={String(option.value)} value={String(option.value)}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <div className="grid gap-1">
+                            <label htmlFor="filter-from" className="text-xs font-medium text-neutral-600">
+                                {tAttachments('filters.from', '起始日期')}
+                            </label>
+                            <Input id="filter-from" type="date" value={filterForm.from} onChange={handleDateChange('from')} className="h-9 sm:w-40" />
+                        </div>
+                        <span className="mt-6 text-neutral-400">~</span>
+                        <div className="grid gap-1">
+                            <label htmlFor="filter-to" className="text-xs font-medium text-neutral-600">
+                                {tAttachments('filters.to', '結束日期')}
+                            </label>
+                            <Input id="filter-to" type="date" value={filterForm.to} onChange={handleDateChange('to')} className="h-9 sm:w-40" />
+                        </div>
+                    </div>
+                </div>
+
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                    <div className="grid gap-1 sm:w-48">
+                        <label htmlFor="filter-sort" className="text-xs font-medium text-neutral-600">
+                            {tAttachments('filters.sort_label', '排序方式')}
+                        </label>
+                        <Select id="filter-sort" value={filterForm.sort} onChange={handleSortChange}>
+                            {SORT_OPTIONS.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {tAttachments(option.label, option.label)}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+                    <Button type="button" size="sm" variant="outline" className="gap-2" onClick={handleDirectionToggle}>
+                        <ArrowUpDown className="h-4 w-4" />
+                        {filterForm.direction === 'asc'
+                            ? tAttachments('filters.direction.asc', '昇冪')
+                            : tAttachments('filters.direction.desc', '降冪')}
                     </Button>
-                    <Button type="button" size="sm" variant="ghost" className="text-neutral-500" onClick={handleResetFilters}>
+                    <Button type="submit" size="sm" className="gap-2 bg-[#0F172A] text-white hover:bg-[#0B1220]">
+                        <Filter className="h-4 w-4" />
+                        {tAttachments('filters.apply', '套用條件')}
+                    </Button>
+                    <Button type="button" size="sm" variant="outline" onClick={handleResetFilters}>
                         <RefreshCcw className="h-4 w-4" />
                         {tAttachments('filters.reset', '重設')}
                     </Button>
                 </div>
-                <Select value={filterForm.type} onChange={handleTypeChange} className="w-40" aria-label={tAttachments('filters.type_label', '附件類型')}>
-                    <option value="">{tAttachments('filters.type_all', '全部類型')}</option>
-                    {filterOptions.types.map((option) => (
-                        <option key={String(option.value)} value={String(option.value)}>
-                            {option.label}
-                        </option>
-                    ))}
-                </Select>
-                <Select
-                    value={filterForm.visibility}
-                    onChange={handleVisibilityChange}
-                    className="w-36"
-                    aria-label={tAttachments('filters.visibility_label', '可見性篩選')}
-                >
-                    <option value="">{tAttachments('filters.visibility_all', '全部可見性')}</option>
-                    {filterOptions.visibilities.map((option) => (
-                        <option key={String(option.value)} value={String(option.value)}>
-                            {option.label}
-                        </option>
-                    ))}
-                </Select>
-                <Select value={filterForm.space} onChange={handleSpaceChange} className="w-40" aria-label={tAttachments('filters.space_label', '綁定空間')}>
-                    <option value="">{tAttachments('filters.space_all', '全部空間')}</option>
-                    {filterOptions.spaces.map((option) => (
-                        <option key={String(option.value)} value={String(option.value)}>
-                            {option.label}
-                        </option>
-                    ))}
-                </Select>
-                <Select value={filterForm.tag} onChange={handleTagChange} className="w-44" aria-label={tAttachments('filters.tag_label', '標籤篩選')}>
-                    <option value="">{tAttachments('filters.tag_all', '全部標籤')}</option>
-                    {filterOptions.tags.map((option) => (
-                        <option key={String(option.value)} value={String(option.value)}>
-                            {option.label}
-                        </option>
-                    ))}
-                </Select>
-                <div className="flex items-center gap-2">
-                    <label className="text-xs text-neutral-500" htmlFor="filter-from">
-                        {tAttachments('filters.from', '起始日期')}
-                    </label>
-                    <Input
-                        id="filter-from"
-                        type="date"
-                        value={filterForm.from}
-                        onChange={handleDateChange('from')}
-                        className="h-9 w-36"
-                    />
-                    <span className="text-neutral-400">~</span>
-                    <Input
-                        type="date"
-                        value={filterForm.to}
-                        onChange={handleDateChange('to')}
-                        className="h-9 w-36"
-                    />
-                </div>
             </form>
-
-            <div className="flex flex-wrap items-center gap-2">
-                {/* 批次操作選單：提供下載與刪除功能 */}
-                {selectedIds.length > 0 && (
-                    <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                            <Button size="sm" variant="outline" className="gap-2">
-                                <CheckCircle2 className="h-4 w-4" />
-                                {tAttachments('bulk.actions', '批次操作')} ({selectedIds.length})
-                            </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-52">
-                            <DropdownMenuLabel>{tAttachments('bulk.title', '選擇批次動作')}</DropdownMenuLabel>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                                onSelect={() => {
-                                    setPendingBulkAction('download');
-                                    setConfirmBulkOpen(true);
-                                }}
-                                className="gap-2"
-                            >
-                                <Download className="h-4 w-4" />
-                                {tAttachments('bulk.download', '批次下載')}
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                                disabled={!abilities.canDelete}
-                                onSelect={() => {
-                                    setPendingBulkAction('delete');
-                                    setConfirmBulkOpen(true);
-                                }}
-                                className="gap-2 text-red-600"
-                            >
-                                <Trash2 className="h-4 w-4" />
-                                {tAttachments('bulk.delete', '批次刪除')}
-                            </DropdownMenuItem>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
-                )}
-
-                <Select value={filterForm.sort} onChange={handleSortChange} className="w-40" aria-label={tAttachments('filters.sort_label', '排序方式')}>
-                    {sortOptions.map((option) => (
-                        <option key={option.value} value={option.value}>
-                            {tAttachments(`filters.sort.${option.value}`, option.label)}
-                        </option>
-                    ))}
-                </Select>
-                <Button type="button" variant="outline" size="sm" onClick={handleDirectionToggle} className="gap-1">
-                    <ArrowUpDown className="h-4 w-4" />
-                    {filterForm.direction === 'asc'
-                        ? tAttachments('filters.direction.asc', '昇冪')
-                        : tAttachments('filters.direction.desc', '降冪')}
-                </Button>
-                <div className="flex items-center gap-1">
-                    <Button
-                        type="button"
-                        variant={filterForm.view === 'list' ? 'default' : 'outline'}
-                        size="sm"
-                        onClick={() => handleViewChange('list')}
-                        aria-label={tAttachments('view.list', '列表模式')}
-                    >
-                        <ListIcon className="h-4 w-4" />
-                    </Button>
-                    <Button
-                        type="button"
-                        variant={filterForm.view === 'grid' ? 'default' : 'outline'}
-                        size="sm"
-                        onClick={() => handleViewChange('grid')}
-                        aria-label={tAttachments('view.grid', '卡片模式')}
-                    >
-                        <LayoutGrid className="h-4 w-4" />
-                    </Button>
-                </div>
-                {abilities.canUpload ? (
-                    <Button
-                        size="sm"
-                        className="gap-2 bg-[#10B981] hover:bg-[#059669] text-white border-transparent"
-                        onClick={() => setUploadModalOpen(true)}
-                    >
-                        <CloudUpload className="h-4 w-4" />
-                        {tAttachments('actions.upload', '上傳附件')}
-                    </Button>
-                ) : null}
-            </div>
-        </div>
+        </ManageToolbar>
     );
 
-    const renderListView = (items: ManageAttachmentListItem[]) => {
-        if (items.length === 0) {
-            return <TableEmpty title={tAttachments('empty.title', '尚無附件')} description={tAttachments('empty.description', '還沒有任何可供管理的附件資源。')} />;
-        }
+    const hasAttachments = attachments.data.length > 0;
+    const headerCheckboxState = selectedIds.length > 0 && selectedIds.length === attachments.data.length;
 
-        return (
+    const mobileBulkActions = selectedIds.length > 0
+        ? [
+              <div
+                  key="summary"
+                  className="flex items-center justify-between rounded-lg border border-neutral-200/80 bg-neutral-50 px-3 py-2 text-sm text-neutral-600"
+              >
+                  <span className="font-medium text-neutral-700">
+                      {tAttachments('selection.count', '已選擇 {count} 筆附件', { count: selectedIds.length })}
+                  </span>
+                  <Button type="button" variant="ghost" size="sm" className="h-8 px-2 text-xs" onClick={() => setSelectedIds([])}>
+                      {tAttachments('selection.clear', '清除')}
+                  </Button>
+              </div>,
+              <Button
+                  key="mobile-download"
+                  type="button"
+                  className="w-full justify-center gap-2 bg-[#2563EB] text-white hover:bg-[#1D4ED8]"
+                  onClick={() => {
+                      setPendingBulkAction('download');
+                      setConfirmBulkOpen(true);
+                  }}
+              >
+                  <Download className="h-4 w-4" />
+                  {tAttachments('bulk.download', '批次下載')}
+              </Button>,
+              abilities.canDelete ? (
+                  <Button
+                      key="mobile-delete"
+                      type="button"
+                      variant="destructive"
+                      className="w-full justify-center gap-2"
+                      onClick={() => {
+                          setPendingBulkAction('delete');
+                          setConfirmBulkOpen(true);
+                      }}
+                  >
+                      <Trash2 className="h-4 w-4" />
+                      {tAttachments('bulk.delete', '批次刪除')}
+                  </Button>
+              ) : null,
+          ].filter(Boolean)
+        : undefined;
+
+    const tableView = (
+        <div className="overflow-x-auto">
             <Table>
                 <TableHeader>
-                    <TableRow className="border-neutral-200/80">
+                    <TableRow className="border-b border-neutral-200/70 bg-neutral-50/70">
                         <TableHead className="w-10">
                             <Checkbox
-                                checked={selectedIds.length > 0 && selectedIds.length === items.length}
-                                onCheckedChange={checked => handleSelectAll(Boolean(checked))}
+                                checked={headerCheckboxState}
+                                onCheckedChange={(checked) => handleSelectAll(checked === true)}
                                 aria-label={tAttachments('table.select_all', '全選')}
                             />
                         </TableHead>
-                        <TableHead className="w-[34%] text-neutral-500">{tAttachments('table.title', '附件')}</TableHead>
-                        <TableHead className="w-[16%] text-neutral-500">{tAttachments('table.type', '類型與可見性')}</TableHead>
-                        <TableHead className="w-[22%] text-neutral-500">{tAttachments('table.attachable', '所屬資源')}</TableHead>
-                        <TableHead className="w-[12%] text-neutral-500">{tAttachments('table.size', '檔案大小')}</TableHead>
-                        <TableHead className="w-[8%] text-right text-neutral-500">{tAttachments('table.actions', '操作')}</TableHead>
+                        <TableHead className="min-w-[220px] text-neutral-500">
+                            {tAttachments('table.title', '附件資訊')}
+                        </TableHead>
+                        <TableHead className="min-w-[180px] text-neutral-500">
+                            {tAttachments('table.type', '類型與可見性')}
+                        </TableHead>
+                        <TableHead className="min-w-[220px] text-neutral-500">
+                            {tAttachments('table.attachable', '關聯資源')}
+                        </TableHead>
+                        <TableHead className="min-w-[120px] text-neutral-500">
+                            {tAttachments('table.size', '檔案大小')}
+                        </TableHead>
+                        <TableHead className="w-28 text-right text-neutral-500" aria-label={tAttachments('table.actions', '操作')} />
                     </TableRow>
                 </TableHeader>
                 <TableBody>
-                    {items.map((attachment) => {
-                        const downloadHref = attachment.download_url ?? attachment.external_url ?? attachment.file_url ?? '';
+                    {attachments.data.length === 0 ? (
+                        <TableRow>
+                            <TableCell colSpan={6} className="py-12">
+                                <TableEmpty
+                                    title={tAttachments('empty.title', '尚無附件')}
+                                    description={tAttachments('empty.description', '還沒有任何可供管理的附件資源。')}
+                                />
+                            </TableCell>
+                        </TableRow>
+                    ) : (
+                        attachments.data.map((attachment) => {
+                            const downloadHref = attachment.download_url ?? attachment.external_url ?? attachment.file_url ?? '';
+                            const preview = getAttachmentPreview(attachment);
+                            const isSelected = selectedIds.includes(attachment.id);
 
-                        return (
-                            <TableRow key={attachment.id} className="border-neutral-200/60">
-                                <TableCell>
-                                    <Checkbox
-                                        checked={selectedIds.includes(attachment.id)}
-                                        onCheckedChange={checked => handleRowSelect(attachment.id, Boolean(checked))}
-                                        aria-label={tAttachments('table.select_row', '選擇附件')}
-                                    />
-                                </TableCell>
-                                <TableCell className="space-y-1">
-                                    <div className="font-medium text-neutral-800">{attachment.title ?? attachment.filename ?? tAttachments('table.untitled', '未命名附件')}</div>
-                                    <div className="text-xs text-neutral-500">
-                                        {attachment.filename ?? tAttachments('table.no_filename', '無檔名')}
-                                    </div>
-                                    <div className="text-xs text-neutral-400">
-                                        {tAttachments('table.uploaded_at', '上傳於 :date', {
-                                            date: attachment.created_at
-                                                ? new Date(attachment.created_at).toLocaleString(page.props.locale ?? 'zh-TW')
-                                                : '—',
-                                        })}
-                                    </div>
-                                    {/* 顯示附件描述內容，協助管理員快速辨識用途 */}
-                                    {attachment.description ? (
-                                        <p className="text-xs text-neutral-500">{attachment.description}</p>
-                                    ) : null}
-                                    {/* 標籤列出時改用膠囊標示，突顯分類資訊 */}
-                                    {attachment.tags && attachment.tags.length > 0 ? (
-                                        <div className="flex flex-wrap gap-1">
-                                            {attachment.tags.map((tag) => (
-                                                <Badge key={tag} variant="outline" className="text-[10px] capitalize text-neutral-500">
-                                                    #{tag}
-                                                </Badge>
-                                            ))}
-                                        </div>
-                                    ) : null}
-                                    {attachment.uploader ? (
-                                        <div className="text-xs text-neutral-400">
-                                            {tAttachments('table.uploader', '由 :name 上傳', { name: attachment.uploader.name })}
-                                        </div>
-                                    ) : null}
-                                </TableCell>
-                                <TableCell className="space-y-2">
-                                    <Badge variant="outline" className="capitalize text-neutral-600">
-                                        {tAttachments(`types.${attachment.type}`, attachment.type)}
-                                    </Badge>
-                                    <Badge variant={visibilityVariantMap[attachment.visibility] ?? 'outline'} className="capitalize">
-                                        {tAttachments(`visibility.${attachment.visibility}`, attachment.visibility)}
-                                    </Badge>
-                                </TableCell>
-                                <TableCell className="space-y-1 text-sm text-neutral-600">
-                                    {attachment.attachable ? (
-                                        <div>
-                                            <div className="font-medium text-neutral-700">{attachment.attachable.title ?? tAttachments('table.unknown_attachable', '未知來源')}</div>
-                                            {attachment.attachable.space ? (
-                                                <div className="text-xs text-neutral-500">
-                                                    {tAttachments('table.space', '空間：:name', { name: attachment.attachable.space.name })}
+                            return (
+                                <TableRow key={attachment.id} className={cn('border-b border-neutral-200/60', isSelected && 'bg-blue-50/40')}>
+                                    <TableCell>
+                                        <Checkbox
+                                            checked={isSelected}
+                                            onCheckedChange={(checked) => toggleSelection(attachment.id, checked === true)}
+                                            aria-label={tAttachments('table.select_row', '選擇附件')}
+                                        />
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex items-start gap-3">
+                                            {preview ? (
+                                                <div className="h-16 w-20 overflow-hidden rounded-lg border border-neutral-200 bg-neutral-100">
+                                                    <img src={preview} alt={attachment.title ?? attachment.filename ?? ''} className="h-full w-full object-cover" />
                                                 </div>
-                                            ) : null}
-                                            <div className="text-xs text-neutral-400 capitalize">
-                                                {tAttachments(`table.attachable_type.${attachment.attachable.type}`, attachment.attachable.type)}
+                                            ) : (
+                                                <div className="flex h-16 w-20 items-center justify-center rounded-lg border border-dashed border-neutral-200 bg-neutral-50 text-neutral-400">
+                                                    <Paperclip className="h-6 w-6" />
+                                                </div>
+                                            )}
+                                            <div className="space-y-1">
+                                                <div className="font-medium text-neutral-900">
+                                                    {attachment.title ?? attachment.filename ?? tAttachments('table.untitled', '未命名附件')}
+                                                </div>
+                                                {attachment.description ? (
+                                                    <div className="text-xs text-neutral-500">{attachment.description}</div>
+                                                ) : null}
+                                                <div className="flex flex-wrap gap-1 text-[11px] text-neutral-500">
+                                                    {attachment.tags?.map((tag) => (
+                                                        <span key={tag} className="rounded-full bg-neutral-100 px-2 py-0.5">#{tag}</span>
+                                                    ))}
+                                                </div>
+                                                <div className="text-xs text-neutral-400">
+                                                    {attachment.uploader
+                                                        ? tAttachments('table.uploader', '由 :name 上傳', { name: attachment.uploader.name })
+                                                        : tAttachments('table.uploader_unknown', '上傳者未知')}
+                                                </div>
                                             </div>
                                         </div>
-                                    ) : attachment.space ? (
-                                        <div>
-                                            <div className="font-medium text-neutral-700">{tAttachments('table.space', '空間：:name', { name: attachment.space.name })}</div>
-                                            <div className="text-xs text-neutral-400">{tAttachments('table.orphan', '尚未綁定資源')}</div>
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex flex-col gap-2">
+                                            <span className="text-sm text-neutral-600">{attachment.type}</span>
+                                            <Badge
+                                                variant="outline"
+                                                className={cn(
+                                                    'w-fit rounded-full border px-2 py-0.5 text-xs',
+                                                    VISIBILITY_BADGE[attachment.visibility] ?? 'border-neutral-200 bg-neutral-100 text-neutral-600'
+                                                )}
+                                            >
+                                                {tAttachments(`visibility.${attachment.visibility}`, attachment.visibility)}
+                                            </Badge>
                                         </div>
-                                    ) : (
-                                        <span className="text-xs text-neutral-400">{tAttachments('table.orphan', '尚未綁定資源')}</span>
-                                    )}
-                                </TableCell>
-                                <TableCell className="text-sm text-neutral-600">{formatFileSize(attachment.size)}</TableCell>
-                                <TableCell className="text-right">
-                                    <div className="flex items-center justify-end gap-1">
-                                        <Button
-                                            variant="ghost"
-                                            size="sm"
-                                            onClick={() => openDetail(attachment)}
-                                            className="gap-1"
-                                        >
-                                            <Eye className="h-4 w-4" />
-                                        </Button>
-                                        <Button
-                                            variant="outline"
-                                            size="sm"
-                                            className="gap-1"
-                                            asChild={!!downloadHref}
-                                            disabled={!downloadHref}
-                                        >
-                                            {downloadHref ? (
-                                                <Link href={downloadHref} target={attachment.external_url ? '_blank' : undefined} rel={attachment.external_url ? 'noopener noreferrer' : undefined}>
+                                    </TableCell>
+                                    <TableCell>
+                                        {attachment.attachable ? (
+                                            <div className="space-y-1 text-sm text-neutral-600">
+                                                <div className="font-medium text-neutral-800">{attachment.attachable.title ?? attachment.attachable.type}</div>
+                                                {attachment.attachable.space ? (
+                                                    <div className="text-xs text-neutral-500">
+                                                        {tAttachments('table.space', '歸屬空間：:name', { name: attachment.attachable.space.name })}
+                                                    </div>
+                                                ) : null}
+                                                <div className="flex items-center gap-1 text-xs text-neutral-400">
+                                                    <Link2 className="h-3.5 w-3.5" />
+                                                    <span className="capitalize">{attachment.attachable.type}</span>
+                                                </div>
+                                            </div>
+                                        ) : attachment.space ? (
+                                            <div className="rounded-lg bg-neutral-50/80 p-3 text-xs text-neutral-500">
+                                                {tAttachments('table.space', '歸屬空間：:name', { name: attachment.space.name })}
+                                            </div>
+                                        ) : (
+                                            <div className="rounded-lg bg-neutral-50/80 p-3 text-xs text-neutral-400">
+                                                {tAttachments('table.orphan', '尚未綁定資源')}
+                                            </div>
+                                        )}
+                                    </TableCell>
+                                    <TableCell className="text-sm text-neutral-600">
+                                        {attachment.size ? formatBytes(attachment.size) : '—'}
+                                    </TableCell>
+                                    <TableCell className="text-right">
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button type="button" variant="ghost" size="icon" className="h-8 w-8 text-neutral-500 hover:text-neutral-700">
+                                                    <MoreHorizontal className="h-4 w-4" />
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent align="end" className="w-44">
+                                                <DropdownMenuItem className="gap-2" onSelect={() => openDetail(attachment)}>
+                                                    <Eye className="h-4 w-4" />
+                                                    {tAttachments('actions.preview', '檢視資訊')}
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem
+                                                    className={cn('gap-2', downloadHref ? '' : 'pointer-events-none text-neutral-400')}
+                                                    onSelect={() => {
+                                                        if (downloadHref) {
+                                                            window.open(downloadHref, '_blank');
+                                                        }
+                                                    }}
+                                                >
                                                     <Download className="h-4 w-4" />
-                                                </Link>
-                                            ) : (
-                                                <span className="inline-flex items-center gap-1 text-neutral-400">
-                                                    <Download className="h-4 w-4" />
-                                                </span>
-                                            )}
-                                        </Button>
-                                    </div>
-                                </TableCell>
-                            </TableRow>
-                        );
-                    })}
+                                                    {tAttachments('table.download', '下載')}
+                                                </DropdownMenuItem>
+                                                {abilities.canDelete ? (
+                                                    <DropdownMenuItem
+                                                        className="gap-2 text-rose-600"
+                                                        onSelect={() => {
+                                                            setSelectedIds([attachment.id]);
+                                                            setPendingBulkAction('delete');
+                                                            setConfirmBulkOpen(true);
+                                                        }}
+                                                    >
+                                                        <Trash2 className="h-4 w-4" />
+                                                        {tAttachments('bulk.delete_single', '刪除此附件')}
+                                                    </DropdownMenuItem>
+                                                ) : null}
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </TableCell>
+                                </TableRow>
+                            );
+                        })
+                    )}
                 </TableBody>
             </Table>
-        );
+        </div>
+    );
+
+    const cardView = (
+        <div className="space-y-3">
+            {hasAttachments
+                ? attachments.data.map((attachment) => {
+                      const isSelected = selectedIds.includes(attachment.id);
+                      const downloadHref = attachment.download_url ?? attachment.external_url ?? attachment.file_url ?? '';
+
+                      return (
+                          <AttachmentCard
+                              key={attachment.id}
+                              attachment={attachment}
+                              locale={locale}
+                              selected={isSelected}
+                              onSelect={(checked) => toggleSelection(attachment.id, checked)}
+                              onOpen={() => openDetail(attachment)}
+                              canDelete={abilities.canDelete}
+                              onDownload={() => {
+                                  if (downloadHref) {
+                                      window.open(downloadHref, '_blank');
+                                  }
+                              }}
+                          />
+                      );
+                  })
+                : (
+                      <div className="rounded-xl border border-dashed border-neutral-200 bg-white/80 p-6 text-center">
+                          <TableEmpty
+                              title={tAttachments('empty.title', '尚無附件')}
+                              description={tAttachments('empty.description', '還沒有任何可供管理的附件資源。')}
+                          />
+                      </div>
+                  )}
+        </div>
+    );
+
+    const paginationMeta = {
+        current_page: attachments.meta.current_page ?? 1,
+        last_page: attachments.meta.last_page ?? 1,
+        per_page: attachments.meta.per_page ?? Number(filterForm.per_page),
+        total: attachments.meta.total ?? 0,
+        from: attachments.meta.from ?? 0,
+        to: attachments.meta.to ?? 0,
+        links: attachments.links ?? [],
     };
 
-    const renderGridView = (items: ManageAttachmentListItem[]) => {
-        if (items.length === 0) {
-            return (
-                <div className="rounded-xl border border-dashed border-neutral-200/80 bg-white/80 px-6 py-12 text-center text-sm text-neutral-500">
-                    {tAttachments('empty.description', '還沒有任何可供管理的附件資源。')}
-                </div>
-            );
-        }
+    const confirmTitle = pendingBulkAction === 'download'
+        ? tAttachments('bulk.confirm_download_title', '確認批次下載')
+        : tAttachments('bulk.confirm_delete_title', '確認批次刪除');
 
-        return (
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                {items.map((attachment) => {
-                    const downloadHref = attachment.download_url ?? attachment.external_url ?? attachment.file_url ?? '';
-
-                    return (
-                        <Card key={attachment.id} className="border border-neutral-200/80">
-                            <CardHeader className="space-y-2">
-                                <CardTitle className="flex items-start justify-between gap-2 text-base font-semibold text-neutral-800">
-                                    <span>{attachment.title ?? attachment.filename ?? tAttachments('table.untitled', '未命名附件')}</span>
-                                    <Badge variant={visibilityVariantMap[attachment.visibility] ?? 'outline'} className="capitalize">
-                                        {tAttachments(`visibility.${attachment.visibility}`, attachment.visibility)}
-                                    </Badge>
-                                </CardTitle>
-                                <div className="text-xs text-neutral-500">
-                                    {attachment.filename ?? tAttachments('table.no_filename', '無檔名')}
-                                </div>
-                                <div className="text-xs text-neutral-400">
-                                    {tAttachments('table.uploaded_at', '上傳於 :date', {
-                                        date: attachment.created_at
-                                            ? new Date(attachment.created_at).toLocaleString(page.props.locale ?? 'zh-TW')
-                                            : '—',
-                                    })}
-                                </div>
-                            </CardHeader>
-                            <CardContent className="space-y-2 text-sm text-neutral-600">
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <Badge variant="outline" className="capitalize text-neutral-600">
-                                        {tAttachments(`types.${attachment.type}`, attachment.type)}
-                                    </Badge>
-                                    <span className="text-xs text-neutral-400">{formatFileSize(attachment.size)}</span>
-                                </div>
-                                {/* 描述文字以段落顯示，提供更多上下文 */}
-                                {attachment.description ? (
-                                    <p className="text-xs text-neutral-500">{attachment.description}</p>
-                                ) : null}
-                                {/* 在卡片模式同樣顯示標籤資料 */}
-                                {attachment.tags && attachment.tags.length > 0 ? (
-                                    <div className="flex flex-wrap gap-1">
-                                        {attachment.tags.map((tag) => (
-                                            <Badge key={tag} variant="outline" className="text-[10px] capitalize text-neutral-500">
-                                                #{tag}
-                                            </Badge>
-                                        ))}
-                                    </div>
-                                ) : null}
-                                {attachment.attachable ? (
-                                    <div className="space-y-1 rounded-lg bg-neutral-50/70 p-3 text-xs">
-                                        <div className="font-medium text-neutral-700">
-                                            {tAttachments('grid.attachable_title', '綁定資源')}
-                                        </div>
-                                        <div className="text-neutral-600">{attachment.attachable.title ?? tAttachments('table.unknown_attachable', '未知來源')}</div>
-                                        {attachment.attachable.space ? (
-                                            <div className="text-neutral-500">
-                                                {tAttachments('table.space', '空間：:name', { name: attachment.attachable.space.name })}
-                                            </div>
-                                        ) : null}
-                                        <div className="text-neutral-400 capitalize">
-                                            {tAttachments(`table.attachable_type.${attachment.attachable.type}`, attachment.attachable.type)}
-                                        </div>
-                                    </div>
-                                ) : attachment.space ? (
-                                    <div className="space-y-1 rounded-lg bg-neutral-50/70 p-3 text-xs">
-                                        <div className="font-medium text-neutral-700">{tAttachments('table.space', '空間：:name', { name: attachment.space.name })}</div>
-                                        <div className="text-neutral-500">{tAttachments('table.orphan', '尚未綁定資源')}</div>
-                                    </div>
-                                ) : (
-                                    <div className="rounded-lg bg-neutral-50/70 p-3 text-xs text-neutral-400">
-                                        {tAttachments('table.orphan', '尚未綁定資源')}
-                                    </div>
-                                )}
-                            </CardContent>
-                            <CardFooter className="flex items-center justify-between">
-                                <div className="text-xs text-neutral-400">
-                                    {attachment.uploader
-                                        ? tAttachments('table.uploader', '由 :name 上傳', { name: attachment.uploader.name })
-                                        : tAttachments('table.uploader_unknown', '上傳者未知')}
-                                </div>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    className="gap-1"
-                                    asChild={!!downloadHref}
-                                    disabled={!downloadHref}
-                                >
-                                    {downloadHref ? (
-                                        <Link href={downloadHref} target={attachment.external_url ? '_blank' : undefined} rel={attachment.external_url ? 'noopener noreferrer' : undefined}>
-                                            <Download className="h-4 w-4" />
-                                            {tAttachments('table.download', '下載')}
-                                        </Link>
-                                    ) : (
-                                        <span className="inline-flex items-center gap-1 text-neutral-400">
-                                            <Download className="h-4 w-4" />
-                                            {tAttachments('table.download', '下載')}
-                                        </span>
-                                    )}
-                                </Button>
-                            </CardFooter>
-                        </Card>
-                    );
-                })}
-            </div>
-        );
-    };
-
-    const meta = attachments.meta;
+    const confirmDescription = pendingBulkAction === 'download'
+        ? tAttachments('bulk.confirm_download_description', '將開啟所有選取附件的下載連結，是否繼續？')
+        : tAttachments('bulk.confirm_delete_description', '將永久刪除所有選取的附件，此動作無法還原，是否繼續？');
 
     return (
         <>
@@ -736,51 +922,43 @@ export default function ManageAdminAttachmentsIndex() {
             <ToastContainer toasts={toasts} onDismiss={dismissToast} position="top-right" />
             <ManagePage
                 title={pageTitle}
-                description={t('attachments.description', '管理公告使用的文件與媒體資源。')}
+                description={tAttachments('description', '集中管理公告所使用的媒體與文件，支援批次操作與行動版卡片檢視。')}
                 breadcrumbs={breadcrumbs}
                 toolbar={toolbar}
             >
-                <section className="rounded-xl border border-neutral-200/80 bg-white/95 p-4 shadow-sm">
-                    {/* 顯示選擇狀態統計資訊 */}
-                    {selectedIds.length > 0 && (
-                        <div className="mb-3 rounded-lg bg-blue-50/70 p-3 text-sm text-blue-700">
-                            {tAttachments('selection.count', '已選擇 {count} 筆附件', { count: selectedIds.length })}
-                        </div>
-                    )}
-
-                    {filterForm.view === 'grid'
-                        ? renderGridView(attachments.data)
-                        : renderListView(attachments.data)}
-                    <Pagination
-                        meta={{
-                            current_page: meta.current_page,
-                            from: meta.from ?? 0,
-                            to: meta.to ?? 0,
-                            total: meta.total,
-                            last_page: meta.last_page,
-                            per_page: meta.per_page,
-                            links: meta.links ?? [],
-                        }}
-                        onPerPageChange={(value) => handlePerPageChange(String(value))}
-                        className="mt-4"
+                <section className="rounded-xl border border-neutral-200/80 bg-white/95 shadow-sm">
+                    <ResponsiveDataView
+                        className="space-y-0"
+                        mode={filterForm.view === 'grid' ? 'card' : 'auto'}
+                        table={tableView}
+                        card={cardView}
+                        isEmpty={!hasAttachments}
+                        emptyState={
+                            <div className="p-8">
+                                <TableEmpty
+                                    title={tAttachments('empty.title', '尚無附件')}
+                                    description={tAttachments('empty.description', '還沒有任何可供管理的附件資源。')}
+                                />
+                            </div>
+                        }
+                        stickyActions={mobileBulkActions}
                     />
+
+                    <div className="border-t border-neutral-200/80 px-4 py-3">
+                        <Pagination
+                            meta={paginationMeta}
+                            onPerPageChange={handlePerPageChange}
+                            perPageOptions={PER_PAGE_OPTIONS.map((item) => Number(item))}
+                        />
+                    </div>
                 </section>
             </ManagePage>
 
-            {/* 批次操作確認對話框 */}
             <ConfirmDialog
                 open={confirmBulkOpen}
                 onOpenChange={setConfirmBulkOpen}
-                title={
-                    pendingBulkAction === 'download'
-                        ? tAttachments('bulk.confirm_download_title', '確認批次下載')
-                        : tAttachments('bulk.confirm_delete_title', '確認批次刪除')
-                }
-                description={
-                    pendingBulkAction === 'download'
-                        ? tAttachments('bulk.confirm_download_description', '將開啟所有選取附件的下載連結，是否繼續？')
-                        : tAttachments('bulk.confirm_delete_description', '將永久刪除所有選取的附件，此動作無法還原，是否繼續？')
-                }
+                title={confirmTitle}
+                description={confirmDescription}
                 onConfirm={() => {
                     if (pendingBulkAction === 'download') {
                         executeBulkDownload();
@@ -791,159 +969,101 @@ export default function ManageAdminAttachmentsIndex() {
                 variant={pendingBulkAction === 'delete' ? 'destructive' : 'default'}
             />
 
-            {/* 附件詳細資訊抽屜：顯示完整 metadata 與引用紀錄 */}
             <Sheet open={detailOpen} onOpenChange={setDetailOpen}>
-                <SheetContent className="w-full overflow-y-auto sm:max-w-2xl">
+                <SheetContent className="w-full max-w-2xl overflow-y-auto">
                     <SheetHeader>
                         <SheetTitle>
                             {detailAttachment?.title ?? detailAttachment?.filename ?? tAttachments('detail.title', '附件詳情')}
                         </SheetTitle>
                         <SheetDescription>
-                            {tAttachments('detail.description', '檢視附件的完整資訊與引用紀錄。')}
+                            {tAttachments('detail.description', '檢視檔案中繼資料、關聯資源與存取資訊。')}
                         </SheetDescription>
                     </SheetHeader>
 
-                    {detailAttachment && (
-                        <div className="grid gap-6 px-4 pb-8 pt-6">
-                            {/* 基本資訊區塊 */}
-                            <div className="rounded-lg border border-neutral-200/70 p-4">
-                                <h3 className="mb-3 text-sm font-semibold text-neutral-700">
-                                    {tAttachments('detail.sections.basic', '基本資訊')}
-                                </h3>
-                                <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
-                                    <div>
-                                        <dt className="text-neutral-400">{tAttachments('detail.fields.filename', '檔案名稱')}</dt>
-                                        <dd className="text-neutral-700">{detailAttachment.filename ?? '—'}</dd>
-                                    </div>
-                                    <div>
-                                        <dt className="text-neutral-400">{tAttachments('detail.fields.size', '檔案大小')}</dt>
-                                        <dd className="text-neutral-700">{formatFileSize(detailAttachment.size)}</dd>
-                                    </div>
-                                    <div>
-                                        <dt className="text-neutral-400">{tAttachments('detail.fields.type', '類型')}</dt>
-                                        <dd className="text-neutral-700 capitalize">{detailAttachment.type}</dd>
-                                    </div>
-                                    <div>
-                                        <dt className="text-neutral-400">{tAttachments('detail.fields.visibility', '可見性')}</dt>
-                                        <dd>
-                                            <Badge variant={visibilityVariantMap[detailAttachment.visibility] ?? 'outline'} className="capitalize">
-                                                {detailAttachment.visibility}
-                                            </Badge>
-                                        </dd>
-                                    </div>
-                                    <div>
-                                        <dt className="text-neutral-400">{tAttachments('detail.fields.created_at', '建立時間')}</dt>
-                                        <dd className="text-neutral-700">
-                                            {detailAttachment.created_at
-                                                ? new Date(detailAttachment.created_at).toLocaleString(page.props.locale ?? 'zh-TW')
-                                                : '—'}
-                                        </dd>
-                                    </div>
-                                    <div>
-                                        <dt className="text-neutral-400">{tAttachments('detail.fields.uploader', '上傳者')}</dt>
-                                        <dd className="text-neutral-700">
-                                            {detailAttachment.uploader?.name ?? tAttachments('detail.uploader_unknown', '未知')}
-                                        </dd>
-                                    </div>
-                                </dl>
-
-                                {detailAttachment.description && (
-                                    <div className="mt-4">
-                                        <dt className="text-neutral-400">{tAttachments('detail.fields.description', '描述')}</dt>
-                                        <dd className="mt-1 text-sm text-neutral-700">{detailAttachment.description}</dd>
-                                    </div>
-                                )}
-                            </div>
-
-                            {/* 標籤資訊 */}
-                            {detailAttachment.tags && detailAttachment.tags.length > 0 && (
-                                <div className="rounded-lg border border-neutral-200/70 p-4">
-                                    <h3 className="mb-3 text-sm font-semibold text-neutral-700">
-                                        {tAttachments('detail.sections.tags', '標籤')}
-                                    </h3>
-                                    <div className="flex flex-wrap gap-2">
-                                        {detailAttachment.tags.map((tag) => (
-                                            <Badge key={tag} variant="outline" className="text-xs capitalize">
-                                                #{tag}
-                                            </Badge>
-                                        ))}
-                                    </div>
+                    {detailAttachment ? (
+                        <div className="mt-4 space-y-4 text-sm text-neutral-600">
+                            {getAttachmentPreview(detailAttachment) ? (
+                                <div className="overflow-hidden rounded-xl border border-neutral-200 bg-neutral-50">
+                                    <img
+                                        src={getAttachmentPreview(detailAttachment)}
+                                        alt={detailAttachment.title ?? detailAttachment.filename ?? ''}
+                                        className="w-full object-cover"
+                                    />
                                 </div>
-                            )}
+                            ) : null}
 
-                            {/* 引用資源資訊 */}
-                            <div className="rounded-lg border border-neutral-200/70 p-4">
-                                <h3 className="mb-3 text-sm font-semibold text-neutral-700">
-                                    {tAttachments('detail.sections.usage', '引用紀錄')}
-                                </h3>
-                                {detailAttachment.attachable ? (
-                                    <div className="space-y-2 rounded-lg bg-neutral-50/70 p-3 text-sm">
-                                        <div className="font-medium text-neutral-700">
-                                            {detailAttachment.attachable.title ?? tAttachments('detail.unknown_resource', '未知資源')}
-                                        </div>
-                                        <div className="text-xs text-neutral-500 capitalize">
-                                            {tAttachments(`table.attachable_type.${detailAttachment.attachable.type}`, detailAttachment.attachable.type)}
-                                        </div>
-                                        {detailAttachment.attachable.space && (
-                                            <div className="text-xs text-neutral-600">
-                                                {tAttachments('table.space', '空間：:name', { name: detailAttachment.attachable.space.name })}
-                                            </div>
-                                        )}
-                                    </div>
-                                ) : detailAttachment.space ? (
-                                    <div className="space-y-2 rounded-lg bg-neutral-50/70 p-3 text-sm">
-                                        <div className="font-medium text-neutral-700">
-                                            {tAttachments('table.space', '空間：:name', { name: detailAttachment.space.name })}
-                                        </div>
-                                        <div className="text-xs text-neutral-500">{tAttachments('table.orphan', '尚未綁定資源')}</div>
-                                    </div>
-                                ) : (
-                                    <p className="text-sm text-neutral-500">
-                                        {tAttachments('detail.no_usage', '此附件尚未被任何資源引用。')}
-                                    </p>
-                                )}
+                            <div className="grid gap-2 rounded-lg border border-neutral-200/80 bg-neutral-50/80 p-3">
+                                <div className="flex items-center gap-2 text-neutral-500">
+                                    <Paperclip className="h-4 w-4" />
+                                    <span>{detailAttachment.filename}</span>
+                                </div>
+                                <div>{tAttachments('detail.type', '檔案類型：:type', { type: detailAttachment.type })}</div>
+                                <div>
+                                    {tAttachments('detail.size', '檔案大小：:size', {
+                                        size: detailAttachment.size ? formatBytes(detailAttachment.size) : '—',
+                                    })}
+                                </div>
+                                <div>
+                                    {tAttachments('detail.visibility', '可見性：:visibility', {
+                                        visibility: tAttachments(`visibility.${detailAttachment.visibility}`, detailAttachment.visibility),
+                                    })}
+                                </div>
+                                <div>
+                                    {tAttachments('detail.uploaded_at', '上傳時間：:time', {
+                                        time: formatDateTime(detailAttachment.created_at ?? detailAttachment.uploaded_at, locale) || '—',
+                                    })}
+                                </div>
                             </div>
 
-                            {/* 操作按鈕 */}
-                            <div className="flex items-center justify-end gap-3 border-t border-neutral-200/70 pt-4">
-                                {detailAttachment.download_url ?? detailAttachment.external_url ?? detailAttachment.file_url ? (
-                                    <Button
-                                        variant="outline"
-                                        asChild
-                                        className="gap-2"
-                                    >
-                                        <Link
-                                            href={detailAttachment.download_url ?? detailAttachment.external_url ?? detailAttachment.file_url ?? ''}
-                                            target={detailAttachment.external_url ? '_blank' : undefined}
-                                            rel={detailAttachment.external_url ? 'noopener noreferrer' : undefined}
-                                        >
+                            {detailAttachment.attachable ? (
+                                <div className="space-y-2 rounded-lg border border-neutral-200/80 bg-white/95 p-3">
+                                    <h3 className="text-sm font-semibold text-neutral-800">
+                                        {tAttachments('detail.attachable_title', '關聯資源')}
+                                    </h3>
+                                    <p className="text-sm text-neutral-600">{detailAttachment.attachable.title ?? detailAttachment.attachable.type}</p>
+                                    {detailAttachment.attachable.space ? (
+                                        <p className="text-xs text-neutral-500">
+                                            {tAttachments('table.space', '歸屬空間：:name', { name: detailAttachment.attachable.space.name })}
+                                        </p>
+                                    ) : null}
+                                </div>
+                            ) : null}
+
+                            <div className="flex flex-wrap gap-2 text-xs text-neutral-500">
+                                {detailAttachment.tags?.map((tag) => (
+                                    <span key={tag} className="rounded-full bg-neutral-100 px-2 py-0.5">
+                                        #{tag}
+                                    </span>
+                                ))}
+                            </div>
+
+                            <div className="flex flex-col gap-2 text-xs text-neutral-500">
+                                {detailAttachment.download_url ? (
+                                    <Button type="button" variant="outline" className="w-full justify-center gap-2" asChild>
+                                        <Link href={detailAttachment.download_url} target="_blank" rel="noopener noreferrer">
                                             <Download className="h-4 w-4" />
-                                            {tAttachments('detail.actions.download', '下載')}
+                                            {tAttachments('detail.download', '下載原始檔案')}
                                         </Link>
                                     </Button>
                                 ) : null}
-                                <Button variant="ghost" onClick={() => setDetailOpen(false)}>
-                                    {tAttachments('detail.actions.close', '關閉')}
-                                </Button>
+                                {detailAttachment.external_url ? (
+                                    <Button type="button" variant="outline" className="w-full justify-center gap-2" asChild>
+                                        <Link href={detailAttachment.external_url} target="_blank" rel="noopener noreferrer">
+                                            <Eye className="h-4 w-4" />
+                                            {tAttachments('detail.view_external', '檢視外部連結')}
+                                        </Link>
+                                    </Button>
+                                ) : null}
                             </div>
                         </div>
-                    )}
+                    ) : null}
                 </SheetContent>
             </Sheet>
 
-            {/* 上傳附件對話框 */}
-            <AttachmentUploadModal
-                open={uploadModalOpen}
-                onOpenChange={setUploadModalOpen}
-                onUploadComplete={() => {
-                    router.reload({ only: ['attachments'] });
-                }}
-                filterOptions={filterOptions}
-                onError={showError}
-                onSuccess={showSuccess}
-            />
+            <AttachmentUploadModal open={uploadModalOpen} onOpenChange={setUploadModalOpen} />
         </>
     );
 }
 
 ManageAdminAttachmentsIndex.layout = (page: ReactElement) => <AppLayout>{page}</AppLayout>;
+

--- a/resources/js/pages/manage/admin/messages/index.tsx
+++ b/resources/js/pages/manage/admin/messages/index.tsx
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ChangeEvent, FocusEvent, FormEvent, MouseEvent, ReactElement } from 'react';
+
+import { Head, Link, router, usePage } from '@inertiajs/react';
+import { CalendarClock, Download, Filter, Mail, MailOpen, MailPlus, Phone, User } from 'lucide-react';
 
 import AppLayout from '@/layouts/app-layout';
 import ManagePage from '@/layouts/manage/manage-page';
+import ManageToolbar from '@/components/manage/manage-toolbar';
+import ResponsiveDataView from '@/components/manage/responsive-data-view';
+import DataCard from '@/components/manage/data-card';
+import TableEmpty from '@/components/manage/table-empty';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -9,8 +17,9 @@ import Pagination from '@/components/ui/pagination';
 import { Select } from '@/components/ui/select';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import TableEmpty from '@/components/manage/table-empty';
 import { useTranslator } from '@/hooks/use-translator';
+import { formatDateTime } from '@/lib/shared/format';
+import { cn } from '@/lib/shared/utils';
 import type {
     ManageMessageFilterOptions,
     ManageMessageFilterState,
@@ -18,9 +27,6 @@ import type {
     ManageMessageListResponse,
 } from '@/types/manage';
 import type { BreadcrumbItem, SharedData } from '@/types/shared';
-import { Head, Link, router, usePage } from '@inertiajs/react';
-import type { ChangeEvent, FocusEvent, FormEvent, MouseEvent, ReactElement } from 'react';
-import { Download, Filter, Mail, MailPlus, User as UserIcon } from 'lucide-react';
 
 interface ManageAdminMessagesPageProps extends SharedData {
     messages: ManageMessageListResponse;
@@ -37,12 +43,28 @@ interface FilterFormState {
     per_page: string;
 }
 
-const statusVariantMap: Record<string, 'default' | 'secondary' | 'outline' | 'destructive'> = {
-    new: 'default',
-    processing: 'secondary',
-    resolved: 'outline',
-    spam: 'destructive',
+const STATUS_BADGE_CLASS: Record<string, string> = {
+    new: 'border-blue-200 bg-blue-50 text-blue-700',
+    processing: 'border-amber-200 bg-amber-50 text-amber-700',
+    resolved: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    spam: 'border-rose-200 bg-rose-50 text-rose-700',
 };
+
+const STATUS_ICON: Record<string, typeof MailOpen> = {
+    new: MailOpen,
+    processing: CalendarClock,
+    resolved: Mail,
+    spam: Mail,
+};
+
+const STATUS_TONE: Record<string, 'info' | 'warning' | 'success' | 'danger' | 'neutral'> = {
+    new: 'info',
+    processing: 'warning',
+    resolved: 'success',
+    spam: 'danger',
+};
+
+const PER_PAGE_OPTIONS = ['10', '15', '25', '50'] as const;
 
 function buildPayload(state: FilterFormState) {
     return {
@@ -54,9 +76,82 @@ function buildPayload(state: FilterFormState) {
     };
 }
 
+function renderStatusBadge(status: string, label: string) {
+    const badgeClass = STATUS_BADGE_CLASS[status] ?? 'border-neutral-200 bg-neutral-100 text-neutral-700';
+
+    return (
+        <Badge variant="outline" className={cn('flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium', badgeClass)}>
+            {label}
+        </Badge>
+    );
+}
+
+function MessageMobileCard({ message, locale, onOpen }: { message: ManageMessageListItem; locale: string; onOpen: () => void }) {
+    const { t: tMessages } = useTranslator('manage.messages');
+    const statusLabel = tMessages(`status.${message.status}`, message.status);
+    const IconComponent = STATUS_ICON[message.status] ?? MailOpen;
+
+    const metadata = [
+        {
+            label: tMessages('table.created', '建立時間'),
+            value: formatDateTime(message.created_at, locale) || '—',
+            icon: <CalendarClock className="h-3.5 w-3.5 text-neutral-400" />,
+        },
+        {
+            label: tMessages('detail.contact', '聯絡人'),
+            value: (
+                <span className="flex items-center gap-1">
+                    <User className="h-3.5 w-3.5 text-neutral-400" />
+                    <span>{message.name || tMessages('detail.unknown_name', '訪客')}</span>
+                </span>
+            ),
+        },
+    ];
+
+    return (
+        <DataCard
+            title={message.subject ?? tMessages('table.no_subject', '未填寫主旨')}
+            description={message.message.slice(0, 120)}
+            status={{
+                label: statusLabel,
+                tone: STATUS_TONE[message.status] ?? 'neutral',
+                icon: <IconComponent className="h-3.5 w-3.5" aria-hidden="true" />,
+            }}
+            metadata={metadata}
+            actions={[
+                <Button key="open" type="button" className="w-full justify-center gap-2 bg-[#2563EB] text-white hover:bg-[#1D4ED8]" onClick={onOpen}>
+                    <Mail className="h-4 w-4" />
+                    {tMessages('detail.open', '檢視內容')}
+                </Button>,
+            ]}
+            mobileActions={[
+                <Button key="open-mobile" type="button" variant="outline" className="w-full justify-center gap-2" onClick={onOpen}>
+                    <Mail className="h-4 w-4" />
+                    {tMessages('detail.open', '檢視內容')}
+                </Button>,
+            ]}
+        >
+            <div className="space-y-2 text-sm text-neutral-600">
+                <div className="flex items-center gap-2">
+                    <Mail className="h-3.5 w-3.5 text-neutral-400" />
+                    <span className="break-all">{message.email}</span>
+                </div>
+                {message.phone ? (
+                    <div className="flex items-center gap-2">
+                        <Phone className="h-3.5 w-3.5 text-neutral-400" />
+                        <span className="break-all">{message.phone}</span>
+                    </div>
+                ) : null}
+            </div>
+        </DataCard>
+    );
+}
+
 export default function ManageAdminMessagesIndex() {
     const page = usePage<ManageAdminMessagesPageProps>();
     const { messages, filters, filterOptions, statusSummary } = page.props;
+    const locale = page.props.locale ?? 'zh-TW';
+
     const { t } = useTranslator('manage');
     const { t: tMessages } = useTranslator('manage.messages');
 
@@ -78,7 +173,7 @@ export default function ManageAdminMessagesIndex() {
         status: filters.status ?? '',
         from: filters.from ?? '',
         to: filters.to ?? '',
-        per_page: String(filters.per_page ?? messages.meta.per_page ?? 15),
+        per_page: String(filters.per_page ?? messages.meta.per_page ?? Number(PER_PAGE_OPTIONS[1])),
     }), [filters.keyword, filters.status, filters.from, filters.to, filters.per_page, messages.meta.per_page]);
 
     const [filterForm, setFilterForm] = useState<FilterFormState>(defaultFilterForm);
@@ -126,11 +221,6 @@ export default function ManageAdminMessagesIndex() {
         setFilterForm((prev) => ({ ...prev, keyword: event.target.value }));
     };
 
-    const handleFilterSubmit = (event: FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-        applyFilters();
-    };
-
     const handleStatusChange = (event: ChangeEvent<HTMLSelectElement>) => {
         const value = event.target.value;
         setFilterForm((prev) => ({ ...prev, status: value }));
@@ -143,14 +233,9 @@ export default function ManageAdminMessagesIndex() {
         applyFilters({ [field]: value } as Partial<FilterFormState>);
     };
 
-    const openDatePicker = useCallback((event: FocusEvent<HTMLInputElement> | MouseEvent<HTMLInputElement>) => {
-        const input = event.currentTarget as HTMLInputElement & { showPicker?: () => void };
-        input.showPicker?.();
-    }, []);
-
-    const handlePerPageChange = (value: string) => {
-        setFilterForm((prev) => ({ ...prev, per_page: value }));
-        applyFilters({ per_page: value }, { replace: true });
+    const handleFilterSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        applyFilters();
     };
 
     const handleResetFilters = () => {
@@ -158,119 +243,128 @@ export default function ManageAdminMessagesIndex() {
         applyFilters(defaultFilterForm, { replace: true });
     };
 
-    const handleRowClick = (message: ManageMessageListItem) => {
-        setSelectedMessage(message);
+    const openDatePicker = useCallback((event: FocusEvent<HTMLInputElement> | MouseEvent<HTMLInputElement>) => {
+        const input = event.currentTarget as HTMLInputElement & { showPicker?: () => void };
+        input.showPicker?.();
+    }, []);
+
+    const handlePerPageChange = (value: number) => {
+        const next = String(value);
+        setFilterForm((prev) => ({ ...prev, per_page: next }));
+        applyFilters({ per_page: next }, { replace: true });
     };
 
-    const closeDetail = () => setSelectedMessage(null);
-
     const toolbar = (
-        <div className="flex w-full flex-col gap-3">
-            <form onSubmit={handleFilterSubmit} className="w-full">
-                {/* Row 1: search + status */}
-                <div className="flex flex-wrap items-end gap-4">
-                    <div className="grid gap-1.5 lg:w-60">
-                        <label htmlFor="filter-keyword" className="text-xs font-medium text-neutral-600">
-                            {tMessages('filters.keyword_label', '搜尋訊息')}
+        <ManageToolbar
+            wrap
+            primary={[
+                <div key="keyword" className="grid w-full gap-1 sm:w-64">
+                    <label htmlFor="filter-keyword" className="text-xs font-medium text-neutral-600">
+                        {tMessages('filters.keyword_label', '搜尋訊息')}
+                    </label>
+                    <Input
+                        id="filter-keyword"
+                        type="search"
+                        value={filterForm.keyword}
+                        onChange={handleKeywordChange}
+                        placeholder={tMessages('filters.keyword_placeholder', '搜尋主旨或聯絡人')}
+                    />
+                </div>,
+                <div key="status" className="grid w-full gap-1 sm:w-48">
+                    <label htmlFor="filter-status" className="text-xs font-medium text-neutral-600">
+                        {tMessages('filters.status_label', '狀態篩選')}
+                    </label>
+                    <Select id="filter-status" value={filterForm.status} onChange={handleStatusChange}>
+                        <option value="">{tMessages('filters.status_all', '全部狀態')}</option>
+                        {filterOptions.statuses.map((option) => (
+                            <option key={String(option.value)} value={String(option.value)}>
+                                {option.label}
+                                {option.count !== undefined ? ` (${option.count})` : ''}
+                            </option>
+                        ))}
+                    </Select>
+                </div>,
+            ]}
+            secondary={
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                    <Button type="button" size="sm" variant="outline" className="gap-2" asChild>
+                        <Link href="#">
+                            <Download className="h-4 w-4" />
+                            {tMessages('actions.export', '匯出紀錄')}
+                        </Link>
+                    </Button>
+                    <Button type="button" size="sm" className="gap-2 bg-[#2563EB] text-white hover:bg-[#1D4ED8]">
+                        <MailPlus className="h-4 w-4" />
+                        {tMessages('actions.new', '建立新訊息')}
+                    </Button>
+                </div>
+            }
+        >
+            <form onSubmit={handleFilterSubmit} className="flex w-full flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                    <div className="grid gap-1">
+                        <label htmlFor="filter-from" className="text-xs font-medium text-neutral-600">
+                            {tMessages('filters.from', '起始日期')}
                         </label>
                         <Input
-                            id="filter-keyword"
-                            type="search"
-                            value={filterForm.keyword}
-                            onChange={handleKeywordChange}
-                            placeholder={tMessages('filters.keyword_placeholder', '搜尋主旨或聯絡人')}
+                            id="filter-from"
+                            type="date"
+                            name="from"
+                            value={filterForm.from}
+                            onChange={handleDateChange('from')}
+                            onClick={openDatePicker}
+                            onFocus={openDatePicker}
+                            className="h-9 sm:w-40"
                         />
                     </div>
 
-                    <div className="grid gap-1.5">
-                        <label htmlFor="filter-status" className="text-xs font-medium text-neutral-600">
-                            {tMessages('filters.status_label', '狀態篩選')}
+                    <div className="grid gap-1">
+                        <label htmlFor="filter-to" className="text-xs font-medium text-neutral-600">
+                            {tMessages('filters.to', '結束日期')}
                         </label>
-                        <Select id="filter-status" value={filterForm.status} onChange={handleStatusChange} className="w-full sm:w-40">
-                            <option value="">{tMessages('filters.status_all', '全部狀態')}</option>
-                            {filterOptions.statuses.map((option) => (
-                                <option key={String(option.value)} value={String(option.value)}>
-                                    {option.label}
-                                    {option.count !== undefined ? ` (${option.count})` : ''}
-                                </option>
-                            ))}
-                        </Select>
+                        <Input
+                            id="filter-to"
+                            type="date"
+                            name="to"
+                            value={filterForm.to}
+                            onChange={handleDateChange('to')}
+                            onClick={openDatePicker}
+                            onFocus={openDatePicker}
+                            className="h-9 sm:w-40"
+                        />
                     </div>
                 </div>
 
-                {/* Row 2: dates left, actions right */}
-                <div className="flex flex-wrap items-center justify-between gap-4 mt-3">
-                    <div className="flex items-center gap-4">
-                        <div className="grid gap-1.5">
-                            <label htmlFor="filter-from" className="text-xs font-medium text-neutral-600">
-                                {tMessages('filters.from', '起始日期')}
-                            </label>
-                            <Input
-                                id="filter-from"
-                                type="date"
-                                name="from"
-                                value={filterForm.from}
-                                onChange={handleDateChange('from')}
-                                onClick={openDatePicker}
-                                onFocus={openDatePicker}
-                                className="h-9 w-full sm:w-36"
-                            />
-                        </div>
-
-                        <div className="text-neutral-400">~</div>
-
-                        <div className="grid gap-1.5">
-                            <label htmlFor="filter-to" className="text-xs font-medium text-neutral-600">
-                                {tMessages('filters.to', '結束日期')}
-                            </label>
-                            <Input
-                                id="filter-to"
-                                type="date"
-                                name="to"
-                                aria-label={tMessages('filters.to', '結束日期')}
-                                value={filterForm.to}
-                                onChange={handleDateChange('to')}
-                                onClick={openDatePicker}
-                                onFocus={openDatePicker}
-                                className="h-9 w-full sm:w-36"
-                            />
-                        </div>
-                    </div>
-
-                    <div className="flex items-center gap-3">
-                        <Button size="sm" className="gap-1 bg-[#1E293B] hover:bg-[#0F172A] text-white border-transparent" asChild>
-                            <Link href="#">
-                                <Download className="h-4 w-4" />
-                                {tMessages('actions.export', '匯出紀錄')}
-                            </Link>
-                        </Button>
-
-                        <Button size="sm" className="gap-2 bg-[#10B981] hover:bg-[#059669] text-white border-transparent">
-                            <MailPlus className="h-4 w-4" />
-                            {tMessages('actions.new', '建立新訊息')}
-                        </Button>
-
-                        <div className="w-px h-6 bg-neutral-200" />
-
-                        <Button type="submit" size="sm" className="gap-1 bg-[#3B82F6] hover:bg-[#2563EB] text-white border-transparent">
-                            <Filter className="h-4 w-4" />
-                            {tMessages('filters.apply', '套用')}
-                        </Button>
-
-                        <Button type="button" size="sm" className="gap-1 bg-[#EF4444] hover:bg-[#DC2626] text-white border-transparent" onClick={handleResetFilters}>
-                            {tMessages('filters.reset', '重設')}
-                        </Button>
-                    </div>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                    <Button type="submit" size="sm" className="gap-2 bg-[#0F172A] text-white hover:bg-[#0B1220]">
+                        <Filter className="h-4 w-4" />
+                        {tMessages('filters.apply', '套用條件')}
+                    </Button>
+                    <Button type="button" size="sm" variant="outline" onClick={handleResetFilters}>
+                        {tMessages('filters.reset', '重設')}
+                    </Button>
                 </div>
             </form>
-        </div>
+        </ManageToolbar>
     );
+
+    const hasMessages = messages.data.length > 0;
+    const paginationLinks = messages.links ?? { first: null, last: null, prev: null, next: null };
+    const paginationMeta = {
+        current_page: messages.meta.current_page ?? 1,
+        last_page: messages.meta.last_page ?? 1,
+        per_page: messages.meta.per_page ?? Number(filterForm.per_page),
+        total: messages.meta.total ?? 0,
+        from: messages.meta.from ?? 0,
+        to: messages.meta.to ?? 0,
+        links: paginationLinks,
+    };
 
     const renderTableRows = (items: ManageMessageListItem[]) => {
         if (items.length === 0) {
             return (
                 <TableRow>
-                    <TableCell colSpan={4} className="py-12">
+                    <TableCell colSpan={5} className="py-12">
                         <TableEmpty
                             title={tMessages('empty.title', '尚無訊息')}
                             description={tMessages('empty.description', '目前沒有符合條件的聯絡表單紀錄。')}
@@ -280,83 +374,133 @@ export default function ManageAdminMessagesIndex() {
             );
         }
 
-        return items.map((message) => (
-            <TableRow
-                key={message.id}
-                className="cursor-pointer border-neutral-200/60 transition hover:bg-blue-50/40"
-                onClick={() => handleRowClick(message)}
-            >
-                <TableCell className="space-y-1">
-                    <div className="font-medium text-neutral-800">{message.subject ?? tMessages('table.no_subject', '未填寫主旨')}</div>
-                    <div className="text-xs text-neutral-500">{message.name} · {message.email}</div>
-                </TableCell>
-                <TableCell>
-                    <Badge variant={statusVariantMap[message.status] ?? 'outline'} className="capitalize">
-                        {tMessages(`status.${message.status}`, message.status)}
-                    </Badge>
-                </TableCell>
-                <TableCell className="text-sm text-neutral-600">
-                    {message.created_at
-                        ? new Date(message.created_at).toLocaleString(page.props.locale ?? 'zh-TW')
-                        : '—'}
-                </TableCell>
-                <TableCell className="text-sm text-neutral-500">
-                    {message.processed_at
-                        ? new Date(message.processed_at).toLocaleString(page.props.locale ?? 'zh-TW')
-                        : tMessages('table.unprocessed', '尚未處理')}
-                </TableCell>
-            </TableRow>
-        ));
+        return items.map((message) => {
+            const statusLabel = tMessages(`status.${message.status}`, message.status);
+            const createdAt = formatDateTime(message.created_at, locale) || '—';
+            const processedAt = formatDateTime(message.processed_at, locale) || tMessages('table.unprocessed', '尚未處理');
+
+            return (
+                <TableRow
+                    key={message.id}
+                    className="cursor-pointer border-b border-neutral-200/70 transition hover:bg-blue-50/40"
+                    onClick={() => setSelectedMessage(message)}
+                >
+                    <TableCell className="max-w-[280px]">
+                        <div className="flex flex-col gap-1">
+                            <span className="font-medium text-neutral-900">
+                                {message.subject ?? tMessages('table.no_subject', '未填寫主旨')}
+                            </span>
+                            <span className="text-xs text-neutral-500">
+                                {message.name} · {message.email}
+                            </span>
+                        </div>
+                    </TableCell>
+                    <TableCell>{renderStatusBadge(message.status, statusLabel)}</TableCell>
+                    <TableCell className="text-sm text-neutral-600">{createdAt}</TableCell>
+                    <TableCell className="text-sm text-neutral-600">{processedAt}</TableCell>
+                    <TableCell className="w-20 text-right">
+                        <Button type="button" variant="ghost" size="sm" className="h-8 px-3 text-blue-600 hover:text-blue-700">
+                            {tMessages('detail.open', '檢視內容')}
+                        </Button>
+                    </TableCell>
+                </TableRow>
+            );
+        });
     };
 
-    const statusCards = (
+    const statusOverview = (
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-            {filterOptions.statuses.map((status) => (
-                <div key={String(status.value)} className="rounded-xl border border-neutral-200/80 bg-white/80 px-4 py-3 shadow-sm">
-                    <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
-                        {tMessages(`status.${status.value}`, status.label)}
+            {filterOptions.statuses.map((status) => {
+                const valueKey = String(status.value);
+                const count = statusSummary[valueKey] ?? status.count ?? 0;
+
+                return (
+                    <div
+                        key={valueKey}
+                        className="flex flex-col gap-1 rounded-xl border border-neutral-200/80 bg-white/95 px-4 py-3 shadow-sm"
+                    >
+                        <span className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                            {tMessages(`status.${valueKey}`, status.label)}
+                        </span>
+                        <span className="text-2xl font-semibold text-neutral-900">{count}</span>
                     </div>
-                    <div className="text-2xl font-semibold text-neutral-900">
-                        {statusSummary[String(status.value)] ?? status.count ?? 0}
-                    </div>
-                </div>
-            ))}
+                );
+            })}
         </div>
     );
-
-    const meta = messages.meta;
 
     return (
         <>
             <Head title={pageTitle} />
             <ManagePage
                 title={pageTitle}
-                description={t('messages.description', '追蹤與回覆訪客的聯絡資訊。')}
+                description={tMessages('description', '集中檢視訪客透過聯絡表單傳送的訊息，並追蹤處理狀態。')}
                 breadcrumbs={breadcrumbs}
                 toolbar={toolbar}
             >
-                {statusCards}
+                {statusOverview}
 
                 <section className="mt-4 rounded-xl border border-neutral-200/80 bg-white/95 shadow-sm">
-                    <Table>
-                        <TableHeader>
-                            <TableRow className="border-neutral-200/80">
-                                <TableHead className="w-2/5 text-neutral-500">{tMessages('table.subject', '主旨')}</TableHead>
-                                <TableHead className="w-1/5 text-neutral-500">{tMessages('table.status', '狀態')}</TableHead>
-                                <TableHead className="w-1/5 text-neutral-500">{tMessages('table.created', '建立時間')}</TableHead>
-                                <TableHead className="w-1/5 text-neutral-500">{tMessages('table.processed', '處理時間')}</TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>{renderTableRows(messages.data)}</TableBody>
-                    </Table>
-                    <div className="px-4 py-3">
-                        <Pagination meta={meta} onPerPageChange={(value) => handlePerPageChange(String(value))} />
+                    <ResponsiveDataView
+                        table={() => (
+                            <div className="overflow-x-auto">
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow className="border-b border-neutral-200/70 bg-neutral-50/70">
+                                            <TableHead className="min-w-[280px] text-neutral-500">
+                                                {tMessages('table.subject', '主旨')}
+                                            </TableHead>
+                                            <TableHead className="min-w-[140px] text-neutral-500">
+                                                {tMessages('table.status', '狀態')}
+                                            </TableHead>
+                                            <TableHead className="min-w-[160px] text-neutral-500">
+                                                {tMessages('table.created', '建立時間')}
+                                            </TableHead>
+                                            <TableHead className="min-w-[160px] text-neutral-500">
+                                                {tMessages('table.processed', '處理時間')}
+                                            </TableHead>
+                                            <TableHead className="w-20" aria-label={tMessages('table.actions', '操作')} />
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>{renderTableRows(messages.data)}</TableBody>
+                                </Table>
+                            </div>
+                        )}
+                        card={() => (
+                            <div className="space-y-3">
+                                {hasMessages
+                                    ? messages.data.map((message) => (
+                                          <MessageMobileCard
+                                              key={message.id}
+                                              message={message}
+                                              locale={locale}
+                                              onOpen={() => setSelectedMessage(message)}
+                                          />
+                                      ))
+                                    : (
+                                          <div className="rounded-xl border border-dashed border-neutral-200 bg-white/70 p-6 text-center">
+                                              <TableEmpty
+                                                  title={tMessages('empty.title', '尚無訊息')}
+                                                  description={tMessages('empty.description', '目前沒有符合條件的聯絡表單紀錄。')}
+                                              />
+                                          </div>
+                                      )}
+                            </div>
+                        )}
+                    />
+
+                    <div className="border-t border-neutral-200/80 px-4 py-3">
+                        <Pagination
+                            meta={paginationMeta}
+                            onPerPageChange={handlePerPageChange}
+                            perPageOptions={PER_PAGE_OPTIONS.map((item) => Number(item))}
+                        />
                     </div>
                 </section>
             </ManagePage>
 
-            <Sheet open={!!selectedMessage} onOpenChange={(open) => (open ? null : closeDetail())}>
-                <SheetContent className="w-full sm:max-w-xl">
+            <Sheet open={!!selectedMessage} onOpenChange={(open) => (open ? null : setSelectedMessage(null))}>
+                <SheetContent className="w-full max-w-2xl">
                     {selectedMessage ? (
                         <div className="flex h-full flex-col gap-4">
                             <SheetHeader>
@@ -370,20 +514,19 @@ export default function ManageAdminMessagesIndex() {
                             </SheetHeader>
 
                             <div className="flex flex-wrap items-center gap-2">
-                                <Badge variant={statusVariantMap[selectedMessage.status] ?? 'outline'} className="capitalize">
-                                    {tMessages(`status.${selectedMessage.status}`, selectedMessage.status)}
-                                </Badge>
+                                {renderStatusBadge(
+                                    selectedMessage.status,
+                                    tMessages(`status.${selectedMessage.status}`, selectedMessage.status)
+                                )}
                                 <span className="text-xs text-neutral-400">
-                                    {selectedMessage.created_at
-                                        ? new Date(selectedMessage.created_at).toLocaleString(page.props.locale ?? 'zh-TW')
-                                        : '—'}
+                                    {formatDateTime(selectedMessage.created_at, locale)}
                                 </span>
                             </div>
 
                             <div className="space-y-2 rounded-lg border border-neutral-200/80 bg-neutral-50/80 p-3 text-sm text-neutral-600">
                                 <div className="flex items-center gap-2">
-                                    <UserIcon className="h-4 w-4 text-neutral-400" />
-                                    <span>{selectedMessage.name}</span>
+                                    <User className="h-4 w-4 text-neutral-400" />
+                                    <span>{selectedMessage.name || tMessages('detail.unknown_name', '訪客')}</span>
                                 </div>
                                 <div className="flex items-center gap-2">
                                     <Mail className="h-4 w-4 text-neutral-400" />
@@ -391,6 +534,12 @@ export default function ManageAdminMessagesIndex() {
                                         {selectedMessage.email}
                                     </Link>
                                 </div>
+                                {selectedMessage.phone ? (
+                                    <div className="flex items-center gap-2">
+                                        <Phone className="h-4 w-4 text-neutral-400" />
+                                        <span className="break-all">{selectedMessage.phone}</span>
+                                    </div>
+                                ) : null}
                                 {selectedMessage.locale ? (
                                     <div className="text-xs text-neutral-400">
                                         {tMessages('detail.locale', '語系：:locale', { locale: selectedMessage.locale })}
@@ -410,19 +559,22 @@ export default function ManageAdminMessagesIndex() {
                                 <div>
                                     {selectedMessage.processed_at
                                         ? tMessages('detail.processed_at', '處理時間：:time', {
-                                              time: new Date(selectedMessage.processed_at).toLocaleString(page.props.locale ?? 'zh-TW'),
+                                              time: formatDateTime(selectedMessage.processed_at, locale),
                                           })
                                         : tMessages('detail.not_processed', '尚未紀錄處理時間')}
                                 </div>
                                 {selectedMessage.processor ? (
-                                    <div>
-                                        {tMessages('detail.processor', '處理人員：:name', { name: selectedMessage.processor.name })}
-                                    </div>
+                                    <div>{tMessages('detail.processor', '處理人員：:name', { name: selectedMessage.processor.name })}</div>
                                 ) : null}
                                 {selectedMessage.file_url ? (
                                     <div className="flex items-center gap-2">
                                         <Download className="h-4 w-4" />
-                                        <Link href={selectedMessage.file_url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-700">
+                                        <Link
+                                            href={selectedMessage.file_url}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-blue-600 hover:text-blue-700"
+                                        >
                                             {tMessages('detail.attachment', '下載附件')}
                                         </Link>
                                     </div>
@@ -430,7 +582,7 @@ export default function ManageAdminMessagesIndex() {
                             </div>
 
                             <div className="flex justify-end">
-                                <Button variant="outline" onClick={closeDetail}>
+                                <Button variant="outline" onClick={() => setSelectedMessage(null)}>
                                     {tMessages('detail.close', '關閉')}
                                 </Button>
                             </div>
@@ -443,3 +595,4 @@ export default function ManageAdminMessagesIndex() {
 }
 
 ManageAdminMessagesIndex.layout = (page: ReactElement) => <AppLayout>{page}</AppLayout>;
+


### PR DESCRIPTION
## Summary
- Rebuild the admin messages list around ManageToolbar and ResponsiveDataView with card/table parity, sticky mobile actions, and improved detail sheet formatting
- Rework the admin attachments manager with shared attachment cards, responsive table/grid toggles, and mobile bulk action flow plus image previews
- Mark the Milestone B messages/attachments task as complete in `plan.md`

## Testing
- npm run build *(fails: php artisan wayfinder:generate --with-form is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e334ed7e208323b6fece1676fdb263